### PR TITLE
Changed provider email

### DIFF
--- a/app/controllers/applications/change_provider/check_answers_controller.rb
+++ b/app/controllers/applications/change_provider/check_answers_controller.rb
@@ -16,6 +16,17 @@ module Applications
         # Don't leave this in :)
         application.update!(lead_provider_id: new_provider.id)
 
+        GenericMailer.with(
+          to: application.user.email,
+          full_name: application.user.full_name,
+          provider_name: application.lead_provider.name,
+          course_name: application.course.name,
+          cohort_date: application.cohort.name,
+          ecf_id: application.ecf_id,
+          sign_in_link: Rails.configuration.sign_in_link,
+          feedback_link: Rails.configuration.feedback_link,
+        ).change_provider.deliver_later
+
         flash[:notice] = {
           title: t("applications.change_provider.check_answers.success.title"),
           message: t("applications.change_provider.check_answers.success.message"),

--- a/app/controllers/email_updates_controller.rb
+++ b/app/controllers/email_updates_controller.rb
@@ -14,7 +14,7 @@ class EmailUpdatesController < PublicPagesController
     @form = EmailUpdates.new(email_update_params)
     if @form.valid?
       current_user.update_email_updates_status(@form)
-      GenericMailer.with(to: current_user.email, service_link: service_url, unsubscribe_link:).email_updates_confirmation.deliver_now
+      GenericMailer.with(to: current_user.email, service_link: Rails.configuration.service_base_url, unsubscribe_link:).email_updates_confirmation.deliver_now
     else
       render :new
     end
@@ -44,14 +44,6 @@ private
   end
 
   def unsubscribe_link
-    "#{service_url}#{unsubscribe_email_updates_path(unsubscribe_key: current_user.email_updates_unsubscribe_key)}"
-  end
-
-  def service_url
-    if Rails.env.production?
-      "https://register-national-professional-qualifications.education.gov.uk/"
-    else
-      "https://#{ENV['DOMAIN']}"
-    end
+    "#{Rails.configuration.service_base_url}#{unsubscribe_email_updates_path(unsubscribe_key: current_user.email_updates_unsubscribe_key)}"
   end
 end

--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -29,8 +29,6 @@ private
     view_mail(TEMPLATE_ID, to: params[:to], subject: I18n.t(subject))
   end
 
-private
-
   def application
     @application ||= Application.find_by(ecf_id: params[:ecf_id]) if params[:ecf_id].present?
   end

--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -4,19 +4,29 @@ class GenericMailer < ApplicationMailer
   after_action :log_application_event, if: :application
 
   def eligible_for_funding
-    view_mail(TEMPLATE_ID, to: params[:to], subject: "Eligible for funding")
+    generic_mail(subject: "mailers.eligible_for_funding")
   end
 
   def application_submitted
-    view_mail(TEMPLATE_ID, to: params[:to], subject: "Application submitted")
+    generic_mail(subject: "mailers.application_submitted")
   end
 
   def confirmation_code
-    view_mail(TEMPLATE_ID, to: params[:to], subject: "Confirmation Code")
+    generic_mail(subject: "mailers.confirmation_code")
   end
 
   def email_updates_confirmation
-    view_mail(TEMPLATE_ID, to: params[:to], subject: "Email Updates Confirmation")
+    generic_mail(subject: "mailers.email_updates_confirmation")
+  end
+
+  def change_provider
+    generic_mail(subject: "mailers.change_provider")
+  end
+
+private
+
+  def generic_mail(subject:)
+    view_mail(TEMPLATE_ID, to: params[:to], subject: I18n.t(subject))
   end
 
 private

--- a/app/views/generic_mailer/change_provider.text.erb
+++ b/app/views/generic_mailer/change_provider.text.erb
@@ -1,0 +1,31 @@
+Application ID: <%= params[:ecf_id] %>
+
+Dear <%= params[:full_name] %>,
+
+You've been registered for <%= params[:course_name] %> starting in <%= params[:cohort_date] %>.
+
+# Apply through your provider
+You still need to apply through <%= params[:provider_name] %>. They'll contact you by email to outline the next steps, including how to apply.
+
+After you apply your course provider will check that:
+- you meet the course's suitability requirements.
+- a funded place is available (if we've told you you're eligible for funding)
+
+# Course start
+You've registered for a course which starts in <%= params[:cohort_date] %>.
+
+# Check or change your registration
+
+[Sign in](<%= params[:sign_in_link] %>) to:
+- update your name, date of birth, email address or phone number
+- change your course or provider
+- check your registration details, including any funding you're eligible for
+
+# We'd like your feedback
+Tell us about your experience using the registration service by [completing a short feedback form](<%= params[:feedback_link] %>).
+
+# Get help
+Email continuing-professional-development@education.gov.uk
+
+Regards,
+The Teacher Continuing Professional Development Team

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -96,4 +96,8 @@ Rails.application.configure do
     Bullet.add_footer                   = true
     Bullet.unused_eager_loading_enable  = false # Disabled due to the way our queries are structured
   end
+
+  config.service_base_url = ENV["DOMAIN"]
+  config.sign_in_link = "#{config.service_base_url}/sign-in"
+  config.feedback_link = "#{config.service_base_url}/feedback"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,4 +103,7 @@ Rails.application.configure do
                                           end
                                         },
                        }
