### PR TITLE
Update lead provider config so hint is blank

### DIFF
--- a/db/seeds/base/constants.rb
+++ b/db/seeds/base/constants.rb
@@ -2,36 +2,36 @@ LEAD_PROVIDER_CONFIG = {
   "Ambition Institute" => {
     token: "ambition-token",
     url: "https://www.ambition.org.uk/",
-    hint: "Ambition Institute is a graduate school with programmes designed to support educators throughout the education sector, including teachers, leaders, and executive leaders.",
+    hint: nil,
   },
   "Best Practice Network" => {
     token: "best-practice-token",
     url: "https://www.bestpracticenet.co.uk/",
-    hint: "We share the desire of every practitioner that every child, regardless of their background, should benefit from an excellent education.",
+    hint: nil,
   },
   "Church of England" => {
     token: "coe-token",
     url: "https://www.nse.org.uk/",
-    hint: "TBD",
+    hint: nil,
   },
   "University College London (UCL) Institute of Education" => {
     token: "ucl-token",
     url: "https://www.ucl.ac.uk/ioe/courses/professional-development-teachers/",
-    hint: "We work across education, culture, psychology and social science to create lasting and evolving change.",
+    hint: nil,
   },
   "National Institute of Teaching" => {
     token: "niot-token",
     url: "https://niot.org.uk/",
-    hint: "We research and run professional development for teachers and school leaders for the benefit of pupils across England. #traintoteach",
+    hint: nil,
   },
   "LLSE" => {
     token: "llse-token",
     url: "https://www.llse.org.uk/",
-    hint: "An Outstanding Lead Provider of National Professional Qualifications (NPQs) for School Leadership",
+    hint: nil,
   },
   "Teach First" => {
     token: "teach-first-token",
     url: "https://teachfirst.co.uk",
-    hint: "Teach first hint",
+    hint: nil,
   },
 }.freeze

--- a/lib/tasks/data_migrations/migrate_lead_provider_details.rake
+++ b/lib/tasks/data_migrations/migrate_lead_provider_details.rake
@@ -3,9 +3,9 @@ OLD_NAMES_MAP = {
 }.freeze
 
 namespace :data_migrations do
-  desc "Update provider url and h"
+  desc "Update provider details from config"
   task migrate_lead_provider_details: :environment do
-    LeadProvider.where(url: nil).find_each do |lead_provider|
+    LeadProvider.find_each do |lead_provider|
       config = LEAD_PROVIDER_CONFIG[lead_provider.name]
 
       # If the name has changed, update it


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#345

Update lead providers so that the hint is blank

### Changes proposed in this pull request

- Update LP config

## Checklists:

### Data & Schema Changes
None

### Integration Impact
None

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration
Run: `bundle exec rake data_migrations:migrate_lead_provider_details` to update existing providers
</details>
