### PR TITLE
Extract shared example to fix CodeQL syntax warning

### DIFF
--- a/spec/controllers/registration_wizard_controller_spec.rb
+++ b/spec/controllers/registration_wizard_controller_spec.rb
@@ -15,34 +15,6 @@ RSpec.describe RegistrationWizardController do
 
   subject(:page_response) { make_request && response }
 
-  RSpec.shared_examples "it redirects on missing mandatory institution" do
-    before do
-      allow(RegistrationWizard).to receive(:new).and_return(missing_institution_wizard.new)
-      session["registration_store"] = registration_store
-      make_request
-    end
-
-    context "when working in a school" do
-      let(:registration_store) { { "works_in_school" => "yes" } }
-
-      it { is_expected.to redirect_to registration_wizard_show_path("choose-school") }
-    end
-
-    context "when working in a private nursery" do
-      let(:registration_store) do
-        { "works_in_childcare" => "yes", "kind_of_nursery" => "private_nursery" }
-      end
-
-      it { is_expected.to redirect_to registration_wizard_show_path("have-ofsted-urn") }
-    end
-
-    context "when working in an early years setting" do
-      let(:registration_store) { { "works_in_childcare" => "yes" } }
-
-      it { is_expected.to redirect_to registration_wizard_show_path("choose-childcare-provider") }
-    end
-  end
-
   describe "#show" do
     let(:make_request) { get(:show, params: { step: "course-start-date" }) }
 

--- a/spec/support/shared_examples/missing_institution_redirect_support.rb
+++ b/spec/support/shared_examples/missing_institution_redirect_support.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.shared_examples "it redirects on missing mandatory institution" do
+  before do
+    allow(RegistrationWizard).to receive(:new).and_return(missing_institution_wizard.new)
+    session["registration_store"] = registration_store
+    make_request
+  end
+
+  context "when working in a school" do
+    let(:registration_store) { { "works_in_school" => "yes" } }
+
+    it { is_expected.to redirect_to registration_wizard_show_path("choose-school") }
+  end
+
+  context "when working in a private nursery" do
+    let(:registration_store) do
+      { "works_in_childcare" => "yes", "kind_of_nursery" => "private_nursery" }
+    end
+
+    it { is_expected.to redirect_to registration_wizard_show_path("have-ofsted-urn") }
+  end
+
+  context "when working in an early years setting" do
+    let(:registration_store) { { "works_in_childcare" => "yes" } }
+
+    it { is_expected.to redirect_to registration_wizard_show_path("choose-childcare-provider") }
+  end
+end


### PR DESCRIPTION
### Context

Ticket: N/A

Fix CodeQL issue

### Changes proposed in this pull request

` RSpec.shared_examples` is nested within ` RSpec.describe`, so extracting it to a `shared_example`
