### PR TITLE
Change provider allowed up to started status

### DIFF
--- a/app/controllers/applications/change_provider/check_answers_controller.rb
+++ b/app/controllers/applications/change_provider/check_answers_controller.rb
@@ -6,6 +6,8 @@ module Applications
       storing_form_session_as :change_provider
 
       def index
+        redirect_to application_path(application.ecf_id) and return unless application.can_change_provider?
+
         redirect_to application_change_provider_start_index_path(application.ecf_id) and return if new_provider.nil?
       end
 

--- a/app/controllers/applications/change_provider/providers_controller.rb
+++ b/app/controllers/applications/change_provider/providers_controller.rb
@@ -6,7 +6,9 @@ module Applications
       before_action :set_form
       storing_form_session_as :change_provider
 
-      def index; end
+      def index
+        redirect_to application_path(application.ecf_id) unless application.can_change_provider?
+      end
 
       def create
         render :index, status: :unprocessable_content and return unless @form.valid?

--- a/app/controllers/applications/change_provider/start_controller.rb
+++ b/app/controllers/applications/change_provider/start_controller.rb
@@ -6,7 +6,9 @@ module Applications
       before_action :set_form
       storing_form_session_as :change_provider
 
-      def index; end
+      def index
+        redirect_to application_path(application.ecf_id) unless application.can_change_provider?
+      end
 
       def create
         render :index, status: :unprocessable_content and return unless @form.valid?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,26 +34,6 @@ module ApplicationHelper
     Rails.configuration.x.tracking_pixels_enabled && cookies["consented-to-cookies"] == "accept"
   end
 
-  def accepted?(application)
-    application.accepted_status?
-  end
-
-  def pending?(application)
-    application.pending_status?
-  end
-
-  def rejected?(application)
-    application.rejected_status?
-  end
-
-  def deferred?(application)
-    application.deferred_status?
-  end
-
-  def withdrawn?(application)
-    application.withdrawn_status?
-  end
-
   def application_course_start_date
     "autumn 2025"
   end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -133,7 +133,7 @@ class Application < ApplicationRecord
   end
 
   def can_change_provider?
-    pending_status?
+    pending_status? || accepted_status?
   end
 
   def can_transition_to?(new_status)

--- a/app/services/applications/change_lead_provider.rb
+++ b/app/services/applications/change_lead_provider.rb
@@ -3,7 +3,7 @@ module Applications
     include ActiveModel::Model
     include ActiveModel::Validations
 
-    validate :application_status_is_pending
+    validate :application_can_change_provider
     validate :not_previously_changed_to_provider
     validate :new_provider_is_different
 
@@ -44,10 +44,10 @@ module Applications
       "Changed lead provider from #{@old_provider.name} to #{@new_provider.name}"
     end
 
-    def application_status_is_pending
-      return if @application.pending_status?
+    def application_can_change_provider
+      return if @application.can_change_provider?
 
-      errors.add(:application, :application_must_be_pending_status)
+      errors.add(:application, :application_cannot_change_provider)
     end
 
     def not_previously_changed_to_provider

--- a/app/views/applications/applications/_active_application_table.html.erb
+++ b/app/views/applications/applications/_active_application_table.html.erb
@@ -29,15 +29,15 @@
           <% if application.status.blank? || pending?(application) %>
             <%= govuk_tag(text: "Apply with provider", colour: "yellow") %>
             <%= render 'provider_pending_status' %>
-          <% elsif accepted?(application) %>
+          <% elsif application.accepted_status?(application) %>
             <%= govuk_tag(text: "Successful", colour: "green") %>
-          <% elsif rejected?(application) %>
+          <% elsif application.rejected_status? %>
             <%= govuk_tag(text: "Unsuccessful", colour: "red") %>
           <% end %>
         </dd>
       </div>
 
-      <% if application.latest_participant_outcome_state.present? && accepted?(application) %>
+      <% if application.latest_participant_outcome_state.present? && application.accepted_status? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Course outcome

--- a/app/views/applications/applications/_course_details.html.erb
+++ b/app/views/applications/applications/_course_details.html.erb
@@ -20,7 +20,7 @@
         <dd class="govuk-summary-list__value">
           <%= application.lead_provider.name %>
         </dd>
-        <% if pending?(application) %>
+        <% if application.can_change_provider? %>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="<%= application_change_provider_start_index_path(application.ecf_id) %>">Register with a different provider</a>
           </dd>
@@ -32,18 +32,17 @@
           Provider application
         </dt>
         <dd class="govuk-summary-list__value">
-          <% if application.status.blank? || pending?(application) %>
+          <% if application.pending_status? %>
             <%= govuk_tag(text: "Apply with provider", colour: application_status_colour(application.status)) %>
             <%= render 'provider_pending_status' %>
-          <% elsif accepted?(application) %>
+          <% elsif application.accepted_status? %>
             <%= govuk_tag(text: "Successful", colour: application_status_colour(application.status)) %>
