### PR TITLE
Fix translation error around application status change

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,6 +131,7 @@ en:
               format: You can only enter numeric values in the adjustment amount
                 field
         application:
+          <<: *application
           attributes:
             funded_place:
               inclusion: Set '#/%{parameterized_attribute}' to true or false.

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe Application do
 
   describe "validations" do
     describe "Status change" do
-      context "when valid transition" do
+      context "when invalid transition" do
         it do
           subject.status = Application::COMPLETED
           expect(subject).to have_error(:status, :invalid_status_transition, I18n.t("activerecord.errors.models.application.invalid_status_transition"))
         end
       end
 
-      context "when invalid transition" do
+      context "when valid transition" do
         it do
           subject.status = Application::PENDING
           expect(subject).not_to have_error(:status)

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe Application do
   end
 
   describe "validations" do
+    describe "Status change" do
+      context "when valid transition" do
+        it do
+          subject.status = Application::COMPLETED
+          expect(subject).to have_error(:status, :invalid_status_transition, I18n.t("activerecord.errors.models.application.invalid_status_transition"))
+        end
+      end
+
+      context "when invalid transition" do
+        it do
+          subject.status = Application::PENDING
+          expect(subject).not_to have_error(:status)
+        end
+      end
+    end
+
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
 
     context "when the cohort has a funding cap" do


### PR DESCRIPTION
Fixes Sentry bug TEACHER-TRAINING-ENTITLEMENT-26 which was a missing translation for an invalid status transition.