### PR TITLE
[335] Email: Provider has rejected a Participant

### DIFF
--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -35,6 +35,10 @@ class GenericMailer < ApplicationMailer
     generic_mail(subject: "mailers.deferral_expiring_notification")
   end
 
+  def provider_rejected
+    generic_mail(subject: "mailers.provider_rejected")
+  end
+
 private
 
   def generic_mail(subject:)

--- a/app/services/applications/reject.rb
+++ b/app/services/applications/reject.rb
@@ -2,6 +2,7 @@ module Applications
   class Reject
     include ActiveModel::Model
     include ActiveModel::Attributes
+    include CourseHelper
 
     attribute :application
     attribute :reason_for_rejection
@@ -18,7 +19,21 @@ module Applications
       application.update!(status: Application::REJECTED, reason_for_rejection:)
       application.reload
 
+      send_rejection_email if reason_for_rejection == Application.reason_for_rejections[:rejected_by_provider]
+
       true
+    end
+
+    def send_rejection_email
+      GenericMailer.with(
+        to: application.user.email,
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: title_embedded_course_name(application.course),
+        cohort_date: application.cohort.name,
+        sign_in_link: Rails.configuration.sign_in_link,
+        ecf_id: application.ecf_id,
+      ).provider_rejected.deliver_later
     end
 
   private

--- a/app/views/generic_mailer/provider_rejected.text.erb
+++ b/app/views/generic_mailer/provider_rejected.text.erb
@@ -1,0 +1,25 @@
+Department for Education
+
+Application ID: <%= params[:ecf_id] %>
+
+Dear <%= params[:full_name] %>
+
+You registered for <%= params[:course_name] %> with <%= params[:provider_name] %> starting in <%= params[:cohort_date] %>.
+
+# Change to your registration
+
+Your provider has notified us that they were not able to offer you a place on the course. This could be because you were not suitable for the course or they did not have a funded place available.
+
+# Your options
+
+If your provider did not have a funded place available and you would still like to continue your application, you can:
+
+- [register with a different provider](<%= params[:sign_in_link] %>)
+- talk to your provider about changing to a later course start date
+
+# Get help
+
+Email continuing-professional-development@digital.education.gov.uk
+
+Regards,
+The Teacher Continuing Professional Development Team

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
     deferral_notification: Notification of deferral - %{course_name}
     registration_open_notification: Registration open - %{course_name}
     deferral_expiring_notification: Registration about to expire - %{course_name}
+    provider_rejected: Registration status updated for %{course_name} – next steps
 
   application: &application
     blank: The entered '#/%{parameterized_attribute}' is missing from your request. Check details and try again.

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -313,6 +313,46 @@ RSpec.describe GenericMailer, type: :mailer do
     it_behaves_like "a mailer with redacted logs"
   end
 
+  describe "#provider_rejected" do
+    let(:to) { "recipient@example.com" }
+    let(:full_name) { "Example User" }
+    let(:provider_name) { "Example Provider" }
+    let(:course_name) { "Early Years TTE" }
+    let(:cohort_date) { "autumn 2026" }
+    let(:sign_in_link) { "https://example.com/sign-in" }
+    let(:ecf_id) { "ABC123" }
+
+    subject(:mail) do
+      described_class.with(
+        to:,
+        full_name:,
+        provider_name:,
+        course_name:,
+        cohort_date:,
+        sign_in_link:,
+        ecf_id:,
+      ).provider_rejected
+    end
+
+    it do
+      aggregate_failures do
+        expect(subject).to use_template(GenericMailer::TEMPLATE_ID)
+        expect(mail.to).to eq([to])
+        expect(mail.personalisation[:subject]).to eq("Registration status updated for #{course_name} – next steps")
+
+        body = mail.personalisation[:body]
+        expect(body).to include(full_name)
+        expect(body).to include(provider_name)
+        expect(body).to include(course_name)
+        expect(body).to include(cohort_date)
+        expect(body).to include(sign_in_link)
+        expect(body).to include(ecf_id)
+      end
+    end
+
+    it_behaves_like "a mailer with redacted logs"
+  end
+
   describe "sandbox environment", :sandbox do
     before { allow(Rails.env).to receive(:sandbox?).and_return(true) }
 

--- a/spec/mailers/previews/generic_mailer_preview.rb
+++ b/spec/mailers/previews/generic_mailer_preview.rb
@@ -79,4 +79,16 @@ class GenericMailerPreview < ActionMailer::Preview
       ecf_id: "abc-123-def-456",
     ).registration_open_notification
   end
+
+  def provider_rejected
+    GenericMailer.with(
+      to: "test@example.com",
+      full_name: "Jane Smith",
+      course_name: "Early Years TTE",
+      provider_name: "Ambition Institute",
+      cohort_date: "Autumn 2026",
+      sign_in_link: "https://signin.service.gov.uk",
+      ecf_id: "abc-123-def-456",
+    ).provider_rejected
+  end
 end

--- a/spec/services/applications/reject_spec.rb
+++ b/spec/services/applications/reject_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Applications::Reject, type: :model do
+  include ActiveJob::TestHelper
+
   subject(:service) { described_class.new(application:, reason_for_rejection:) }
 
   let(:reason_for_rejection) { Application.reason_for_rejections[:rejected_by_provider] }
@@ -47,6 +49,24 @@ RSpec.describe Applications::Reject, type: :model do
 
     it "sets the reason for rejection" do
       expect { service.call }.to change { application.reload.reason_for_rejection }.from(nil).to(reason_for_rejection)
+    end
+
+    context "when reason is rejected_by_provider" do
+      let(:reason_for_rejection) { Application.reason_for_rejections[:rejected_by_provider] }
+
+      it "enqueues a provider rejection email" do
+        service.reject
+        expect(ActionMailer::MailDeliveryJob).to have_been_enqueued.with("GenericMailer", "provider_rejected", "deliver_now", anything)
+      end
+    end
+
+    context "when reason is not rejected_by_provider" do
+      let(:reason_for_rejection) { Application.reason_for_rejections[:registration_expired] }
+
+      it "does not enqueue a provider rejection email" do
+        service.reject
+        expect(ActionMailer::MailDeliveryJob).not_to have_been_enqueued.with("GenericMailer", "provider_rejected", "deliver_now", anything)
+      end
     end
   end
 end

--- a/spec/services/applications/reject_spec.rb
+++ b/spec/services/applications/reject_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Applications::Reject, type: :model do
       let(:reason_for_rejection) { Application.reason_for_rejections[:rejected_by_provider] }
 
       it "enqueues a provider rejection email" do
-        service.reject
+        service.call
         expect(ActionMailer::MailDeliveryJob).to have_been_enqueued.with("GenericMailer", "provider_rejected", "deliver_now", anything)
       end
     end
@@ -64,7 +64,7 @@ RSpec.describe Applications::Reject, type: :model do
       let(:reason_for_rejection) { Application.reason_for_rejections[:registration_expired] }
 
       it "does not enqueue a provider rejection email" do
-        service.reject
+        service.call
         expect(ActionMailer::MailDeliveryJob).not_to have_been_enqueued.with("GenericMailer", "provider_rejected", "deliver_now", anything)
       end
     end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/335

As a Participant
I need to be notified that I have not been accepted by my chosen Provider
So that I can register with a different Provider

### Changes proposed in this pull request

- Send rejection email when a provider rejects an application via the API
- Only triggers for rejected_by_provider reason, not for registration_expired or other rejection reasons