+  config.service_base_url = config.service_base_url = Rails.env.production? ? "https://national-professional-development.education.gov.uk/" : "http://#{ENV['DOMAIN']}"
+  config.sign_in_link = "#{config.service_base_url}/sign-in"
+  config.feedback_link = "#{config.service_base_url}/feedback"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,4 +52,8 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   config.middleware.use RackSessionAccess::Middleware
+
+  config.service_base_url = "http://test.tte.education.gov.uk"
+  config.sign_in_link = "http://test.sign_in.education.gov.uk"
+  config.feedback_link = "http://test.feedback.education.gov.uk"
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,12 @@ en:
         blank: TRN can't be blank
         not_real: You must enter a valid TRN
         wrong_length: TRN is the wrong length (should be %{count} characters)
+  mailers:
+    eligible_for_funding: Eligible for funding
+    application_submitted: Application submitted
+    confirmation_code:  Confirmation Code
+    email_updates_confirmation: Email Updates Confirmation
+    change_provider: You've registered for %{course_name} - next steps
 
   application: &application
     blank: The entered '#/%{parameterized_attribute}' is missing from your request. Check details and try again.

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe GenericMailer, type: :mailer do
       aggregate_failures do
         expect(subject).to use_template(GenericMailer::TEMPLATE_ID)
         expect(mail.to).to eq([to])
-        expect(mail.personalisation[:subject]).to eq("Email Updates Confirmation")
+        expect(mail.personalisation[:subject]).to eq(I18n.t("mailers.email_updates_confirmation"))
 
         body = mail.personalisation[:body]
         expect(body).to include(service_link)
@@ -52,7 +52,7 @@ RSpec.describe GenericMailer, type: :mailer do
       aggregate_failures do
         expect(subject).to use_template(GenericMailer::TEMPLATE_ID)
         expect(mail.to).to eq([to])
-        expect(mail.personalisation[:subject]).to eq("Application submitted")
+        expect(mail.personalisation[:subject]).to eq(I18n.t("mailers.application_submitted"))
 
         body = mail.personalisation[:body]
         expect(body).to include(full_name)
@@ -80,7 +80,7 @@ RSpec.describe GenericMailer, type: :mailer do
       aggregate_failures do
         expect(subject).to use_template(GenericMailer::TEMPLATE_ID)
         expect(mail.to).to eq([to])
-        expect(mail.personalisation[:subject]).to eq("Confirmation Code")
+        expect(mail.personalisation[:subject]).to eq(I18n.t("mailers.confirmation_code"))
 
         body = mail.personalisation[:body]
         expect(body).to include(code)
@@ -111,12 +111,55 @@ RSpec.describe GenericMailer, type: :mailer do
       aggregate_failures do
         expect(subject).to use_template(GenericMailer::TEMPLATE_ID)
         expect(mail.to).to eq([to])
-        expect(mail.personalisation[:subject]).to eq("Eligible for funding")
+        expect(mail.personalisation[:subject]).to eq(I18n.t("mailers.eligible_for_funding"))
 
         body = mail.personalisation[:body]
         expect(body).to include(full_name)
         expect(body).to include(provider_name)
         expect(body).to include(course_name)
+        expect(body).to include(ecf_id)
+      end
+    end
+
+    it_behaves_like "a mailer with redacted logs"
+  end
+
+  describe "#change_provider" do
+    let(:to) { "recipient@example.com" }
+    let(:full_name) { "Example User" }
+    let(:provider_name) { "Example Provider" }
+    let(:course_name) { "Example Course" }
+    let(:cohort_date) { "autumn 2026" }
+    let(:ecf_id) { "ABC123" }
+    let(:sign_in_link) { "sign_in_link" }
+    let(:feedback_link) { "feedback_link" }
+
+    subject(:mail) do
+      described_class.with(
+        to:,
+        full_name:,
+        provider_name:,
+        course_name:,
+        cohort_date:,
+        ecf_id:,
+        sign_in_link:,
+        feedback_link:,
+      ).change_provider
+    end
+
+    it do
+      aggregate_failures do
+        expect(subject).to use_template(GenericMailer::TEMPLATE_ID)
+        expect(mail.to).to eq([to])
+        expect(mail.personalisation[:subject]).to eq(I18n.t("mailers.change_provider"))
+
+        body = mail.personalisation[:body]
+        expect(body).to include(full_name)
+        expect(body).to include(provider_name)
+        expect(body).to include(course_name)
+        expect(body).to include(cohort_date)
+        expect(body).to include(sign_in_link)
+        expect(body).to include(feedback_link)
         expect(body).to include(ecf_id)
       end
     end

--- a/spec/mailers/previews/generic_mailer_preview.rb
+++ b/spec/mailers/previews/generic_mailer_preview.rb
@@ -34,4 +34,17 @@ class GenericMailerPreview < ActionMailer::Preview
       unsubscribe_link: "https://example.service.gov.uk/unsubscribe?token=abc123",
     ).email_updates_confirmation
   end
+
+  def change_provider
+    GenericMailer.with(
+      to: "test@example.com",
+      ecf_id: "abcd-1234-efgh-5678-ijkl",
+      full_name: "Dave Coaches",
+      course_name: "Teaching in Reception",
+      cohort_date: "Autumn 2026",
+      provider_name: "Acme Teaching",
+      sign_in_link: "https://signin.service.gov.uk",
+      feedback_link: "https://feedback.service.gov.uk",
+    ).change_provider
+  end
 end

--- a/spec/requests/applications/change_provider/check_answers_spec.rb
+++ b/spec/requests/applications/change_provider/check_answers_spec.rb
@@ -42,7 +42,18 @@ RSpec.describe "Applications::ChangeProvider::CheckAnswers", type: :request do
     context "with valid provider_id in the session" do
       let(:session_provider_id) { another_provider.id }
 
-      it "updates the application's lead provider and redirects to user registrations path" do
+      it "updates the application's lead provider, sends an email and redirects to user registrations path" do
+        expect(GenericMailer).to receive(:with).with(
+          to: application.user.email,
+          full_name: application.user.full_name,
+          provider_name: another_provider.name,
+          course_name: application.course.name,
+          cohort_date: application.cohort.name,
+          ecf_id: application.ecf_id,
+          sign_in_link: Rails.configuration.sign_in_link,
+          feedback_link: Rails.configuration.feedback_link,
+        ).and_call_original
+
         post url
         expect(response).to redirect_to(application_path(application.ecf_id))
         expect(application.reload.lead_provider_id).to eq(session_provider_id)


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/283

After a user has changed provider, send an email to confirm.

### Changes proposed in this pull request

[What has been changed?]

- Added GenericMailer#change_provider email
- Added some rails config for service/feedback urls