### PR TITLE
add rake task to migrate rejection reasons and accepted_at

### DIFF
--- a/lib/tasks/data_migrations/migrate_accepted_at_from_applications.rake
+++ b/lib/tasks/data_migrations/migrate_accepted_at_from_applications.rake
@@ -1,0 +1,38 @@
+namespace :data_migrations do
+  desc "Copy application accepted_at values into accepted state change metadata"
+  task migrate_accepted_at_from_applications: :environment do
+    unless Application.column_names.include?("accepted_at")
+      puts "Skipping: applications.accepted_at does not exist"
+      next
+    end
+
+    created_count = 0
+    skipped_count = 0
+
+    Application.where.not(accepted_at: nil).find_each do |application|
+      accepted_at = Application.where(id: application.id).pick(:accepted_at)
+
+      existing_state_change = application
+        .state_changes
+        .where(event: Application::ACCEPTED)
+        .exists?
+
+      if existing_state_change
+        skipped_count += 1
+        next
+      end
+
+      application.state_changes.create!(
+        event: Application::ACCEPTED,
+        lead_provider: application.lead_provider,
+        created_at: accepted_at,
+        updated_at: accepted_at,
+      )
+
+      created_count += 1
+    end
+
+    puts "Created #{created_count} rejected state changes"
+    puts "Skipped #{skipped_count} applications with existing accepted state changes"
+  end
+end

--- a/lib/tasks/data_migrations/migrate_reason_for_rejection_from_applications.rake
+++ b/lib/tasks/data_migrations/migrate_reason_for_rejection_from_applications.rake
@@ -1,6 +1,6 @@
 namespace :data_migrations do
   desc "Copy application reason_for_rejection values into rejected state change metadata"
-  task remove_reason_for_rejection_from_applications: :environment do
+  task migrate_reason_for_rejection_from_applications: :environment do
     unless Application.column_names.include?("reason_for_rejection")
       puts "Skipping: applications.reason_for_rejection does not exist"
       next

--- a/lib/tasks/data_migrations/remove_reason_for_rejection_from_applications.rake
+++ b/lib/tasks/data_migrations/remove_reason_for_rejection_from_applications.rake
@@ -1,0 +1,38 @@
+namespace :data_migrations do
+  desc "Copy application reason_for_rejection values into rejected state change metadata"
+  task remove_reason_for_rejection_from_applications: :environment do
+    unless Application.column_names.include?("reason_for_rejection")
+      puts "Skipping: applications.reason_for_rejection does not exist"
+      next
+    end
+
+    created_count = 0
+    skipped_count = 0
+
+    Application.where.not(reason_for_rejection: nil).find_each do |application|
+      reason = Application.where(id: application.id).pick(:reason_for_rejection)
+
+      existing_state_change = application
+        .state_changes
+        .where(event: Application::REJECTED)
+        .where("metadata ->> 'reason' = ?", reason)
+        .exists?
+
+      if existing_state_change
+        skipped_count += 1
+        next
+      end
+
+      application.state_changes.create!(
+        event: Application::REJECTED,
+        lead_provider: application.lead_provider,
+        metadata: { reason: },
+      )
+
+      created_count += 1
+    end
+
+    puts "Created #{created_count} rejected state changes"
+    puts "Skipped #{skipped_count} applications with existing rejected state changes"
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/teacher-training-entitlement-board/issues/356

Data migration in preparation for PR#356

### Changes proposed in this pull request
PR#356 will remove the following fields:
- `application#accepted_at`
- `application#rejection_reason` and use `state_change.reason`

This PR will migrate the data in preparation for that.

### Data Integrity

Does this change affects existing data:
- [*] Plan data migration

- Added rake task lib/tasks/data_migrations/migrate_reason_for_rejection_from_applications.rake which creates application_event entries for rejected applications
- Added rake task lib/tasks/data_migrations/migrate_accepted_at_from_applications.rakewhich creates application_event entries for accepted applications

