### PR TITLE
Resolve require errors running specs with docker

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,8 @@ require "capybara/cuprite"
 require "rack_session_access/capybara"
 require "axe-rspec"
 require "axe-capybara"
+require "rspec/default_http_header"
+require "shoulda-matchers"
 
 Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(


### PR DESCRIPTION
### Context

Ticket: N/A

Resolve errors running specs locally w/ docker compose

### Changes proposed in this pull request

Explicitly require `rspec-default_http_header` and `shoulda-matchers`
