### PR TITLE
Show previous providers on admin/applications#show

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,6 @@ on:
    branches:
     - main
   pull_request:
-    branches:
-    - main
     types: [opened, reopened, synchronize, labeled]
 
 env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ on:
    branches:
     - main
   pull_request:
+    branches:
+    - main
     types: [opened, reopened, synchronize, labeled]
 
 env:

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -71,3 +71,9 @@ $admin-template-max-width: 1200px;
     margin-bottom: govuk-spacing(1);
   }
 }
+
+.govuk-table-no-border {
+  .govuk-table__cell {
+    border-bottom: 0;
+  }
+}

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -36,6 +36,27 @@
       row.with_value(text: @application.lead_provider.name)
     end
     sl.with_row do |row|
+      previous_alp = @application.application_lead_providers.previous
+
+      row.with_key(text: "Previous #{previous_alp.many? ? 'Providers' : 'Provider'}")
+      row.with_value do
+        if previous_alp.any?
+          govuk_table(classes: "govuk-table-no-border govuk-!-margin-bottom-0") do |table|
+            table.with_body do |body|
+              previous_alp.each do |application_lead_provider|
+                body.with_row do |provider_row|
+                  provider_row.with_cell(text: application_lead_provider.lead_provider.name)
+                  provider_row.with_cell(text: "Unassigned on #{application_lead_provider.updated_at.to_date.strftime("%d %b %Y")}")
+                end
+              end
+            end
+          end
+        else
+          "-"
+        end
+      end
+    end
+    sl.with_row do |row|
       row.with_key(text: "Application status")
       row.with_value(text: @application.status.try(:humanize))
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -50,8 +50,6 @@ RSpec.describe Application do
       end
     end
 
-    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
-
     it {
       expect(subject).to validate_uniqueness_of(:ecf_id)
         .case_insensitive

--- a/spec/views/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/admin/applications/show.html.erb_spec.rb
@@ -7,10 +7,15 @@ RSpec.describe "admin/applications/show.html.erb", type: :view do
   let(:application_attributes) { {} }
   let :application do
     application = build_stubbed(:application, application_trait, **application_attributes)
-    allow(application).to receive(:lead_provider).and_return(build_stubbed(:lead_provider))
+    allow(application).to receive_messages(
+      lead_provider: build_stubbed(:lead_provider),
+      application_lead_providers: application_lead_providers,
+    )
     application
   end
 
+  let(:application_lead_providers) { double(previous: previous_application_lead_providers) }
+  let(:previous_application_lead_providers) { [] }
   let(:declarations) { [] }
 
   before do
@@ -41,7 +46,41 @@ RSpec.describe "admin/applications/show.html.erb", type: :view do
       it { is_expected.to have_summary_item "Application ID", application.ecf_id }
       it { is_expected.to have_summary_item "User ID", application.user.ecf_id }
       it { is_expected.to have_summary_item "Provider", application.lead_provider.name }
+      it { is_expected.to have_summary_item "Previous Provider", "-" }
       it { is_expected.to have_summary_item "Course", application.course.name }
+
+      context "when the application has previous providers" do
+        let(:previous_application_lead_providers) do
+          [
+            build_stubbed(
+              :application_lead_provider,
+              lead_provider: build_stubbed(:lead_provider, name: "First previous provider"),
+              updated_at: Time.zone.local(2025, 5, 3),
+              current: false,
+            ),
+            build_stubbed(
+              :application_lead_provider,
+              lead_provider: build_stubbed(:lead_provider, name: "Second previous provider"),
+              updated_at: Time.zone.local(2025, 6, 4),
+              current: false,
+            ),
+          ]
+        end
+
+        it "shows each previous provider with the created date" do
+          previous_provider_value = subject
+            .find(".govuk-summary-list__key", text: "Previous Providers", exact_text: true)
+            .sibling(".govuk-summary-list__value")
+
+          expect(previous_provider_value).not_to be_nil
+          rows = previous_provider_value.all(".govuk-table__row")
+
+          expect(rows.first).to have_css(".govuk-table__cell", text: "First previous provider")
+          expect(rows.first).to have_css(".govuk-table__cell", text: "Unassigned on 03 May 2025")
+          expect(rows[1]).to have_css(".govuk-table__cell", text: "Second previous provider")
+          expect(rows[1]).to have_css(".govuk-table__cell", text: "Unassigned on 04 Jun 2025")
+        end
+      end
     end
   end
 
@@ -51,6 +90,7 @@ RSpec.describe "admin/applications/show.html.erb", type: :view do
     it { is_expected.to have_css "h1", text: "Application details" }
     it { is_expected.to have_summary_item "Application ID", application.ecf_id }
     it { is_expected.to have_summary_item "Provider", application.lead_provider.name }
+    it { is_expected.to have_summary_item "Previous Provider", "-" }
     it { is_expected.to have_summary_item "Course", application.course.name }
     it { is_expected.to have_summary_item "Unique reference number (URN)", "" }
     it { is_expected.to have_summary_item "UK Provider Reference Number (UKPRN)", "" }


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/334

Show the previous provider(s) on the admin applications page

### Changes proposed in this pull request

Alter admin/applications#show to display old providers and the date they were unassigned on
