### PR TITLE
Accessibility specs

### DIFF
--- a/spec/accessibility/email_updates_spec.rb
+++ b/spec/accessibility/email_updates_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Email updates accessibility", :axe, type: :feature do
+  describe "authenticated pages" do
+    let(:user) { create(:user, :with_one_login_id) }
+
+    before do
+      page.set_rack_session("user_id" => user.id)
+    end
+
+    it "new email updates page is accessible" do
+      visit new_email_update_path
+      expect(page).to be_axe_clean
+    end
+  end
+
+  describe "public pages" do
+    it "unsubscribe page is accessible" do
+      visit unsubscribe_email_updates_path
+      expect(page).to be_axe_clean
+    end
+
+    it "unsubscribed confirmation page is accessible" do
+      visit unsubscribed_email_updates_path
+      expect(page).to be_axe_clean
+    end
+  end
+end

--- a/spec/accessibility/expression_of_interest_spec.rb
+++ b/spec/accessibility/expression_of_interest_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe "Expression of interest accessibility", :axe, type: :feature do
     click_button("Confirm")
     expect(page).to be_axe_clean
 
-    fill_in "questionnaires_registration_interest_notification[email]", with: "alsa@email.com"
+    fill_in "questionnaires_registration_interest_notification[email]", with: "test@example.com"
     click_button("Confirm")
+    page.driver.browser.navigate.refresh
     expect(page).to be_axe_clean
   end
 end

--- a/spec/accessibility/pages_spec.rb
+++ b/spec/accessibility/pages_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Pages accessibility", :axe, type: :feature do
+  it "start page is accessible" do
+    visit root_path
+    expect(page).to be_axe_clean
+  end
+
+  it "sign in page is accessible" do
+    visit "/sign-in"
+    expect(page).to be_axe_clean
+  end
+
+  it "cookies page is accessible" do
+    visit cookies_path
+    expect(page).to be_axe_clean
+  end
+
+  it "accessibility statement is accessible" do
+    visit accessibility_statement_path
+    expect(page).to be_axe_clean
+  end
+
+  it "closed registration exception page is accessible" do
+    visit closed_registration_exception_path
+    expect(page).to be_axe_clean
+  end
+end

--- a/spec/accessibility/registration_closed_spec.rb
+++ b/spec/accessibility/registration_closed_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "Registration closed accessibility", :axe, type: :feature do
+  it "registration closed page is accessible" do
+    visit registration_closed_path
+    expect(page).to be_axe_clean
+  end
+
+  it "registration closed change page is accessible" do
+    visit change_registration_closed_path
+    expect(page).to be_axe_clean
+  end
+end

--- a/spec/accessibility/registration_wizard_spec.rb
+++ b/spec/accessibility/registration_wizard_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+REGISTRATION_WIZARD_TEMPLATES = Dir[Rails.root.join("app/views/registration_wizard/*.html.erb")]
+  .map { |f| File.basename(f, ".html.erb") }
+  .reject { |t| t.start_with?("_") || t == "get_an_identity_callback" }
+  .freeze
+
+RSpec.describe "Registration wizard templates", :axe, type: :view do
+  include RenderedHtmlAccessibilityHelper
+
+  let(:store_stub) do
+    {
+      "national_insurance_number" => "AB123456C",
+      "trn" => "1234567",
+      "course_identifier" => "reception",
+    }
+  end
+
+  # Stub answers for check_answers page
+  let(:answers_stub) { [] }
+
+  # Minimal stub for @wizard using OpenStruct for flexibility
+  let(:wizard_stub) do
+    OpenStruct.new(
+      previous_step_path: "start",
+      next_step_path: "check-answers",
+      current_step: :teacher_catchment,
+      course: nil,
+      store: store_stub,
+      answers: answers_stub,
+    )
+  end
+
+  # Stub course for templates that need it
+  let(:course_stub) do
+    OpenStruct.new(
+      identifier: "npq-leading-teaching",
+      name: "NPQ Leading Teaching",
+    )
+  end
+
+  # Stub question for templates that render questions
+  let(:question_stub) do
+    OpenStruct.new(
+      name: :example_question,
+      question_text: "Example question",
+      type: "radio_button_group",
+      options: [OpenStruct.new(value: "yes", text: "Yes"), OpenStruct.new(value: "no", text: "No")],
+      fieldset_styles: {},
+    )
+  end
+
+  # Minimal stub for @form using OpenStruct
+  let(:form_stub) do
+    obj = OpenStruct.new(
+      questions: [question_stub],
+      to_key: nil,
+      to_param: nil,
+      persisted?: false,
+      course: course_stub,
+      message_template: "eligible_for_scholarship_funding",
+      funding_amount: "£1000",
+    )
+    obj.define_singleton_method(:errors) { ActiveModel::Errors.new(obj) }
+    obj.define_singleton_method(:model_name) { ActiveModel::Name.new(Object, nil, "RegistrationWizard") }
+    obj
+  end
+
+  # Stub user for templates that need current_user
+  let(:user_stub) do
+    OpenStruct.new(
+      trn: "1234567",
+      email: "test@example.com",
+    )
+  end
+
+  before do
+    assign(:wizard, wizard_stub)
+    assign(:form, form_stub)
+    allow(view).to receive_messages(current_user: user_stub, registration_wizard_form_url: "/registration/test")
+  end
+
+  REGISTRATION_WIZARD_TEMPLATES.each do |template|
+    describe template.to_s do
+      # rubocop:disable RSpec/NoExpectationExample -- expectation is inside check_accessibility_of_html
+      it "renders and is accessible" do
+        wizard_stub.current_step = template.to_sym
+        render template: "registration_wizard/#{template}", layout: "layouts/application"
+        check_accessibility_of_html(rendered)
+      end
+      # rubocop:enable RSpec/NoExpectationExample
+    end
+  end
+end


### PR DESCRIPTION
### Context

Fixes N/A

Accessibility specs were removed in this PR: https://github.com/DFE-Digital/teacher-training-entitlement/pull/235


### Changes proposed in this pull request

- Restore accessibility specs
- Fix a spec that requires a page refresh to reload axe

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
