### PR TITLE
Ensure axe loads fresh for each page

### DIFF
--- a/spec/accessibility/expression_of_interest_spec.rb
+++ b/spec/accessibility/expression_of_interest_spec.rb
@@ -1,16 +1,19 @@
 require "rails_helper"
 
 RSpec.describe "Expression of interest accessibility", :axe, type: :feature do
-  it "checks expressions of interest page" do
+  it "sign up page is accessible" do
     visit registration_interest_sign_up_path
     expect(page).to be_axe_clean
+  end
 
+  it "sign up page with validation errors is accessible" do
+    visit registration_interest_sign_up_path
     click_button("Confirm")
     expect(page).to be_axe_clean
+  end
 
-    fill_in "questionnaires_registration_interest_notification[email]", with: "test@example.com"
-    click_button("Confirm")
-    page.driver.browser.navigate.refresh
+  it "confirmation page is accessible" do
+    visit registration_interest_sign_up_confirm_path(email: "test@example.com")
     expect(page).to be_axe_clean
   end
 end


### PR DESCRIPTION
### Context

Fixes spec `spec/accessibility/expression_of_interest_spec.rb`

### Changes proposed in this pull request

If we check one page at a time, Axe reloads.
This is based on the recently deleted: `spec/accessibility/interest_notification_spec.rb`

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
