### PR TITLE
Fix ParticipantOutcomes::Query application_id filter

### DIFF
--- a/app/services/participant_outcomes/query.rb
+++ b/app/services/participant_outcomes/query.rb
@@ -41,7 +41,7 @@ module ParticipantOutcomes
     def where_application_id_is(application_id)
       return if ignore?(filter: application_id)
 
-      scope.merge!(ParticipantOutcome.where(declaration: { application: { ecf_id: application_id } }))
+      scope.merge!(ParticipantOutcome.where(declaration: { applications: { ecf_id: application_id } }))
     end
 
     def all_participant_outcomes

--- a/spec/services/participant_outcomes/query_spec.rb
+++ b/spec/services/participant_outcomes/query_spec.rb
@@ -111,6 +111,29 @@ RSpec.describe ParticipantOutcomes::Query do
           expect(query.scope).not_to constrain_attribute("ecf_id")
         end
       end
+
+      describe "application_id" do
+        it "filters by application_id" do
+          application = create(:application)
+          outcome = create(:participant_outcome, declaration: create(:declaration, application:))
+          create(:participant_outcome)
+
+          query = described_class.new(application_id: application.ecf_id)
+          expect(query.participant_outcomes).to contain_exactly(outcome)
+        end
+
+        it "doesn't filter by application_id when none supplied" do
+          condition_string = %("applications"."ecf_id")
+          expect(described_class.new(application_id: SecureRandom.uuid).scope.to_sql).to include(condition_string)
+          expect(described_class.new.scope.to_sql).not_to include(condition_string)
+        end
+
+        it "does not filter by application_id if an empty string is supplied" do
+          condition_string = %("applications"."ecf_id")
+          query = described_class.new(application_id: " ")
+          expect(query.scope.to_sql).not_to include(condition_string)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#425

filtering the outcomes endpoints caused a 500 server error

### Changes proposed in this pull request

- [X] Fix typo
- [X] add test coverage