### PR TITLE
Application declarations cohort

### DIFF
--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -33,7 +33,7 @@ module Declarations
 
     validate :declaration_valid
 
-    delegate :lead_provider, :schedule, :cohort, to: :application
+    delegate :lead_provider, :schedule, to: :application
 
     attr_reader :raw_declaration_date, :declaration
 
@@ -82,6 +82,19 @@ module Declarations
 
     def started_declaration?
       declaration_type == Declaration::STARTED
+    end
+
+    def cohort
+      if started_declaration?
+        application.cohort
+      else
+        application
+          .declarations
+          .started_declaration_type
+          .billable_or_changeable
+          .first
+          .cohort
+      end
     end
 
   private

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -127,7 +127,7 @@ FactoryBot.define do
 
     trait :with_declaration do
       after(:create) do |application|
-        application.declarations << create(:declaration, :started, application:)
+        application.declarations << create(:declaration, :started, application:, cohort: application.cohort)
       end
     end
 

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -136,11 +136,9 @@ RSpec.describe Declarations::Create, type: :model do
 
   describe "completed declaration" do
     let(:declaration_type) { "completed" }
-    let(:application) do
+    let!(:application) do
       create(:application, :accepted, :with_declaration, course_cohort:, lead_provider:)
     end
-
-    before { application } # this is to force declaration creation ahead of the test
 
     describe "happy paths" do
       it { expect { service.call }.to change(Declaration, :count).by(1) }
@@ -161,6 +159,36 @@ RSpec.describe Declarations::Create, type: :model do
         end
 
         it { expect { service.call }.to change(Declaration, :count).by(1) }
+      end
+
+      context "when the application has resumed in a different cohort" do
+        let(:resume_cohort) { create(:cohort, suffix: "b") }
+        let(:course_cohort) { create(:course_cohort, cohort: resume_cohort) }
+        let(:started_declaration) { application.declarations.started_declaration_type.first }
+        let(:started_cohort) { started_declaration.cohort }
+        let(:delivery_partner_id) do
+          create(:delivery_partner,
+                 lead_providers: {
+                   started_cohort => lead_provider,
+                   resume_cohort => lead_provider,
+                 }).ecf_id
+        end
+        let(:secondary_delivery_partner_id) do
+          create(:delivery_partner,
+                 lead_providers: {
+                   started_cohort => lead_provider,
+                   resume_cohort => lead_provider,
+                 }).ecf_id
+        end
+
+        before do
+          application.update!(course_cohort:)
+        end
+
+        it "uses the started declaration cohort" do
+          expect { service.call }.to change(Declaration, :count).by(1)
+          expect(service.declaration.cohort).to eq(started_declaration.cohort)
+        end
       end
     end
 


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/323

Financial report mandates that declarations are in the same cohort.

### Changes proposed in this pull request

* Update factory to create started declaration cohort matching
application.cohort

* create completed declaration with started declaration cohort