### PR TITLE
Fix admin application actions links

### DIFF
--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -60,13 +60,20 @@
       row.with_key(text: "Application status")
       row.with_value(text: @application.status.try(:humanize))
 
-      unless @application.pending_status?
+      if @application.accepted_status? || @application.rejected_status?
         row.with_action(
           text: "Revert to Pending",
           href: new_admin_applications_revert_to_pending_path(@application))
+      end
+      
+      if @application.accepted_status?
         row.with_action(
-          text: @application.accepted_status? ? "Defer/Withdraw" : "Accept", 
-          href: new_admin_applications_change_status_path(@application))  
+          text: "Defer/Withdraw",
+          href: new_admin_applications_change_status_path(@application))
+      elsif @application.deferred_status? || @application.withdrawn_status?
+        row.with_action(
+          text: "Accept",
+          href: new_admin_applications_change_status_path(@application))
       end
     end
     sl.with_row do |row|

--- a/spec/views/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/admin/applications/show.html.erb_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "admin/applications/show.html.erb", type: :view do
       let(:application_trait) { :withdrawn }
 
       it do
-        expect(subject).to have_link("Revert to Pending")
+        expect(subject).not_to have_link("Revert to Pending")
         expect(subject).to have_link("Accept")
         expect(subject).not_to have_link("Defer/Withdraw")
       end


### PR DESCRIPTION
### Context

We're allowing various action links (like Defer / Withdraw / Accept / Revert to Pending) to show when the application status will not allow it. In order to be a bit nicer on the UI, don't show these links unless at least the status will allow it.

### Changes proposed in this pull request

Alter the admin/applications#show view
