### PR TITLE
Pin 3rd party github actions

### DIFF
--- a/.github/workflows/refresh_knapsack_manifest.yml
+++ b/.github/workflows/refresh_knapsack_manifest.yml
@@ -67,8 +67,8 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Create pull request 
-        uses: peter-evans/create-pull-request@v8
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # Pinned at v8.1.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: refresh-knapsack-manifest

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -165,7 +165,7 @@ jobs:
   #         bundler-cache: true
 
   #     - name: Setup sonarqube
-  #       uses: warchant/setup-sonar-scanner@v9
+  #       uses: warchant/setup-sonar-scanner@7a89a4622e5c3b5d9c9673cf04f15f005f69d2eb # Pinned at v9
 
   #     - name: Download Artifacts
   #       uses: actions/download-artifact@v6


### PR DESCRIPTION
### Trello card

https://trello.com/c/8RwMeaL4/2682-pin-third-party-github-actions-mobilise

### Changes proposed in this pull request

- pin all 3rd party github actions at specific versions (for security)

### Guidance to review

see successful workflows run by this PR