### PR TITLE
Update subscribe  email confirmation text

### DIFF
--- a/app/controllers/email_updates_controller.rb
+++ b/app/controllers/email_updates_controller.rb
@@ -14,7 +14,11 @@ class EmailUpdatesController < PublicPagesController
     @form = EmailUpdates.new(email_update_params)
     if @form.valid?
       current_user.update_email_updates_status(@form)
-      GenericMailer.with(to: current_user.email, service_link: Rails.configuration.service_base_url, unsubscribe_link:).email_updates_confirmation.deliver_now
+      GenericMailer.with(
+        to: current_user.email,
+        name: current_user.full_name,
+        unsubscribe_link:,
+      ).email_updates_confirmation.deliver_now
     else
       render :new
     end

--- a/app/views/generic_mailer/email_updates_confirmation.text.erb
+++ b/app/views/generic_mailer/email_updates_confirmation.text.erb
@@ -1,6 +1,6 @@
 Dear <%= params[:name] %>
-You have successfully signed up to email notifications about this NPD course. We will contact you when the next course registration is open
-You can unsubscribe from this service at any time using the [following link](<%= params[:unsubscribe_link] %>)
+You have successfully signed up to email notifications about this NPD course. We will contact you when the next course registration is open.
+You can unsubscribe from this service at any time using the [following link](<%= params[:unsubscribe_link] %>).
 
 Regards,
-The Teacher Continuing Development team
+The Teacher Continuing Professional Development team

--- a/app/views/generic_mailer/email_updates_confirmation.text.erb
+++ b/app/views/generic_mailer/email_updates_confirmation.text.erb
@@ -1,2 +1,6 @@
-Your service link  <%= params[:service_link] %>.
-You can unsubscribe from this service using the following link: <%= params[:unsubscribe_link] %>.
+Dear <%= params[:name] %>
+You have successfully signed up to email notifications about this NPD course. We will contact you when the next course registration is open
+You can unsubscribe from this service at any time using the [following link](<%= params[:unsubscribe_link] %>)
+
+Regards,
+The Teacher Continuing Development team

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe GenericMailer, type: :mailer do
 
         body = mail.personalisation[:body]
         expect(body).to include(unsubscribe_link)
+        expect(body).to include(name)
       end
     end
 

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -3,14 +3,14 @@ require "rails_helper"
 RSpec.describe GenericMailer, type: :mailer do
   describe "#email_updates_confirmation" do
     let(:to) { "recipient@example.com" }
-    let(:service_link) { "https://example.com/service" }
+    let(:name) { "Some One" }
     let(:unsubscribe_link) { "https://example.com/unsubscribe" }
 
     subject(:mail) do
       described_class.with(
         to:,
-        service_link:,
         unsubscribe_link:,
+        name:,
       ).email_updates_confirmation
     end
 
@@ -21,7 +21,6 @@ RSpec.describe GenericMailer, type: :mailer do
         expect(mail.personalisation[:subject]).to eq(I18n.t("mailers.email_updates_confirmation"))
 
         body = mail.personalisation[:body]
-        expect(body).to include(service_link)
         expect(body).to include(unsubscribe_link)
       end
     end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#384

Update email content for the subscribe confirmation email text

### Changes proposed in this pull request

- Update email text
- Update specs

## Checklists:

### Data & Schema Changes

None