### PR TITLE
Change provider notify previous provider

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Context
 
-Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/XXX
+Fixes DFE-Digital/teacher-training-entitlement-board#XXX
 
 [Why are we making this change?]
 

--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -39,6 +39,10 @@ class GenericMailer < ApplicationMailer
     generic_mail(subject: "mailers.provider_rejected")
   end
 
+  def previous_provider
+    generic_mail(subject: "mailers.previous_provider")
+  end
+
 private
 
   def generic_mail(subject:)

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -38,6 +38,8 @@ class Application < ApplicationRecord
   has_one :current_application_lead_provider,
           -> { where(current: true) }, class_name: "ApplicationLeadProvider"
   has_one :lead_provider, through: :current_application_lead_provider
+  has_one :previous_application_lead_provider, -> { where(current: false).order(created_at: :desc) }, class_name: "ApplicationLeadProvider"
+  has_one :previous_provider, through: :previous_application_lead_provider, source: :lead_provider
 
   scope :expired_applications, -> { where(status: [REJECTED, WITHDRAWN]).where("created_at < ?", cut_off_date_for_expired_applications) }
   scope :active_applications, -> { where.not(id: expired_applications).not_withdrawn }

--- a/app/services/applications/change_lead_provider.rb
+++ b/app/services/applications/change_lead_provider.rb
@@ -39,8 +39,11 @@ module Applications
         if @application.previous_provider.email
           GenericMailer.with(
             to: @application.previous_provider.email,
+            provider_name: @application.previous_provider.name,
             course_name: @application.course.name,
-            cohort_date: @application.cohort.name,
+            participant_trn: @application.user.trn,
+            particitpant_name: @application.user.full_name,
+            change_date: @application.previous_application_lead_provider&.updated_at&.to_fs(:govuk_short),
             ecf_id: @application.ecf_id,
           ).previous_provider.deliver_later
         end

--- a/app/services/applications/change_lead_provider.rb
+++ b/app/services/applications/change_lead_provider.rb
@@ -35,6 +35,15 @@ module Applications
           sign_in_link: Rails.configuration.sign_in_link,
           feedback_link: Rails.configuration.feedback_link,
         ).change_provider.deliver_later
+
+        if @application.previous_provider.email
+          GenericMailer.with(
+            to: @application.previous_provider.email,
+            course_name: @application.course.name,
+            cohort_date: @application.cohort.name,
+            ecf_id: @application.ecf_id,
+          ).previous_provider.deliver_later
+        end
       end
     end
 

--- a/app/views/generic_mailer/previous_provider.text.erb
+++ b/app/views/generic_mailer/previous_provider.text.erb
@@ -1,9 +1,23 @@
+^ Department for Education
+
 Application ID: <%= params[:ecf_id] %>
 
-For <%= params[:course_name] %> starting in <%= params[:cohort_date] %> as a new provider.
+# Participant is no longer registered with you
 
-# Get more information
-Email continuing-professional-development@education.gov.uk
+Dear <%= params[:provider_name] %>
+
+A participant has changed their registration to a different provider and is no longer registered with you:
+
+^ ## Participant details
+^ *Course name: <%= params[:course_name] %>
+^ *TRN: <%= params[:participant_trn] %>
+^ *Participant name: <%= params[:participant_full_name] %>
+^ *Date registration changed: <%= params[:change_date] %>
+
+# What happens next
+
+You need to stop processing their original registration. Whe have updated the participant's details.
 
 Regards,
+
 The Teacher Continuing Professional Development Team

--- a/app/views/generic_mailer/previous_provider.text.erb
+++ b/app/views/generic_mailer/previous_provider.text.erb
@@ -1,0 +1,9 @@
+Application ID: <%= params[:ecf_id] %>
+
+For <%= params[:course_name] %> starting in <%= params[:cohort_date] %> as a new provider.
+
+# Get more information
+Email continuing-professional-development@education.gov.uk
+
+Regards,
+The Teacher Continuing Professional Development Team

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -122,6 +122,8 @@
   - updated_at
   :application_events:
   - type
