### PR TITLE
[281] Implement withdrawal logic

### DIFF
--- a/app/controllers/applications/applications_controller.rb
+++ b/app/controllers/applications/applications_controller.rb
@@ -3,9 +3,8 @@ module Applications
     helper_method :application
 
     def index
-      return unless current_user.applications.count == 1
-
-      redirect_to application_path(current_user.applications.first.ecf_id)
+      latest_application = current_user.applications.order(created_at: :desc).first
+      redirect_to application_path(latest_application.ecf_id) if latest_application
     end
 
     def show

--- a/app/controllers/applications/applications_controller.rb
+++ b/app/controllers/applications/applications_controller.rb
@@ -3,8 +3,13 @@ module Applications
     helper_method :application
 
     def index
-      latest_application = current_user.applications.order(created_at: :desc).first
-      redirect_to application_path(latest_application.ecf_id) if latest_application
+      most_recent_application = current_user.applications.order(created_at: :desc).first
+
+      if most_recent_application
+        redirect_to application_path(most_recent_application.ecf_id)
+      else
+        redirect_to root_path
+      end
     end
 
     def show

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -35,7 +35,7 @@ class Application < ApplicationRecord
   has_many :declarations
 
   scope :expired_applications, -> { where(status: [REJECTED, WITHDRAWN]).where("created_at < ?", cut_off_date_for_expired_applications) }
-  scope :active_applications, -> { where.not(id: expired_applications) }
+  scope :active_applications, -> { where.not(id: expired_applications).not_withdrawn }
   scope :has_been_accepted, -> { where(status: [ACCEPTED, STARTED, COMPLETED, DEFERRED, WITHDRAWN]) }
   scope :eligible_for_funding, -> { where(eligible_for_funding: true) }
   scope :for_manual_review, -> { where.not(review_status: nil) }
