### PR TITLE
Application index rejected_event N+1 error

### DIFF
--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -16,6 +16,7 @@ module Applications
                                  :cohort,
                                  :schedule,
                                  :institution,
+                                 :rejected_event,
                                  { course_cohort: %i[course cohort schedule] }],
                  )
                  .preload(application: { institution: :institutionable })


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#419

Fix N+1 error for the rejected_reason used in application serializer

### Changes proposed in this pull request

Add missing include