### PR TITLE
Fix sandbox course_cohort seeder

### DIFF
--- a/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
+++ b/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
@@ -69,6 +69,7 @@ module ValidTestDataGenerators
       logger.error "APITestScenariosSeeder failed: #{e.message}"
       logger.error e.backtrace.join("\n")
 
+      Sentry.capture_exception(e)
       Outcome[success: false, error: e.message]
     end
 
@@ -257,11 +258,16 @@ module ValidTestDataGenerators
         current_schedule = Schedule.create!(identifier:, **attrs)
       end
 
-      cc = CourseCohort.find_or_create_by!(
-        course:,
-        cohort: current_cohort,
-      )
-      cc.update!(schedule: current_schedule)
+      cc = CourseCohort.find_by(course:, cohort: current_cohort)
+      if cc
+        cc.update!(schedule: current_schedule)
+      else
+        cc = CourseCohort.create!(
+          course:,
+          cohort: current_cohort,
+          schedule: current_schedule,
+        )
+      end
       cc.course_cohort_providers.find_or_create_by!(lead_provider:)
 
       delivery_partners.each do |dp|


### PR DESCRIPTION
### Context

When there is not any data `CourseCohort.find_or_create_by!` fails
because its missing the schedule

### Changes proposed in this pull request

Change how we update / create course_cohort

Add sentry on error