### PR TITLE
Update dev setup

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     image: postgres:latest
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
       - ./create-db-user.sql:/docker-entrypoint-initdb.d/create-db-user.sql
     ports:
       - 5432


### PR DESCRIPTION
### Context

Ticket: DFE-Digital/teacher-training-entitlement-board#4

### Changes proposed in this pull request

Update postgres docker container data volume

Following the postgres major version update from v17 to v18
a breaking changes was introduced for the expected postgres data
directory.
v17 expects postgres-data at `/var/lib/postgresql/data`
while
v18 expects postgres-data at `/var/lib/postgresql`

This commit fixes the postgres-data path inline with the postgres
image tag `postgres:latest` which now return v18

https://github.com/docker-library/postgres/issues/1377#issuecomment-3444256831