### PR TITLE
[355] Disable application notification emails in sandbox

### DIFF
--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -38,6 +38,8 @@ class GenericMailer < ApplicationMailer
 private
 
   def generic_mail(subject:)
+    return if Rails.env.sandbox? && action_name != "confirmation_code"
+
     view_mail(TEMPLATE_ID, to: params[:to], subject: build_subject(subject:))
   end
 

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -312,4 +312,18 @@ RSpec.describe GenericMailer, type: :mailer do
 
     it_behaves_like "a mailer with redacted logs"
   end
+
+  describe "sandbox environment", :sandbox do
+    before { allow(Rails.env).to receive(:sandbox?).and_return(true) }
+
+    it "sends confirmation_code emails" do
+      mail = described_class.with(to: "test@example.com", code: "123").confirmation_code
+      expect(mail.to).to eq(["test@example.com"])
+    end
+
+    it "skips other notification emails" do
+      mail = described_class.with(to: "test@example.com", full_name: "Test", provider_name: "Test", course_name: "Test", ecf_id: "123").application_submitted
+      expect(mail.to).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/355

Prevent errors from fake seed data during provider integration testing.

### Changes proposed in this pull request

Allow only `confirmation_code` emails on sandbox
