### PR TITLE
Fix nil current_lead_provider

### DIFF
--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -18,7 +18,7 @@ class APIToken < ApplicationRecord
 
   def self.find_by_unhashed_token(unhashed_token, scope:)
     hashed_token = Devise.token_generator.digest(APIToken, :hashed_token, unhashed_token)
-    includes(:lead_provider).find_by(hashed_token:, scope:)
+    includes(:lead_provider).find_by!(hashed_token:, scope:)
   end
 
   # only used in specs and seeds

--- a/lib/middleware/api_authentication.rb
+++ b/lib/middleware/api_authentication.rb
@@ -32,10 +32,13 @@ module Middleware
         if api_token
           api_token.update!(last_used_at: Time.zone.now)
           api_token.lead_provider
+        else
+          raise ActiveRecord::RecordNotFound, "token not found"
         end
       end
     rescue StandardError => e
       Sentry.capture_exception(e)
+      nil
     end
 
     def unauthenticated

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe APIToken, type: :model do
       before { APIToken.create_with_known_token!(unhashed_token, scope: "teacher_record_service") }
 
       it "doesn't find the APIToken" do
-        expect(APIToken.find_by_unhashed_token(unhashed_token, scope:)).to be_nil
+        expect { APIToken.find_by_unhashed_token(unhashed_token, scope:) }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#393


### Changes proposed in this pull request

Attempt to fix nil current_lead_provider by raising an error
when API token lookup does not find anything to avoid caching `nil`
and stop request.