@@ -73,7 +73,7 @@ class Application < ApplicationRecord
   STATUS_TRANSITIONS = {
     nil => [PENDING].freeze,
     PENDING => [ACCEPTED, REJECTED].freeze,
-    ACCEPTED => [STARTED, COMPLETED].freeze,
+    ACCEPTED => [STARTED, COMPLETED, WITHDRAWN].freeze,
     STARTED => [COMPLETED, DEFERRED, WITHDRAWN, ACCEPTED].freeze,
     DEFERRED => [STARTED, WITHDRAWN].freeze,
     WITHDRAWN => [STARTED].freeze,

--- a/app/services/applications/withdraw.rb
+++ b/app/services/applications/withdraw.rb
@@ -14,7 +14,7 @@ module Applications
       change-in-developmental-or-personal-priorities
       change-in-school-circumstances
       change-in-school-leadership
-      quality-of-programme-structure-not-suitable.
+      quality-of-programme-structure-not-suitable
       quality-of-programme-content-not-suitable
       quality-of-programme-facilitation-not-effective
       quality-of-programme-accessibility

--- a/app/views/applications/applications/_withdrawal_details.html.erb
+++ b/app/views/applications/applications/_withdrawal_details.html.erb
@@ -1,3 +1,6 @@
 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0">
-  <%= I18n.t('withdrawal_details.date_withdrawn', withdrawn_at: application.withdrawn_at&.to_fs(:govuk_short)) %>
+  <%= t('withdrawal_details.submit_new_registration_html', link: link_to(t('withdrawal_details.submit_new_registration_link'), registration_wizard_show_path(step: "course-start-date"))) %>
+</p>
+<p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0">
+  <%= t('withdrawal_details.date_withdrawn', withdrawn_at: application.withdrawn_at&.to_fs(:govuk_short)) %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -787,6 +787,8 @@ en:
       if_you_do_not_restart: If you do not restart the course within 12 months your registration will expire and you will be withdrawn from the course.
       funded_place: After you have been withdrawn, you will not be eligible for further funding.
   withdrawal_details:
+      submit_new_registration_html: "If you wish to register for a new course, you can %{link}."
+      submit_new_registration_link: "submit a new registration"
       date_withdrawn: "Date withdrawn: %{withdrawn_at}"
   course_start_details:
     eligible_for_funding: If your provider does not confirm you’ve started the course

--- a/lib/tasks/api_test/helpers/defer_application.rb
+++ b/lib/tasks/api_test/helpers/defer_application.rb
@@ -33,6 +33,10 @@ class DeferApplication
 private
 
   def application
-    @application ||= Application.started_status.last
+    @application ||= Application
+      .started_status
+      .joins(:course)
+      .where(courses: { identifier: Course::IDENTIFIERS })
+      .last
   end
 end

--- a/lib/tasks/api_test/helpers/withdraw_application.rb
+++ b/lib/tasks/api_test/helpers/withdraw_application.rb
@@ -1,0 +1,38 @@
+require_relative "call_api"
+
+class WithdrawApplication
+  include CallApi
+  include Rails.application.routes.url_helpers
+
+  def initialize(application: nil)
+    @application = application
+  end
+
+  def call
+    if application.nil?
+      raise "[WithdrawApplication] Could not find a withdrawable application"
+    end
+
+    body = {
+      data: {
+        type: "application",
+        attributes: {
+          reason: "other",
+        },
+      },
+    }.to_json
+
+    url = withdraw_api_v1_application_url(application.ecf_id, host: "localhost:3000")
+
+    response = call_api(lead_provider: application.lead_provider, url:, body:)
+
+    puts "status: #{response.code}" # rubocop:disable Rails/Output
+    puts "response: #{response.parsed_response}" # rubocop:disable Rails/Output
+  end
+
+private
+
+  def application
+    @application ||= Application.accepted_status.last
+  end
+end

--- a/lib/tasks/api_test/helpers/withdraw_application.rb
+++ b/lib/tasks/api_test/helpers/withdraw_application.rb
@@ -33,6 +33,10 @@ class WithdrawApplication
 private
 
   def application
-    @application ||= Application.accepted_status.last
+    @application ||= Application
+      .accepted_status
+      .joins(:course)
+      .where(courses: { identifier: Course::IDENTIFIERS })
+      .last
   end
 end

--- a/lib/tasks/api_test/withdraw.rake
+++ b/lib/tasks/api_test/withdraw.rake
@@ -1,0 +1,20 @@
+require_relative "helpers/withdraw_application"
+
+namespace :api_test do
+  desc "Test the Withdraw endpoint"
+  # Call the withdraw api endpoint using any accepted application
+  # or optionally with a specific application id
+  # Usage when using any accepted application:
+  #    rake api_test:withdraw_application
+  #
+  # Usage when using a specific application
+  #    rake api_test:withdraw_application\[279]
+  #
+  task :withdraw_application, %i[application_id] => :environment do |_t, args|
+    application = if args[:application_id].present?
+                    Application.find_by_id(args[:application_id])
+                  end
+
+    WithdrawApplication.new(application:).call
+  end
+end

--- a/public/api/docs/v1/swagger.yaml
+++ b/public/api/docs/v1/swagger.yaml
@@ -1668,7 +1668,7 @@ components:
                   - change-in-developmental-or-personal-priorities
                   - change-in-school-circumstances
                   - change-in-school-leadership
-                  - quality-of-programme-structure-not-suitable.
+                  - quality-of-programme-structure-not-suitable
                   - quality-of-programme-content-not-suitable
                   - quality-of-programme-facilitation-not-effective
                   - quality-of-programme-accessibility
@@ -1868,7 +1868,7 @@ components:
                         - change-in-developmental-or-personal-priorities
                         - change-in-school-circumstances
                         - change-in-school-leadership
-                        - quality-of-programme-structure-not-suitable.
+                        - quality-of-programme-structure-not-suitable
                         - quality-of-programme-content-not-suitable
                         - quality-of-programme-facilitation-not-effective
                         - quality-of-programme-accessibility

--- a/spec/controllers/registration_wizard_controller_spec.rb
+++ b/spec/controllers/registration_wizard_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe RegistrationWizardController do
 
     context "when user has a withdrawn application for the course" do
       let(:course) { create(:course) }
-      let!(:application) { create(:application, :accepted, course:, user: current_user, status: Application::WITHDRAWN) }
+      let!(:application) { create(:application, :withdrawn, course:, user: current_user) }
 
       before do
         session["registration_store"] = { "course_identifier" => course.identifier }

--- a/spec/controllers/registration_wizard_controller_spec.rb
+++ b/spec/controllers/registration_wizard_controller_spec.rb
@@ -78,6 +78,20 @@ RSpec.describe RegistrationWizardController do
         end
       end
     end
+
+    context "when user has a withdrawn application for the course" do
+      let(:course) { create(:course) }
+      let!(:application) { create(:application, :accepted, course:, user: current_user, status: Application::WITHDRAWN) }
+
+      before do
+        session["registration_store"] = { "course_identifier" => course.identifier }
+        patch(:update, params: { step: "choose-your-course" })
+      end
+
+      it "does not redirect to the withdrawn application" do
+        expect(response).not_to redirect_to application_path(application.ecf_id)
+      end
+    end
   end
 
   describe "#update" do

--- a/spec/features/applications_spec.rb
+++ b/spec/features/applications_spec.rb
@@ -19,4 +19,44 @@ RSpec.feature "Applications", type: :feature do
       expect(page).to have_current_path("/")
     end
   end
+
+  describe "withdrawn application" do
+    let(:user) { create(:user) }
+    let!(:application) do
+      create(:application, :accepted, user:).tap do |app|
+        app.update!(status: Application::WITHDRAWN)
+        create(:state_change, :withdrawn, application: app, lead_provider: app.lead_provider)
+      end
+    end
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    end
+
+    scenario "shows withdrawn status and re-registration link" do
+      visit application_path(application.ecf_id)
+
+      expect(page).to have_text("Withdrawn")
+      expect(page).to have_text("Date withdrawn:")
+      expect(page).to have_link("submit a new registration", href: registration_wizard_show_path(step: "course-start-date"))
+    end
+
+    scenario "redirects from index to the withdrawn application" do
+      visit applications_path
+
+      expect(page).to have_current_path(application_path(application.ecf_id))
+      expect(page).to have_text("Withdrawn")
+    end
+
+    context "when user also has a newer active application" do
+      let!(:active_application) { create(:application, :accepted, user:, created_at: 1.day.from_now) }
+
+      scenario "redirects to the most recent application" do
+        visit applications_path
+
+        expect(page).to have_current_path(application_path(active_application.ecf_id))
+        expect(page).not_to have_text("Withdrawn")
+      end
+    end
+  end
 end

--- a/spec/features/applications_spec.rb
+++ b/spec/features/applications_spec.rb
@@ -36,12 +36,7 @@ RSpec.feature "Applications", type: :feature do
 
   describe "withdrawn application" do
     let(:user) { create(:user) }
-    let!(:application) do
-      create(:application, :accepted, user:).tap do |app|
-        app.update!(status: Application::WITHDRAWN)
-        create(:state_change, :withdrawn, application: app, lead_provider: app.lead_provider)
-      end
-    end
+    let!(:application) { create(:application, :withdrawn, user:) }
 
     before do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)

