### PR TITLE
Update DeliveryPartners::Query cohort filter

### DIFF
--- a/app/controllers/api/v1/delivery_partners_controller.rb
+++ b/app/controllers/api/v1/delivery_partners_controller.rb
@@ -4,7 +4,7 @@ module API
       include Pagination
 
       def index
-        conditions = { cohort_start_year:, sort: }
+        conditions = { cohort_start_years:, sort: }
         delivery_partners = query(conditions:).delivery_partners
 
         render json: to_json(paginate(delivery_partners))
@@ -25,7 +25,7 @@ module API
         query.delivery_partner(ecf_id: delivery_partner_params[:ecf_id])
       end
 
-      def cohort_start_year
+      def cohort_start_years
         delivery_partner_params.dig(:filter, :cohort)
       end
 

--- a/app/services/delivery_partners/query.rb
+++ b/app/services/delivery_partners/query.rb
@@ -6,12 +6,12 @@ module DeliveryPartners
 
     attr_reader :scope, :sort
 
-    def initialize(lead_provider:, cohort_start_year: :ignore, sort: nil)
+    def initialize(lead_provider:, cohort_start_years: :ignore, sort: nil)
       @scope = all_delivery_partners
       @sort = sort
 
       where_lead_provider_is(lead_provider)
-      where_cohort_start_year(cohort_start_year)
+      where_cohort_start_year_in(cohort_start_years)
     end
 
     def delivery_partners
@@ -31,10 +31,10 @@ module DeliveryPartners
       scope.merge!(DeliveryPartner.where(delivery_partnerships: { lead_provider: lead_provider }))
     end
 
-    def where_cohort_start_year(cohort_start_year)
-      return if ignore?(filter: cohort_start_year)
+    def where_cohort_start_year_in(cohort_start_years)
+      return if ignore?(filter: cohort_start_years)
 
-      scope.merge!(DeliveryPartner.where(delivery_partnerships: { cohorts: { start_year: cohort_start_year } }))
+      scope.merge!(DeliveryPartner.where(delivery_partnerships: { cohorts: { start_year: extract_conditions(cohort_start_years) } }))
     end
 
     def order_by

--- a/spec/requests/api/v1/delivery_partners_spec.rb
+++ b/spec/requests/api/v1/delivery_partners_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Delivery Partner endpoints", type: :request do
       end
 
       it "calls the correct query" do
-        expect(query).to receive(:new).with(a_hash_including(lead_provider: current_lead_provider, cohort_start_year: "2023")).and_call_original
+        expect(query).to receive(:new).with(a_hash_including(lead_provider: current_lead_provider, cohort_start_years: "2023")).and_call_original
 
         api_get(path, params: { filter: { cohort: 2023 } })
       end

--- a/spec/services/delivery_partners/query_spec.rb
+++ b/spec/services/delivery_partners/query_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe DeliveryPartners::Query do
     end
 
     context "when filtering by cohort" do
-      subject(:query) { described_class.new lead_provider: lead_provider_1, cohort_start_year: cohort_22.start_year }
+      subject(:query) { described_class.new lead_provider: lead_provider_1, cohort_start_years: cohort_22.start_year }
 
       it "returns delivery partners for the specified cohort" do
         expect(query.delivery_partners).to eq([delivery_partner_2])
@@ -58,7 +58,7 @@ RSpec.describe DeliveryPartners::Query do
     context "when in use in multiple cohorts in a single year" do
       subject :query do
         described_class.new(lead_provider: lead_provider_1,
-                            cohort_start_year: cohort_21.start_year)
+                            cohort_start_years: cohort_21.start_year)
       end
 
       before do
@@ -70,6 +70,19 @@ RSpec.describe DeliveryPartners::Query do
       it "returns delivery partners for the specified cohort year" do
         expect(query.delivery_partners)
           .to contain_exactly(delivery_partner_1, delivery_partner_2)
+      end
+    end
+
+    context "when filtering by multiple cohort start years" do
+      subject(:query) do
+        described_class.new(
+          lead_provider: lead_provider_1,
+          cohort_start_years: "#{cohort_21.start_year},#{cohort_23.start_year}",
+        )
+      end
+
+      it "returns delivery partners matching any of the specified years" do
+        expect(query.delivery_partners).to contain_exactly(delivery_partner_1, delivery_partner_2, delivery_partner_an_hour_ago)
       end
     end
   end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#426

Inconsistent filter[cohort] on delivery-partners endpoint


### Changes proposed in this pull request

add support multiple values inline with other `filter[cohort]`