### PR TITLE
Fix Applications/Reject service

### DIFF
--- a/app/services/applications/reject.rb
+++ b/app/services/applications/reject.rb
@@ -2,7 +2,6 @@ module Applications
   class Reject
     include ActiveModel::Model
     include ActiveModel::Attributes
-    include CourseHelper
 
     attribute :application
     attribute :reason_for_rejection
@@ -29,7 +28,7 @@ module Applications
         to: application.user.email,
         full_name: application.user.full_name,
         provider_name: application.lead_provider.name,
-        course_name: title_embedded_course_name(application.course),
+        course_name: application.course.title_embedded_course_name,
         cohort_date: application.cohort.name,
         sign_in_link: Rails.configuration.sign_in_link,
         ecf_id: application.ecf_id,


### PR DESCRIPTION
### Context

A recent merge has left a reference to the deleted CourseHelper

### Changes proposed in this pull request

Remove reference from Applications/Reject