### PR TITLE
Refactor mailers for consistency

### DIFF
--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -20,25 +20,35 @@ class GenericMailer < ApplicationMailer
   end
 
   def change_provider
-    generic_mail(subject: "mailers.change_provider", course_name: params[:course_name])
+    generic_mail(subject: "mailers.change_provider")
   end
 
   def deferral_notification
-    generic_mail(subject: "mailers.deferral_notification", course_name: params[:course_name])
+    generic_mail(subject: "mailers.deferral_notification")
   end
 
   def registration_open_notification
-    generic_mail(subject: "mailers.registration_open_notification", course_name: params[:course_name])
+    generic_mail(subject: "mailers.registration_open_notification")
   end
 
   def deferral_expiring_notification
-    generic_mail(subject: "mailers.deferral_expiring_notification", course_name: params[:course_name])
+    generic_mail(subject: "mailers.deferral_expiring_notification")
   end
 
 private
 
-  def generic_mail(subject:, course_name: nil)
-    view_mail(TEMPLATE_ID, to: params[:to], subject: I18n.t(subject, course_name:))
+  def generic_mail(subject:)
+    view_mail(TEMPLATE_ID, to: params[:to], subject: build_subject(subject:))
+  end
+
+  def build_subject(subject:)
+    course_name = params[:course_name]
+
+    if course_name.present?
+      I18n.t(subject, course_name:)
+    else
+      I18n.t(subject)
+    end
   end
 
   def application

--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -20,25 +20,25 @@ class GenericMailer < ApplicationMailer
   end
 
   def change_provider
-    generic_mail(subject: "mailers.change_provider")
+    generic_mail(subject: "mailers.change_provider", course_name: params[:course_name])
   end
 
   def deferral_notification
-    view_mail(TEMPLATE_ID, to: params[:to], subject: "Notification of deferral - #{params[:course_name]}")
+    generic_mail(subject: "mailers.deferral_notification", course_name: params[:course_name])
   end
 
   def registration_open_notification
-    view_mail(TEMPLATE_ID, to: params[:to], subject: "Registration open - #{params[:course_name]}")
+    generic_mail(subject: "mailers.registration_open_notification", course_name: params[:course_name])
   end
 
   def deferral_expiring_notification
-    view_mail(TEMPLATE_ID, to: params[:to], subject: "Registration about to expire - #{params[:course_name]}")
+    generic_mail(subject: "mailers.deferral_expiring_notification", course_name: params[:course_name])
   end
 
 private
 
-  def generic_mail(subject:)
-    view_mail(TEMPLATE_ID, to: params[:to], subject: I18n.t(subject))
+  def generic_mail(subject:, course_name: nil)
+    view_mail(TEMPLATE_ID, to: params[:to], subject: I18n.t(subject, course_name:))
   end
 
   def application

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,9 @@ en:
     confirmation_code:  Confirmation Code
     email_updates_confirmation: Email Updates Confirmation
     change_provider: You've registered for %{course_name} - next steps
+    deferral_notification: Notification of deferral - %{course_name}
+    registration_open_notification: Registration open - %{course_name}
+    deferral_expiring_notification: Registration about to expire - %{course_name}
 
   application: &application
     blank: The entered '#/%{parameterized_attribute}' is missing from your request. Check details and try again.

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe GenericMailer, type: :mailer do
       aggregate_failures do
         expect(subject).to use_template(GenericMailer::TEMPLATE_ID)
         expect(mail.to).to eq([to])
-        expect(mail.personalisation[:subject]).to eq(I18n.t("mailers.change_provider"))
+        expect(mail.personalisation[:subject]).to eq(I18n.t("mailers.change_provider", course_name:))
 
         body = mail.personalisation[:body]
         expect(body).to include(full_name)


### PR DESCRIPTION
### Context

Ticket: N/A

Update methods in GenericMailer to use the `generic_mail` method

### Changes proposed in this pull request
 
Add missing `course_name` to `change_provider` email