--- a/spec/features/applications_spec.rb
+++ b/spec/features/applications_spec.rb
@@ -8,6 +8,20 @@ RSpec.feature "Applications", type: :feature do
       visit "/applications"
       expect(page).to have_current_path("/")
     end
+
+    context "when logged in with no applications" do
+      let(:user) { create(:user) }
+
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      end
+
+      scenario "redirects to the registration start page" do
+        visit applications_path
+
+        expect(page).to have_current_path(root_path)
+      end
+    end
   end
 
   describe "application show page" do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -153,6 +153,19 @@ RSpec.describe Application do
 
       it { is_expected.to contain_exactly(no_status_application, active_application, deferred_application) }
     end
+
+    describe ".active_applications" do
+      subject { described_class.active_applications.to_a }
+
+      let!(:pending_application) { create(:application, :pending) }
+      let!(:accepted_application) { create(:application, :accepted) }
+      let!(:withdrawn_application) { create(:application, :withdrawn) }
+
+      it "excludes withdrawn applications" do
+        expect(subject).to contain_exactly(pending_application, accepted_application)
+        expect(subject).not_to include(withdrawn_application)
+      end
+    end
   end
 
   describe "#inside_catchment?" do

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -155,6 +155,13 @@ RSpec.describe "Application endpoints", type: :request do
       it_behaves_like "a successful api call"
     end
 
+    context "when the application is accepted" do
+      let(:application_status_trait) { :accepted }
+      let(:application) { create(:application, application_status_trait, lead_provider: current_lead_provider, course_cohort:) }
+
+      it_behaves_like "a successful api call"
+    end
+
     context "when the application cannot be withdrawn" do
       let(:application_status_trait) { :withdrawn }
       let(:expected_response) do


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/281

As a Provider
I need to inform DfE that a Participant needs to be Withdrawn
So that the Participant registration data can be kept up to date

### Changes proposed in this pull request

 - Add withdrawal details and "submit a new registration" link to `/applications` page
 - Allow applications to transition from ACCEPTED to WITHDRAWN
 - Exclude withdrawn applications from active_applications scope
 - Redirect `/applications `to the user's most recent application (so withdrawn users see their withdrawal status)

**Withdrawn application*
<img width="2099" height="1102" alt="withdrawn-application" src="https://github.com/user-attachments/assets/49ee630c-e6e1-4270-8a3f-d830241cc7f0" />

   