-            <%= application_status_badge(application.status) %>
-          <% elsif rejected?(application) %>
+          <% elsif application.rejected_status? %>
             <%= govuk_tag(text: "Unsuccessful", colour: application_status_colour(application.status)) %>
-          <% elsif deferred?(application) %>
+          <% elsif application.deferred_status? %>
             <%= application_status_badge(application.status) %>
             <%= render "deferral_details", application: application %>
-          <% elsif withdrawn?(application) %>
+          <% elsif application.withdrawn_status? %>
             <%= application_status_badge(application.status) %>
             <%= render "withdrawal_details", application: application %>
           <% else %>
@@ -52,7 +51,7 @@
         </dd>
       </div>
 
-      <% if application.status.blank? || pending?(application) %>
+      <% if application.pending_status? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Course start
@@ -68,7 +67,7 @@
         </div>
       <% end %>
 
-      <% if application.latest_participant_outcome_state.present? && accepted?(application) %>
+      <% if application.latest_participant_outcome_state.present? && application.accepted_status? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Course outcome

--- a/app/views/applications/applications/show.html.erb
+++ b/app/views/applications/applications/show.html.erb
@@ -8,7 +8,7 @@
   <% else %>
     <%= render GovukComponent::BackLinkComponent.new(
       text: "Back",
-      href: request.referrer
+      href: request.referrer.presence || root_path
     ) %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -458,7 +458,7 @@ en:
             provider_must_be_different: Application has {lead_provider_name} already as provider
             previously_changed_to_provider: Application has previously had {lead_provider_name} as provider
           attributes:
-            application_must_be_pending_status: Application status must be pending
+            application_cannot_change_provider: Application status must be pending or accepted to change provider
         eligibility_lists/update:
           attributes:
             file:

--- a/spec/features/applications/change_provider_spec.rb
+++ b/spec/features/applications/change_provider_spec.rb
@@ -11,42 +11,66 @@ RSpec.feature "Change provider", type: :feature do
                            cohort: application.cohort)
   end
 
-  it do
-    #
-    # Start page
-    #
-    visit application_change_provider_start_index_path(application.ecf_id)
+  RSpec.shared_examples "changing provider successfully" do
+    it do
+      #
+      # Start page
+      #
+      visit application_change_provider_start_index_path(application.ecf_id)
 
-    expect(page).to have_text("Register with a different provider for the #{application.course.name}")
+      expect(page).to have_text("Register with a different provider for the #{application.course.name}")
 
-    choose(I18n.t("applications.change_provider.start.form.yes_option"), visible: :all)
+      choose(I18n.t("applications.change_provider.start.form.yes_option"), visible: :all)
 
-    click_button("Continue")
+      click_button("Continue")
 
-    expect(page).to have_current_path(application_change_provider_providers_path(application.ecf_id))
+      expect(page).to have_current_path(application_change_provider_providers_path(application.ecf_id))
 
-    #
-    # Providers page
-    #
-    visit application_change_provider_providers_path(application.ecf_id)
+      #
+      # Providers page
+      #
+      visit application_change_provider_providers_path(application.ecf_id)
 
-    choose(another_provider.name, visible: :all)
+      choose(another_provider.name, visible: :all)
 
-    click_button("Continue")
+      click_button("Continue")
 
-    expect(page).to have_current_path(application_change_provider_check_answers_path(application.ecf_id))
+      expect(page).to have_current_path(application_change_provider_check_answers_path(application.ecf_id))
 
-    expect(page).to have_text(another_provider.name)
-
-    #
-    # Check answers page
-    #
-    within("#new-provider") do
       expect(page).to have_text(another_provider.name)
+
+      #
+      # Check answers page
+      #
+      within("#new-provider") do
+        expect(page).to have_text(another_provider.name)
+      end
+
+      click_button("Submit change")
+
+      expect(page).to have_current_path(application_path(application.ecf_id))
     end
+  end
 
-    click_button("Submit change")
+  context "when application is pending" do
+    let(:application) { create(:application, :pending) }
 
-    expect(page).to have_current_path(application_path(application.ecf_id))
+    it_behaves_like "changing provider successfully"
+  end
+
+  context "when application is accepted" do
+    let(:application) { create(:application, :accepted) }
+
+    it_behaves_like "changing provider successfully"
+  end
+
+  context "when application is started" do
+    let(:application) { create(:application, :started) }
+
+    it "redirects you back to application#show" do
+      visit application_change_provider_start_index_path(application.ecf_id)
+
+      expect(page).to have_current_path(application_path(application.ecf_id))
+    end
   end
 end

--- a/spec/requests/applications/change_provider/check_answers_spec.rb
+++ b/spec/requests/applications/change_provider/check_answers_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe "Applications::ChangeProvider::CheckAnswers", type: :request do
         expect(response).to redirect_to(application_change_provider_start_index_path(application.ecf_id))
       end
     end
