### PR TITLE
Add rake task to call the resume application API endpoint

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -26,9 +26,4 @@ class LeadProvider < ApplicationRecord
   def delivery_partners_for_cohort(cohort)
     delivery_partners.where(delivery_partnerships: { cohort: })
   end
-
-  def generate_token!
-    scope = APIToken.scopes[:lead_provider]
-    APIToken.create_with_random_token!(scope:, lead_provider: self)
-  end
 end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -26,4 +26,9 @@ class LeadProvider < ApplicationRecord
   def delivery_partners_for_cohort(cohort)
     delivery_partners.where(delivery_partnerships: { cohort: })
   end
+
+  def generate_token!
+    scope = APIToken.scopes[:lead_provider]
+    APIToken.create_with_random_token!(scope:, lead_provider: self)
+  end
 end

--- a/lib/tasks/api_test/defer.rake
+++ b/lib/tasks/api_test/defer.rake
@@ -1,0 +1,20 @@
+require_relative "helpers/defer_application"
+
+namespace :api_test do
+  desc "Test the Defer endpoint"
+  # Call the defer api endpoint using any deferred application
+  # or optionally with a specific application id
+  # Usage when using any started application:
+  #    rake api_test:defer_application
+  #
+  # Usage when using a specific application
+  #    rake api_test:defer_application\[279]
+  #
+  task :defer_application, %i[application_id course_cohort_id] => :environment do |_t, args|
+    application = if args[:application_id].present?
+                    Application.find_by_id(args[:application_id])
+                  end
+
+    DeferApplication.new(application:).call
+  end
+end

--- a/lib/tasks/api_test/helpers/call_api.rb
+++ b/lib/tasks/api_test/helpers/call_api.rb
@@ -1,6 +1,6 @@
 module CallApi
   def call_api(lead_provider:, url:, body:)
-    api_token = lead_provider.generate_token!
+    api_token = generate_token!(lead_provider:)
 
     headers = {
       "Authorization" => "Bearer #{api_token}",
@@ -12,5 +12,12 @@ module CallApi
     APIToken.find_by_unhashed_token(api_token, scope: :lead_provider).delete
 
     response
+  end
+
+private
+
+  def generate_token!(lead_provider:)
+    scope = APIToken.scopes[:lead_provider]
+    APIToken.create_with_random_token!(scope:, lead_provider:)
   end
 end

--- a/lib/tasks/api_test/helpers/call_api.rb
+++ b/lib/tasks/api_test/helpers/call_api.rb
@@ -1,0 +1,16 @@
+module CallApi
+  def call_api(lead_provider:, url:, body:)
+    api_token = lead_provider.generate_token!
+
+    headers = {
+      "Authorization" => "Bearer #{api_token}",
+      "Content-Type" => "application/json",
+    }
+
+    response = HTTParty.put(url, body:, headers:)
+
+    APIToken.find_by_unhashed_token(api_token, scope: :lead_provider).delete
+
+    response
+  end
+end

--- a/lib/tasks/api_test/helpers/defer_application.rb
+++ b/lib/tasks/api_test/helpers/defer_application.rb
@@ -1,0 +1,38 @@
+require_relative "call_api"
+
+class DeferApplication
+  include CallApi
+  include Rails.application.routes.url_helpers
+
+  def initialize(application: nil)
+    @application = application
+  end
+
+  def call
+    if application.nil?
+      raise "[DeferApplication] Could not find a deferred application"
+    end
+
+    body = {
+      data: {
+        type: "application",
+        attributes: {
+          reason: "other",
+        },
+      },
+    }.to_json
+
+    url = defer_api_v1_application_url(application.ecf_id, host: "localhost:3000")
+
+    response = call_api(lead_provider: application.lead_provider, url:, body:)
+
+    puts "status: #{response.code}" # rubocop:disable Rails/Output
+    puts "response: #{response.parsed_response}" # rubocop:disable Rails/Output
+  end
+
+private
+
+  def application
+    @application ||= Application.started_status.last
+  end
+end

--- a/lib/tasks/api_test/helpers/resume_application.rb
+++ b/lib/tasks/api_test/helpers/resume_application.rb
@@ -2,6 +2,7 @@ require_relative "call_api"
 
 class ResumeApplication
   include CallApi
+  include Rails.application.routes.url_helpers
 
   def initialize(application: nil, course_cohort: nil)
     @application = application
@@ -22,7 +23,7 @@ class ResumeApplication
       },
     }.to_json
 
