### PR TITLE
2750 - added GCP variables for DfE Analytics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,10 @@ on:
         type: choice
         default: review
         options:
-        - review
-        - staging
-        - sandbox
-        - production
+          - review
+          - staging
+          - sandbox
+          - production
       docker-image-tag:
         description: "Docker image tag to deploy (optional)"
         required: true
@@ -23,16 +23,16 @@ on:
         required: false
         type: string
   push:
-   branches:
-    - main
+    branches:
+      - main
   pull_request:
     branches:
-    - main
+      - main
     types: [opened, reopened, synchronize, labeled]
 
 env:
   TERRAFORM_BASE: terraform/application
-  HEALTHCHECK_CMD: 'healthcheck'
+  HEALTHCHECK_CMD: "healthcheck"
 
 permissions:
   contents: read
@@ -71,19 +71,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
-      name: Checkout
+      - uses: actions/checkout@v6
+        name: Checkout
 
-    - name: Build and push docker image
-      id: build-image
-      uses: DFE-Digital/github-actions/build-docker-image@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        context: .
-        docker-repository: ${{ env.DOCKER_REPOSITORY }}
-        max-cache: true
-        reuse-cache: true
-        snyk-token: ${{ secrets.SNYK_TOKEN }}
+      - name: Build and push docker image
+        id: build-image
+        uses: DFE-Digital/github-actions/build-docker-image@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          context: .
+          docker-repository: ${{ env.DOCKER_REPOSITORY }}
+          max-cache: true
+          reuse-cache: true
+          snyk-token: ${{ secrets.SNYK_TOKEN }}
 
   deploy-review-app:
     name: Deployment To Review
@@ -99,22 +99,22 @@ jobs:
       pull-requests: write
 
     steps:
-    - name: Deploy App to Review
-      id: deploy_review
-      uses: DFE-Digital/github-actions/deploy-to-aks@master
-      with:
-        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        environment: review
-        pr-number: ${{ github.event.pull_request.number }}
-        sha: ${{ needs.build.outputs.docker-image-tag }}
-        terraform-base: ${{ env.TERRAFORM_BASE }}
-        healthcheck: ${{ env.HEALTHCHECK_CMD }}
-        db-seed: true
-        # smoke-test: true
-        gcp-wip: ${{ vars.GCP_WIP }}
-        gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
+      - name: Deploy App to Review
+        id: deploy_review
+        uses: DFE-Digital/github-actions/deploy-to-aks@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          environment: review
+          pr-number: ${{ github.event.pull_request.number }}
+          sha: ${{ needs.build.outputs.docker-image-tag }}
+          terraform-base: ${{ env.TERRAFORM_BASE }}
+          healthcheck: ${{ env.HEALTHCHECK_CMD }}
+          db-seed: true
+          # smoke-test: true
+          gcp-wip: ${{ vars.GCP_WIP }}
+          gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
 
   deploy-staging:
     name: Deploy staging
@@ -139,6 +139,8 @@ jobs:
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           deploy-commit-sha: ${{ needs.build.outputs.docker-image-tag }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+          gcp-wip: ${{ vars.GCP_WIP }}
+          gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Notify teams channel failure
         if: ${{ failure() }}
@@ -207,6 +209,8 @@ jobs:
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           deploy-commit-sha: ${{ needs.build.outputs.docker-image-tag }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+          gcp-wip: ${{ vars.GCP_WIP }}
+          gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Notify teams channel failure
         if: ${{ failure() }}
@@ -234,9 +238,9 @@ jobs:
         id: deploy_domains_infra
         uses: DFE-Digital/github-actions/deploy-domains-infra@master
         with:
-          azure-client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
-          azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
-          azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID  }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID   }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
           service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
 
@@ -260,9 +264,9 @@ jobs:
         id: deploy_domains_env
         uses: DFE-Digital/github-actions/deploy-domains-env@master
         with:
-          azure-client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
-          azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
-          azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID  }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID   }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
           environment: ${{ matrix.domain_environment }}
           healthcheck: healthcheck
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}

--- a/.github/workflows/destroy_review_app.yml
+++ b/.github/workflows/destroy_review_app.yml
@@ -69,4 +69,5 @@ jobs:
           resource-group-name: "s189t01-cpdtte-rv-rg"
           storage-account-name: "s189t01cpdttervtfsa"
           tf-state-file: "${{ github.event.pull_request.number || github.event.inputs.pr_number }}.tfstate"
-
+          gcp-wip: ${{ vars.GCP_WIP }}
+          gcp-project-id: ${{ vars.GCP_PROJECT_ID }}


### PR DESCRIPTION
### Context

Added missing dfe-analytics variables gcp-wip and gcp-project-id to deploy.yml for staging and production and to destroy_review_app.yml

### Changes proposed in this pull request

Added gcp-wip and gcp-project-id variables to .github/workflows/deploy.yml and  .github/workflows/destroy_review_app.yml. These are required when enable_dfe_analytics_federated_auth is set to true.

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

### Integration Impact

Does this change affect any of these integrations?
- [x] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration