### PR TITLE
Fix n+1 queries for application endpoint

### DIFF
--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -9,7 +9,10 @@ module Applications
     def initialize(lead_provider:, cohort_start_years: :ignore, updated_since: :ignore, lead_provider_approval_status: :ignore, participant_ids: :ignore, status: :ignore, course_identifier: :ignore, sort: nil)
       @scope = lead_provider.applications.includes(
         :user,
-        :institution,
+        :course,
+        :cohort,
+        :schedule,
+        institution: :institutionable,
         course_cohort: %i[course cohort schedule],
       )
       @sort = sort


### PR DESCRIPTION
### Context

Ticket: N/A

The review apps are configured to raise errors on bullet warnings.

We need to fix this so we can test API on the review apps

### Changes proposed in this pull request

Add eager loading