-    url = "http://localhost:3000/api/v1/applications/#{application.ecf_id}/resume"
+    url = resume_api_v1_application_url(application.ecf_id, host: "localhost:3000")
 
     response = call_api(lead_provider: application.lead_provider, url:, body:)
 

--- a/lib/tasks/api_test/helpers/resume_application.rb
+++ b/lib/tasks/api_test/helpers/resume_application.rb
@@ -1,0 +1,60 @@
+require_relative "call_api"
+
+class ResumeApplication
+  include CallApi
+
+  def initialize(application: nil, course_cohort: nil)
+    @application = application
+    @course_cohort = course_cohort
+  end
+
+  def call
+    if application.nil?
+      raise "[ResumeApplication] Could not find a deferred application"
+    end
+
+    body = {
+      data: {
+        type: "application",
+        attributes: {
+          schedule_id: course_cohort.ecf_id,
+        },
+      },
+    }.to_json
+
+    url = "http://localhost:3000/api/v1/applications/#{application.ecf_id}/resume"
+
+    response = call_api(lead_provider: application.lead_provider, url:, body:)
+
+    puts "status: #{response.code}" # rubocop:disable Rails/Output
+    puts "response: #{response.parsed_response}" # rubocop:disable Rails/Output
+  end
+
+private
+
+  def application
+    @application ||= LeadProvider.find_each do |lead_provider|
+      course_cohorts = training_live_course_cohorts_for(lead_provider:)
+      next unless course_cohorts.any?
+
+      applications = lead_provider.applications.deferred_status
+
+      return applications.last if applications.any?
+    end
+  end
+
+  def course_cohort
+    @course_cohort ||= begin
+      course_cohorts = training_live_course_cohorts_for(lead_provider: application.lead_provider)
+      if course_cohorts.blank?
+        raise "Cannot find any live course cohorts for #{application.lead_provider.name}"
+      end
+
+      course_cohorts.last
+    end
+  end
+
+  def training_live_course_cohorts_for(lead_provider:)
+    lead_provider.course_cohorts.select { |cc| cc.schedule&.training_live? }
+  end
+end

--- a/lib/tasks/api_test/resume.rake
+++ b/lib/tasks/api_test/resume.rake
@@ -1,0 +1,27 @@
+require_relative "helpers/resume_application"
+
+namespace :api_test do
+  desc "Test the Resume endpoint"
+  # Call the resume api endpoint using any deferred application
+  # or optionally with a specific application id and / or course cohort id
+  # Usage when using any deferred application/live course cohort:
+  #    rake api_test:resume_application
+  #
+  # Usage when using a specific application and any live course cohort for that provider
+  #    rake api_test:resume_application\[279]
+  #
+  # Usage when using a specific application and specific course cohort
+  #    rake api_test:resume_application\[279 777]
+  #
+  task :resume_application, %i[application_id course_cohort_id] => :environment do |_t, args|
+    application = if args[:application_id].present?
+                    Application.find_by_id(args[:application_id])
+                  end
+
+    course_cohort = if args[:course_cohort_id].present?
+                      CourseCohort.find_by_id(args[:course_cohort_id])
+                    end
+
+    ResumeApplication.new(application:, course_cohort:).call
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/280

### Changes proposed in this pull request

Added a rake task to test the resume application API endpoint locally
