### PR TITLE
Assign encryption keys in the initializer

### DIFF
--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -1,8 +1,8 @@
 # Test environment encryption keys are set in config/environments/test.rb
 unless Rails.env.test?
-  Rails.application.configure do
-    config.active_record.encryption.primary_key = ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY")
-    config.active_record.encryption.deterministic_key = ENV.fetch("ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY")
-    config.active_record.encryption.key_derivation_salt = ENV.fetch("ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT")
-  end
+  ActiveRecord::Encryption.configure(
+    primary_key: ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"),
+    deterministic_key: ENV.fetch("ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"),
+    key_derivation_salt: ENV.fetch("ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"),
+  )
 end


### PR DESCRIPTION
### Context

Fixes N/A 

When logging in without a TRN, we get an error because the active record encryption keys aren't available:
```
Missing Active Record encryption credential: active_record_encryption.primary_key
```

### Changes proposed in this pull request

Use `ActiveRecord::Encryption.configure` to set up the encryption keys because `Rails.application.config` is read before initializers run.

To test from a console, this should succeed:
`User.last.update(refresh_token: 'foo')`

And login to the review app with a user without a TRN


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
