### PR TITLE
Fix delivery partner list for all cohorts

### DIFF
--- a/app/controllers/admin/lead_providers_controller.rb
+++ b/app/controllers/admin/lead_providers_controller.rb
@@ -23,7 +23,7 @@ module Admin
         @pagy_statements, @statements = pagy(@lead_provider.statements.where(cohort: @current_cohort))
       else
         @pagy_applications, @applications = pagy(applications_scope, items: 25)
-        @pagy_delivery_partners, @delivery_partners = pagy(@lead_provider.delivery_partners)
+        @pagy_delivery_partners, @delivery_partners = pagy(@lead_provider.delivery_partners.distinct)
         @pagy_statements, @statements = pagy(@lead_provider.statements)
       end
     end


### PR DESCRIPTION
### Context

Some delivery partners are available on multiple cohorts

### Changes proposed in this pull request

This remove duplicate entries for all cohorts