### PR TITLE
[102] Enable 30 minute timeout on registration journey

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include SessionTimeout
+
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   before_action :http_basic_authenticate, if: -> { Rails.env.staging? }

--- a/app/controllers/concerns/session_timeout.rb
+++ b/app/controllers/concerns/session_timeout.rb
@@ -1,0 +1,33 @@
+module SessionTimeout
+  extend ActiveSupport::Concern
+
+  INACTIVITY_TIMEOUT = 30.minutes
+
+  included do
+    before_action :check_session_timeout, if: :user_signed_in?
+    before_action :update_last_activity, if: :user_signed_in?
+  end
+
+private
+
+  def check_session_timeout
+    return if session[:last_activity_at].blank?
+
+    if session[:last_activity_at] < INACTIVITY_TIMEOUT.ago
+      handle_session_timeout
+    end
+  end
+
+  def update_last_activity
+    session[:last_activity_at] = Time.current
+  end
+
+  def handle_session_timeout
+    reset_session
+    redirect_to root_path, notice: "Your session has expired due to inactivity."
+  end
+
+  def user_signed_in?
+    session[:user_id].present?
+  end
+end

--- a/app/views/layouts/shared/_messages.html.erb
+++ b/app/views/layouts/shared/_messages.html.erb
@@ -26,3 +26,11 @@
     end
   %>
 <% end %>
+
+<% if flash[:notice].present? %>
+  <%=
+    govuk_notification_banner(title_text: "Important") do |banner|
+      banner.with_heading(text: flash[:notice])
+    end
+  %>
+<% end %>

--- a/spec/controllers/concerns/session_timeout_spec.rb
+++ b/spec/controllers/concerns/session_timeout_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe SessionTimeout, type: :controller do
+  controller(ApplicationController) do
+    skip_before_action :authenticate_user!
+
+    def index
+      head :ok
+    end
+  end
+
+  let!(:user) { create(:user) }
+
+  before do
+    session[:user_id] = user.id
+  end
+
+  it "allows access when session is active" do
+    session[:last_activity_at] = 15.minutes.ago
+    get :index
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "expires session after 30 minutes of inactivity" do
+    session[:last_activity_at] = 31.minutes.ago
+    get :index
+    expect(response).to redirect_to(root_path)
+    expect(flash[:notice]).to eq("Your session has expired due to inactivity.")
+    expect(session[:user_id]).to be_nil
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/102

Set a timeout after 30 minutes of inactivity.

### Changes proposed in this pull request

Devise has a built in timeout module and that will work for the admin user, but the registration is a bit of a hybrid.

Reluctant to add a client-side timer, so here we use `session[:last_activity_at]` and check if it's within the last 30 minutes.

If not, on the next page request, log the user out of TTE (not Teacher Auth) and redirect to the landing page with a flash message