### PR TITLE
2750 - enable dfe-analytics in sandbox and review

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,6 +113,8 @@ jobs:
         healthcheck: ${{ env.HEALTHCHECK_CMD }}
         db-seed: true
         # smoke-test: true
+        gcp-wip: ${{ vars.GCP_WIP }}
+        gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
 
   deploy-staging:
     name: Deploy staging
@@ -171,6 +173,8 @@ jobs:
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           deploy-commit-sha: ${{ needs.build.outputs.docker-image-tag }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+          gcp-wip: ${{ vars.GCP_WIP }}
+          gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Notify teams channel failure
         if: ${{ failure() }}

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -62,4 +62,5 @@ jobs:
           deploy-commit-sha: ${{ inputs.docker-image-tag }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
           pull-request-number: ${{ inputs.pull-request-number }}
-
+          gcp-wip: ${{ vars.GCP_WIP }}
+          gcp-project-id: ${{ vars.GCP_PROJECT_ID }}

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -20,9 +20,7 @@ DfE::Analytics.configure do |config|
 
   # The name of the BigQuery dataset we're writing to.
   #
-  # config.bigquery_dataset = ENV['BIGQUERY_DATASET']
-
-  config.bigquery_dataset = ENV["BIGQUERY_DFE_ANALYTICS_DATASET"] || "npq_events_#{Rails.env}"
+  config.bigquery_dataset = ENV["BIGQUERY_DATASET"]
 
   # Service account JSON key for the BigQuery API. See
   # https://cloud.google.com/bigquery/docs/authentication/service-account-file

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -24,23 +24,27 @@ module "application_configuration" {
       RAILS_ENV                  = var.environment
       AZURE_STORAGE_ACCOUNT_NAME = module.storage_account.name
       AZURE_STORAGE_CONTAINER    = "uploads"
+      BIGQUERY_PROJECT_ID        = "ecf-bq"
+      BIGQUERY_TABLE_NAME        = var.enable_dfe_analytics_federated_auth ? module.dfe_analytics[0].bigquery_table_name : null
+      BIGQUERY_DATASET           = var.enable_dfe_analytics_federated_auth ? module.dfe_analytics[0].bigquery_dataset : null
     },
     var.environment == "review" ? {
       HOSTING_DOMAIN = "https://${var.service_name}-${local.environment}.${module.cluster_data.ingress_domain}"
     } : {}
   )
   secret_variables = {
-    DATABASE_URL = module.postgres.url
-    REDIS_CACHE_URL = var.deploy_redis_cache ? module.redis-cache.url : ""
-    AZURE_STORAGE_ACCESS_KEY   = module.storage_account.primary_access_key
+    DATABASE_URL             = module.postgres.url
+    REDIS_CACHE_URL          = var.deploy_redis_cache ? module.redis-cache.url : ""
+    AZURE_STORAGE_ACCESS_KEY = module.storage_account.primary_access_key
+    GOOGLE_CLOUD_CREDENTIALS = var.enable_dfe_analytics_federated_auth ? module.dfe_analytics[0].google_cloud_credentials : null
   }
 }
 
 module "web_application" {
   source = "./vendor/modules/aks//aks/application"
 
-  is_web = true
-  web_port = 8080
+  is_web       = true
+  web_port     = 8080
   namespace    = var.namespace
   environment  = local.environment
   service_name = var.service_name
@@ -53,8 +57,8 @@ module "web_application" {
 
   docker_image = var.docker_image
   enable_logit = true
-  command = var.command
-  probe_path = "/up"
+  command      = var.command
+  probe_path   = "/up"
 
   send_traffic_to_maintenance_page = var.send_traffic_to_maintenance_page
 }
@@ -64,7 +68,7 @@ module "worker_application" {
 
   is_web = false
 
-  name = "worker"
+  name         = "worker"
   namespace    = var.namespace
   environment  = local.environment
   service_name = var.service_name
@@ -81,7 +85,7 @@ module "worker_application" {
   replicas   = var.worker_replicas
   max_memory = var.worker_memory_max
 
-  enable_logit = var.enable_logit
+  enable_logit   = var.enable_logit
   enable_gcp_wif = var.enable_dfe_analytics_federated_auth
 
   depends_on = [time_sleep.wait_15_seconds]
@@ -93,7 +97,7 @@ module "worker_application" {
 //
 // Adding a 15 second delay before removing postgres for review apps solves this
 resource "time_sleep" "wait_15_seconds" {
-  count = var.deploy_azure_backing_services ? 0 : 1
-  depends_on = [module.postgres]
+  count            = var.deploy_azure_backing_services ? 0 : 1
+  depends_on       = [module.postgres]
   destroy_duration = "15s"
 }

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -18,5 +18,6 @@
     "apex_url": "https://teacher-training-entitlement.education.gov.uk",
     "statuscake_contact_groups": [282453, 356280],
     "blob_delete_retention_days": 7,
-    "container_delete_retention_days": 7
+    "container_delete_retention_days": 7,
+    "enable_dfe_analytics_federated_auth": false
 }

--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -6,5 +6,6 @@
     "enable_postgres_ssl" : false,
     "command": ["/bin/sh", "-c", "RAILS_ENV=review bundle exec rails db:environment:set db:schema:load db:migrate && bundle exec rails server -b 0.0.0.0"],
     "enable_logit": true,
-    "enable_dfe_analytics_federated_auth": false
+    "enable_dfe_analytics_federated_auth": true,
+    "gcp_table_deletion_protection": false
 }

--- a/terraform/application/config/sandbox.tfvars.json
+++ b/terraform/application/config/sandbox.tfvars.json
@@ -6,5 +6,5 @@
     "enable_logit": true,
     "blob_delete_retention_days": 7,
     "container_delete_retention_days": 7,
-    "enable_dfe_analytics_federated_auth": false
+    "enable_dfe_analytics_federated_auth": true
 }

--- a/terraform/application/config/sandbox.tfvars.json
+++ b/terraform/application/config/sandbox.tfvars.json
@@ -5,5 +5,6 @@
     "enable_postgres_backup_storage" : true,
     "enable_logit": true,
     "blob_delete_retention_days": 7,
-    "container_delete_retention_days": 7
+    "container_delete_retention_days": 7,
+    "enable_dfe_analytics_federated_auth": false
 }

