### PR TITLE
[386] Add refresh token job to keep tokens alive

### DIFF
--- a/app/jobs/crons/enqueue_token_refreshes_job.rb
+++ b/app/jobs/crons/enqueue_token_refreshes_job.rb
@@ -1,0 +1,13 @@
+class Crons::EnqueueTokenRefreshesJob < CronJob
+  include Sentry::Cron::MonitorCheckIns
+
+  self.cron_expression = "0 * * * *"
+
+  sentry_monitor_check_ins slug: "enqueue-token-refreshes"
+
+  def perform
+    User.needing_token_refresh.find_each do |user|
+      RefreshUserTokenJob.perform_later(user)
+    end
+  end
+end

--- a/app/jobs/refresh_user_token_job.rb
+++ b/app/jobs/refresh_user_token_job.rb
@@ -1,0 +1,15 @@
+class RefreshUserTokenJob < ApplicationJob
+  def perform(user)
+    return if user.trn.present?
+    return if user.refresh_token.blank?
+
+    result = TeacherAuth::RefreshToken.new(user.refresh_token).call
+
+    return unless result
+
+    user.update!(
+      refresh_token: result[:refresh_token],
+      refresh_token_updated_at: Time.current,
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,11 @@ class User < ApplicationRecord
   after_commit :touch_significantly_updated_at
 
   scope :admins, -> { where(admin: true) }
+  scope :needing_token_refresh, lambda {
+    where(trn: nil)
+      .where.not(refresh_token: nil)
+      .where("refresh_token_updated_at < ?", 1.day.ago)
+  }
 
   EMAIL_UPDATES_STATES = %i[senco other_npq].freeze
   EMAIL_UPDATES_ALL_STATES = [:empty] + EMAIL_UPDATES_STATES

--- a/app/services/teacher_auth/refresh_token.rb
+++ b/app/services/teacher_auth/refresh_token.rb
@@ -1,0 +1,33 @@
+module TeacherAuth
+  class RefreshToken
+    include HTTParty
+
+    base_uri ENV.fetch("TEACHER_AUTH_DOMAIN", nil)
+
+    def initialize(refresh_token)
+      @refresh_token = refresh_token
+    end
+
+    def call
+      response = self.class.post(
+        "/oauth2/token",
+        body: {
+          grant_type: "refresh_token",
+          refresh_token: @refresh_token,
+          client_id: ENV.fetch("TEACHER_AUTH_CLIENT_ID", nil),
+          client_secret: ENV.fetch("TEACHER_AUTH_CLIENT_SECRET", nil),
+        },
+      )
+
+      if response.success?
+        {
+          access_token: response.parsed_response["access_token"],
+          refresh_token: response.parsed_response["refresh_token"],
+        }
+      else
+        Rails.logger.error("TeacherAuth::RefreshToken failed: #{response.code} - #{response.body}")
+        nil
+      end
+    end
+  end
+end

--- a/spec/jobs/crons/enqueue_token_refreshes_job_spec.rb
+++ b/spec/jobs/crons/enqueue_token_refreshes_job_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Crons::EnqueueTokenRefreshesJob, type: :job do
+  describe "#perform" do
+    it "enqueues RefreshUserTokenJob for users needing token refresh" do
+      user = create(:user, trn: nil, refresh_token: "token", refresh_token_updated_at: 2.days.ago)
+
+      expect { described_class.perform_now }.to have_enqueued_job(RefreshUserTokenJob).with(user)
+    end
+
+    it "does not enqueue jobs for users with TRN" do
+      create(:user, trn: "1234567", refresh_token: "token", refresh_token_updated_at: 2.days.ago)
+
+      expect { described_class.perform_now }.not_to have_enqueued_job(RefreshUserTokenJob)
+    end
+
+    it "does not enqueue jobs for users with recent refresh" do
+      create(:user, trn: nil, refresh_token: "token", refresh_token_updated_at: 1.hour.ago)
+
+      expect { described_class.perform_now }.not_to have_enqueued_job(RefreshUserTokenJob)
+    end
+  end
+end

--- a/spec/jobs/refresh_user_token_job_spec.rb
+++ b/spec/jobs/refresh_user_token_job_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe RefreshUserTokenJob, type: :job do
+  describe "#perform" do
+    let(:user) { create(:user, trn: nil, refresh_token: "old-token", refresh_token_updated_at: 8.days.ago) }
+
+    context "when refresh is successful" do
+      let(:refresh_service) { instance_double(TeacherAuth::RefreshToken) }
+
+      before do
+        allow(TeacherAuth::RefreshToken).to receive(:new).and_return(refresh_service)
+        allow(refresh_service).to receive(:call).and_return(
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+        )
+      end
+
+      it "updates the user's refresh_token" do
+        described_class.perform_now(user)
+        expect(user.reload.refresh_token).to eq("new-refresh-token")
+      end
+
+      it "updates refresh_token_updated_at" do
+        freeze_time do
+          described_class.perform_now(user)
+          expect(user.reload.refresh_token_updated_at).to eq(Time.current)
+        end
+      end
+    end
+
+    context "when user has TRN" do
+      let(:user) { create(:user, trn: "1234567", refresh_token: "token") }
+
+      it "does nothing" do
+        expect(TeacherAuth::RefreshToken).not_to receive(:new)
+        described_class.perform_now(user)
+      end
+    end
+
+    context "when user has no refresh_token" do
+      let(:user) { create(:user, trn: nil, refresh_token: nil) }
+
+      it "does nothing" do
+        expect(TeacherAuth::RefreshToken).not_to receive(:new)
+        described_class.perform_now(user)
+      end
+    end
+
+    context "when refresh fails" do
+      let(:refresh_service) { instance_double(TeacherAuth::RefreshToken) }
+
+      before do
+        allow(TeacherAuth::RefreshToken).to receive(:new).and_return(refresh_service)
+        allow(refresh_service).to receive(:call).and_return(nil)
+      end
+
+      it "does not update the user" do
+        expect {
+          described_class.perform_now(user)
+        }.not_to(change { user.reload.refresh_token })
+      end
+    end
+  end
+end

--- a/spec/services/teacher_auth/refresh_token_spec.rb
+++ b/spec/services/teacher_auth/refresh_token_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe TeacherAuth::RefreshToken do
+  subject { described_class.new(refresh_token).call }
+
+  let(:refresh_token) { "old-refresh-token" }
+  let(:new_access_token) { "new-access-token" }
+  let(:new_refresh_token) { "new-refresh-token" }
+
+  let(:success_response) do
+    {
+      "access_token" => new_access_token,
+      "refresh_token" => new_refresh_token,
+    }
+  end
+
+  describe "#call" do
+    context "when the request is successful" do
+      before do
+        stub_request(:post, %r{/oauth2/token})
+          .with(body: hash_including(grant_type: "refresh_token", refresh_token:))
+          .to_return(status: 200, body: success_response.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "returns the new tokens" do
+        expect(subject).to eq(access_token: new_access_token, refresh_token: new_refresh_token)
+      end
+    end
+
+    context "when the request fails" do
+      before do
+        stub_request(:post, %r{/oauth2/token})
+          .to_return(status: 400, body: { error: "invalid_grant" }.to_json)
+      end
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: DFE-Digital/teacher-training-entitlement-board#386

Users without a TRN may remain in a temporary onboarding state while their teacher record and TRN are being created. Their session must remain valid during this process.

### Changes proposed in this pull request
- Add `TeacherAuth::RefreshToken` service to refresh OAuth tokens  
- Add `RefreshUserTokenJob` to refresh a single user's token and `update refresh_token_updated_at`
- `Add Crons::EnqueueTokenRefreshesJob` (runs hourly) to find users needing a refresh token (updated daily)

This keeps refresh tokens alive for users who logged in without a TRN
 
## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