+
+    context "when application is not eligible for change provider" do
+      let(:application) { create(:application, :started) }
+
+      it "redirects to the application page" do
+        get url
+        expect(response).to redirect_to(application_path(application.ecf_id))
+      end
+    end
   end
 
   describe "POST /applications/:application_id/change-provider/check-answers" do

--- a/spec/requests/applications/change_provider/providers_spec.rb
+++ b/spec/requests/applications/change_provider/providers_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe "Applications::ChangeProvider::Providers", type: :request do
       get url
       expect(response).to render_template(:index)
     end
+
+    context "when application is not eligible for change provider" do
+      let(:application) { create(:application, :started) }
+
+      it "redirects to the application page" do
+        get url
+        expect(response).to redirect_to(application_path(application.ecf_id))
+      end
+    end
   end
 
   describe "POST /applications/:application_id/change-provider/providers" do

--- a/spec/requests/applications/change_provider/start_spec.rb
+++ b/spec/requests/applications/change_provider/start_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe "Applications::ChangeProvider::Start", type: :request do
       get url
       expect(response).to render_template(:index)
     end
+
+    context "when application is not eligible for change provider" do
+      let(:application) { create(:application, :started) }
+
+      it "redirects to the application page" do
+        get url
+        expect(response).to redirect_to(application_path(application.ecf_id))
+      end
+    end
   end
 
   describe "POST /applications/:application_id/change-provider/start" do
@@ -44,9 +53,9 @@ RSpec.describe "Applications::ChangeProvider::Start", type: :request do
     end
 
     context "when application is not eligible for change provider" do
-      let(:application) { create(:application, :accepted) }
+      let(:application) { create(:application, :started) }
 
-      it "redirects to accounts page with alert" do
+      it "redirects to the application page" do
         post url, params: { form: { confirmation: "1" } }
         expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template(:index)

--- a/spec/services/applications/change_lead_provider_spec.rb
+++ b/spec/services/applications/change_lead_provider_spec.rb
@@ -13,15 +13,15 @@ RSpec.describe Applications::ChangeLeadProvider, type: :model do
     expect(application.reload.lead_provider).to eq(new_provider)
     expect(application.status).to eq(Application::PENDING)
     expect(application.application_lead_providers.previous&.last&.lead_provider).to eq(old_provider)
-    # TODO: check application_events
-    # expect(application.application_events.last).to eq(something)
+
+    expect(application.application_events.last&.reason).to eq("Changed lead provider from #{old_provider.name} to #{new_provider.name}")
   end
 
-  context "when application not pending" do
-    let(:application) { create(:application, :accepted, lead_provider: old_provider) }
+  context "when application not pending or accepted" do
+    let(:application) { create(:application, :started, lead_provider: old_provider) }
 
     it do
-      expect(subject).to have_error(:application, :application_must_be_pending_status)
+      expect(subject).to have_error(:application, :application_cannot_change_provider)
     end
   end
 

--- a/spec/views/applications/applications/show.html.erb_spec.rb
+++ b/spec/views/applications/applications/show.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "applications/applications/show.html.erb", type: :view do
+  let(:application) { build_stubbed(:application) }
+
+  subject { Capybara.string(render) }
+
+  before do
+    assign(:application, application)
+    allow(view).to receive(:current_user).and_return(build_stubbed(:user))
+  end
+
+  context "when application is pending" do
+    let(:application) { build_stubbed(:application, :pending) }
+
+    it { is_expected.to have_link "Register with a different provider", href: application_change_provider_start_index_path(application.ecf_id) }
+  end
+
+  context "when application is accepted" do
+    let(:application) { build_stubbed(:application, :accepted) }
+
+    it { is_expected.to have_link "Register with a different provider", href: application_change_provider_start_index_path(application.ecf_id) }
+  end
+
+  context "when application is started" do
+    let(:application) { build_stubbed(:application, :started) }
+
+    it { is_expected.not_to have_link "Register with a different provider" }
+  end
+end

--- a/spec/views/applications/applications/show.html.erb_spec.rb
+++ b/spec/views/applications/applications/show.html.erb_spec.rb
@@ -2,11 +2,13 @@ require "rails_helper"
 
 RSpec.describe "applications/applications/show.html.erb", type: :view do
   let(:application) { build_stubbed(:application) }
+  let(:lead_provider) { build_stubbed(:lead_provider) }
 
   subject { Capybara.string(render) }
 
   before do
     assign(:application, application)
+    allow(application).to receive(:lead_provider).and_return(lead_provider)
     allow(view).to receive(:current_user).and_return(build_stubbed(:user))
   end
 


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/336

Teachers can now change their provider up to when they start their course

### Changes proposed in this pull request

- Show 'change provider' link when pending or accepted
- Add some redirects if land on a 'bookmarked' part of the change provider flow
- Remove some unrequired helper methods