--- a/terraform/application/config/staging.tfvars.json
+++ b/terraform/application/config/staging.tfvars.json
@@ -3,5 +3,6 @@
     "environment": "staging",
     "namespace": "cpd-development",
     "blob_delete_retention_days": 7,
-    "container_delete_retention_days": 7
+    "container_delete_retention_days": 7,
+    "enable_dfe_analytics_federated_auth": false
 }

--- a/terraform/application/dfe_analytics.tf
+++ b/terraform/application/dfe_analytics.tf
@@ -1,0 +1,19 @@
+provider "google" {
+  project = "ecf-bq"
+}
+
+module "dfe_analytics" {
+  count  = var.enable_dfe_analytics_federated_auth ? 1 : 0
+  source = "./vendor/modules/aks//aks/dfe_analytics"
+
+  azure_resource_prefix         = var.azure_resource_prefix
+  cluster                       = var.cluster
+  namespace                     = var.namespace
+  service_short                 = var.service_short
+  environment                   = local.environment
+  gcp_table_deletion_protection = var.gcp_table_deletion_protection
+  gcp_keyring                   = "ecf-key-ring"
+  gcp_key                       = "ecf-key"
+  gcp_taxonomy_id               = "6302091323314055162"
+  gcp_policy_tag_id             = "301313311867345339"
+}

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -100,8 +100,8 @@ variable "app_suffix" {
 }
 
 variable "container_delete_retention_days" {
-  type    = number
-  default = null
+  type        = number
+  default     = null
   description = "Number of days to retain deleted containers"
 }
 
@@ -127,19 +127,19 @@ variable "worker_memory_max" {
 }
 
 variable "worker_replicas" {
-  type = number
+  type    = number
   default = 1
 }
 
 variable "command" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "enable_dfe_analytics_federated_auth" {
   description = "Create the resources in Google cloud for federated authentication and enable in application"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "postgres_flexible_server_sku" {
@@ -152,4 +152,11 @@ variable "azure_maintenance_window" {
 
 variable "postgres_enable_high_availability" {
   default = false
+}
+
+variable "gcp_table_deletion_protection" {
+  type        = bool
+  description = "Prevents deletion of the event table. Default: true"
+  default     = true
+  nullable    = false
 }


### PR DESCRIPTION
### Context

Enabling dfe-analytics in both review and sandbox. 

### Changes proposed in this pull request

Workflows for deploy to review and sandbox and for manual deploy updated for GCP.
Application config variables updated with BIGQUERY variables for the GCP ecf-bq project and GCP credentials.
The existing enable_dfe_analytics_federated_auth variable is explicitly set to false in config environments apart from review and sandbox where it is set to true.
The dfe_analytics.tf Terraform module configuration included to access GCP project ecf-bq and accompanying key, taxonomy and policy tag IDs.
To remove review if not required set "enable_dfe_analytics_federated_auth": false in terraform/application/config/review.tfvars.json

## Checklists:

### Data & Schema Changes

No data structures or validation modifications:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
