### PR TITLE
Cope with lead_provider being nil on participant serializer

### DIFF
--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -80,7 +80,7 @@ module API
             latest_event = application
               .application_events.sort_by(&:created_at)
               .reverse!
-              .find { |e| e.status == Application::DEFERRED && e.lead_provider.id == lead_provider.id }
+              .find { |e| e.status == Application::DEFERRED && e.lead_provider_id == lead_provider.id }
 
             if latest_event.present?
               {

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -63,7 +63,7 @@ module API
             latest_event = application
               .application_events.sort_by(&:created_at)
               .reverse!
-              .find { |e| e.status == Application::WITHDRAWN && e.lead_provider.id == lead_provider.id }
+              .find { |e| e.status == Application::WITHDRAWN && e.lead_provider_id == lead_provider.id }
 
             if latest_event.present?
               {

--- a/spec/serializers/api/participant_serializer_spec.rb
+++ b/spec/serializers/api/participant_serializer_spec.rb
@@ -166,6 +166,27 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
             }.deep_stringify_keys,
           ])
         end
+
+        context "when withdrawn state change is missing lead provider" do
+          before { deferral.update_columns(lead_provider_id: nil) }
+
+          it do
+            expect(attributes["enrolments"]).not_to be_nil
+          end
+        end
+      end
+
+      context "when application has been accepted" do
+        let(:application) { create(:application, :with_declaration, :accepted, :with_accepted_event, :eligible_for_funded_place, lead_provider:) }
+        let(:accepted) { application.state_changes.where(event: Application::ACCEPTED).first }
+
+        context "when accepted state change is missing lead provider" do
+          before { accepted.update_columns(lead_provider_id: nil) }
+
+          it do
+            expect(attributes["enrolments"]).not_to be_nil
+          end
+        end
       end
 
       it "serializes the `participant_id_changes`" do

--- a/spec/serializers/api/participant_serializer_spec.rb
+++ b/spec/serializers/api/participant_serializer_spec.rb
@@ -130,6 +130,14 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
             }.deep_stringify_keys,
           ])
         end
+
+        context "when withdrawn state change is missing lead provider" do
+          before { withdrawal.update_columns(lead_provider_id: nil) }
+
+          it do
+            expect(attributes["enrolments"]).not_to be_nil
+          end
+        end
       end
 
       context "when application has been deferred" do


### PR DESCRIPTION
### Context

Fix Sentry bug event cf0f36e232cc432e983f767760cf9f5e
There are nil lead_provider_id on application_events for withdrawals

### Changes proposed in this pull request

Alter ParticipantSerializer to cope with nil lead_provider_id