### PR TITLE
2750 - added GCP variables to deploy-environment-to-aks action.yml

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -26,6 +26,12 @@ inputs:
   statuscake-api-token:
     description: The Statuscake token
     required: false
+  gcp-wip:
+    description: The full identifier of the GCP Workload Identity Provider.
+    required: false
+  gcp-project-id:
+    description: The name of the GCP Project ID.
+    required: false
 
 outputs:
   url:
@@ -46,6 +52,12 @@ runs:
         client-id: ${{ inputs.azure-client-id }}
         tenant-id: ${{ inputs.azure-tenant-id }}
         subscription-id: ${{ inputs.azure-subscription-id }}
+
+    - uses: google-github-actions/auth@v2
+      if: ${{ inputs.gcp-wip != '' }}
+      with:
+        project_id: ${{ inputs.gcp-project-id }}
+        workload_identity_provider: ${{ inputs.gcp-wip }}
 
     - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
       with:


### PR DESCRIPTION
### Context

Added missing dfe-analytics variables gcp-wip and gcp-project-id to action.yml for deploy-environment-to-aks

### Changes proposed in this pull request

Added gcp-wip and gcp-project-id variables to .github/actions/deploy-environment-to-aks/action.yml. This is required as only review uses the shared deploy action whilst the other environments use local deploy action.

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

### Integration Impact

Does this change affect any of these integrations?
- [x] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration