### PR TITLE
[337] Enable teacher auth on review apps

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -71,8 +71,7 @@ module Registration
     config.x.tracking_pixels_enabled = ENV["TRACKING_PIXELS"].to_s == "true"
     config.x.google_analytics_id = ENV["GOOGLE_ANALYTICS_ID"].presence
 
-    # Teacher Auth OIDC - disabled on review apps as callback URLs cannot be pre-registered
-    config.x.teacher_auth.enabled = !Rails.env.review?
+    config.x.teacher_auth.enabled = true
 
     # Use active record session store in all environments for consistency
     config.session_store :active_record_store, key: "_cpd_tte_session",

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -17,13 +17,18 @@ module "application_configuration" {
   # Delete for non rails apps
   is_rails_application = true
 
-  config_variables = {
-    ENVIRONMENT_NAME = var.environment
-    PGSSLMODE        = local.postgres_ssl_mode
-    RAILS_ENV        = var.environment
-    AZURE_STORAGE_ACCOUNT_NAME = module.storage_account.name
-    AZURE_STORAGE_CONTAINER    = "uploads"
-  }
+  config_variables = merge(
+    {
+      ENVIRONMENT_NAME           = var.environment
+      PGSSLMODE                  = local.postgres_ssl_mode
+      RAILS_ENV                  = var.environment
+      AZURE_STORAGE_ACCOUNT_NAME = module.storage_account.name
+      AZURE_STORAGE_CONTAINER    = "uploads"
+    },
+    var.environment == "review" ? {
+      HOSTING_DOMAIN = "https://${var.service_name}-${local.environment}.${module.cluster_data.ingress_domain}"
+    } : {}
+  )
   secret_variables = {
     DATABASE_URL = module.postgres.url
     REDIS_CACHE_URL = var.deploy_redis_cache ? module.redis-cache.url : ""


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/337

To use Teacher Auth on Review apps

### Changes proposed in this pull request

TRS have added a callback URL with a wildcard:
```https://teacher-training-entitlement-review-<PR-Number>.test.teacherservices.cloud```

- set HOSTING_DOMAIN on deploy (if it is a review app)
- set `teacher_auth.enabled = true` for all envs 
- set env vars in Aws key vault:
```
TEACHER_AUTH_DOMAIN
TEACHER_AUTH_CLIENT_ID
TEACHER_AUTH_CLIENT_SECRET
```