+  :lead_providers:
+  - email
   :application_lead_providers:
   - id
   - application_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,7 @@ en:
     registration_open_notification: Registration open - %{course_name}
     deferral_expiring_notification: Registration about to expire - %{course_name}
     provider_rejected: Registration status updated for %{course_name} – next steps
+    previous_provider: Change provider notification
 
   application: &application
     blank: The entered '#/%{parameterized_attribute}' is missing from your request. Check details and try again.

--- a/db/migrate/20260511130012_add_column_email_to_lead_provider.rb
+++ b/db/migrate/20260511130012_add_column_email_to_lead_provider.rb
@@ -1,0 +1,5 @@
+class AddColumnEmailToLeadProvider < ActiveRecord::Migration[8.1]
+  def change
+    add_column :lead_providers, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_01_101349) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_11_130012) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -388,6 +388,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_101349) do
   create_table "lead_providers", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.uuid "ecf_id"
+    t.string "email"
     t.string "hint"
     t.text "name", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/lead_providers.rb
+++ b/spec/factories/lead_providers.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     name { Faker::Company.unique.name.gsub(",", "") }
     ecf_id { SecureRandom.uuid }
     hint { Faker::Lorem.sentence }
+    email { Faker::Internet.email }
 
     after :create do |lead_provider, evaluator|
       partnerships = if evaluator.delivery_partners.is_a?(Hash)

--- a/spec/mailers/previews/generic_mailer_preview.rb
+++ b/spec/mailers/previews/generic_mailer_preview.rb
@@ -95,9 +95,12 @@ class GenericMailerPreview < ActionMailer::Preview
   def previous_provider
     GenericMailer.with(
       to: "test@example.com",
-      ecf_id: "abcd-1234-efgh-5678-ijkl",
+      provider_name: "Teach First",
       course_name: "Teaching in Reception",
-      cohort_date: "Autumn 2026",
+      participant_trn: nil,
+      particitpant_name: "Tobias Harris",
+      change_date: "13 May 2026 14:00",
+      ecf_id: "abcd-1234-efgh-5678-ijkl",
     ).previous_provider
   end
 end

--- a/spec/mailers/previews/generic_mailer_preview.rb
+++ b/spec/mailers/previews/generic_mailer_preview.rb
@@ -91,4 +91,13 @@ class GenericMailerPreview < ActionMailer::Preview
       ecf_id: "abc-123-def-456",
     ).provider_rejected
   end
+
+  def previous_provider
+    GenericMailer.with(
+      to: "test@example.com",
+      ecf_id: "abcd-1234-efgh-5678-ijkl",
+      course_name: "Teaching in Reception",
+      cohort_date: "Autumn 2026",
+    ).previous_provider
+  end
 end

--- a/spec/requests/applications/change_provider/check_answers_spec.rb
+++ b/spec/requests/applications/change_provider/check_answers_spec.rb
@@ -72,17 +72,6 @@ RSpec.describe "Applications::ChangeProvider::CheckAnswers", type: :request do
 
       context "when changing provider succeeds" do
         it "creates updates the application provider and redirects to user registrations path" do
-          expect(GenericMailer).to receive(:with).with(
-            to: application.user.email,
-            full_name: application.user.full_name,
-            provider_name: new_provider.name,
-            course_name: application.course.name,
-            cohort_date: application.cohort.name,
-            ecf_id: application.ecf_id,
-            sign_in_link: Rails.configuration.sign_in_link,
-            feedback_link: Rails.configuration.feedback_link,
-          ).and_call_original
-
           post url
 
           aggregate_failures do

--- a/spec/services/applications/change_lead_provider_spec.rb
+++ b/spec/services/applications/change_lead_provider_spec.rb
@@ -85,8 +85,11 @@ RSpec.describe Applications::ChangeLeadProvider, type: :model do
       let(:email_attrs) do
         {
           to: old_provider.email,
+          provider_name: old_provider.name,
           course_name: application.course.name,
-          cohort_date: application.cohort.name,
+          participant_trn: application.user.trn,
+          particitpant_name: application.user.full_name,
+          change_date: application.previous_application_lead_provider&.updated_at&.to_fs(:govuk_short),
           ecf_id: application.ecf_id,
         }
       end

--- a/spec/services/applications/change_lead_provider_spec.rb
+++ b/spec/services/applications/change_lead_provider_spec.rb
@@ -7,42 +7,104 @@ RSpec.describe Applications::ChangeLeadProvider, type: :model do
 
   subject(:service) { described_class.new(application:, new_provider:) }
 
-  before { subject.call }
-
-  it do
-    expect(application.reload.lead_provider).to eq(new_provider)
-    expect(application.status).to eq(Application::PENDING)
-    expect(application.application_lead_providers.previous&.last&.lead_provider).to eq(old_provider)
-
-    expect(application.application_events.last&.reason).to eq("Changed lead provider from #{old_provider.name} to #{new_provider.name}")
-  end
-
-  context "when application not pending or accepted" do
-    let(:application) { create(:application, :started, lead_provider: old_provider) }
-
-    it do
-      expect(subject).to have_error(:application, :application_cannot_change_provider)
-    end
-  end
-
-  context "when application provider is same as new provider" do
-    let(:application) { create(:application, :pending, lead_provider: new_provider) }
-
-    it do
-      expect(subject).to have_error(:base, :provider_must_be_different)
-    end
-  end
-
-  context "when application has previously been assigned to new provider" do
-    let(:application) do
-      create(:application, :pending,
-             :with_application_lead_provider,
-             old_lead_provider: new_provider,
-             lead_provider: old_provider)
+  describe ".call" do
+    before do
+      subject.call
     end
 
     it do
-      expect(subject).to have_error(:base, :previously_changed_to_provider)
+      expect(application.reload.lead_provider).to eq(new_provider)
+      expect(application.status).to eq(Application::PENDING)
+      expect(application.application_lead_providers.previous.last.lead_provider).to eq(old_provider)
+
+      expect(application.application_events.last&.reason).to eq("Changed lead provider from #{old_provider.name} to #{new_provider.name}")
+    end
+
+    context "when application not pending or accepted" do
+      let(:application) { create(:application, :started, lead_provider: old_provider) }
+
+      it do
+        expect(subject).to have_error(:application, :application_cannot_change_provider)
+      end
+    end
+
+    context "when application provider is same as new provider" do
+      let(:application) { create(:application, :pending, lead_provider: new_provider) }
+
+      it do
+        expect(subject).to have_error(:base, :provider_must_be_different)
+      end
+    end
+
+    context "when application has previously been assigned to new provider" do
+      let(:application) do
+        create(:application, :pending,
+               :with_application_lead_provider,
+               old_lead_provider: new_provider,
+               lead_provider: old_provider)
+      end
+
+      it do
+        expect(subject).to have_error(:base, :previously_changed_to_provider)
+      end
+    end
+  end
+
+  describe "notification" do
+    context "when participants" do
+      let(:email_attrs) do
+        {
+          to: application.user.email,
+          full_name: application.user.full_name,
+          provider_name: new_provider.name,
+          course_name: application.course.name,
+          cohort_date: application.cohort.name,
+          ecf_id: application.ecf_id,
+          sign_in_link: Rails.configuration.sign_in_link,
+          feedback_link: Rails.configuration.feedback_link,
+        }
+      end
+      let(:job_attrs) do
+        [
+          "GenericMailer",
+          "change_provider",
+          "deliver_now",
+          {
+            params: email_attrs,
+            args: [],
+          },
+        ]
+      end
+
+      it do
+        expect { service.call }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(*job_attrs)
+      end
+    end
+
+    context "when previous provider" do
+      let(:email_attrs) do
+        {
+          to: old_provider.email,
+          course_name: application.course.name,
+          cohort_date: application.cohort.name,
+          ecf_id: application.ecf_id,
+        }
+      end
+      let(:job_attrs) do
+        [
+          "GenericMailer",
+          "previous_provider",
+          "deliver_now",
+          {
+            params: email_attrs,
+            args: [],
+          },
+        ]
+      end
+
+      it do
+        expect { service.call }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(*job_attrs)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/343

Notify previous provider after participant change provider

### Changes proposed in this pull request

- Add lead_provider.email field
- Add GenericMailer.previous_provider email [template pending]

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [X] Adds database fields