### PR TITLE
Add auditable field on application assignment

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -49,7 +49,7 @@ class Application < ApplicationRecord
   scope :not_withdrawn, -> { where.not(status: WITHDRAWN).or(where(status: nil)) }
   scope :not_rejected, -> { where.not(status: REJECTED) }
 
-  attr_accessor :version_note, :skip_touch_user_if_changed, :admin_user
+  attr_accessor :version_note, :skip_touch_user_if_changed, :admin_user, :assignment
 
   validates :ecf_id, uniqueness: { case_sensitive: false }
 
@@ -125,8 +125,26 @@ class Application < ApplicationRecord
   def lead_provider=(new_provider)
     return if new_provider == lead_provider
 
-    application_lead_providers.current.update_all(current: false, updated_at: Time.zone.now)
-    application_lead_providers.create!(lead_provider: new_provider, current: true)
+    timestamp = Time.zone.now
+    application_lead_providers.current.update_all(
+      current: false,
+      updated_at: timestamp,
+      unassigned_at: timestamp,
+    )
+    application_lead_providers.create!(
+      lead_provider: new_provider,
+      current: true,
+      assigned_at: timestamp,
+    )
+  end
+
+  def assigned_at
+    current_application_lead_provider.assigned_at
+  end
+
+  def unassigned_at
+    # assignment is a specific previous application_lead_provider record set before render
+    assignment&.unassigned_at
   end
 
   def can_change_provider?

--- a/app/serializers/api/application_lead_provider_serializer.rb
+++ b/app/serializers/api/application_lead_provider_serializer.rb
@@ -11,7 +11,9 @@ module API
 
       def render_one(application_lead_provider, view:, root:)
         view = application_lead_provider.current? ? view : "#{view}_reassigned".to_sym
-        ApplicationSerializer.render(application_lead_provider.application, view:, root:)
+        application = application_lead_provider.application
+        application.assignment = application_lead_provider
+        ApplicationSerializer.render(application, view:, root:)
       end
 
       def render_array(application_lead_providers, view:, root:)

--- a/app/serializers/api/application_serializer.rb
+++ b/app/serializers/api/application_serializer.rb
@@ -28,6 +28,8 @@ module API
         field(:teacher_catchment_iso_country_code)
         field(:funded_place)
         field(:schedule_identifier) { |a| a.schedule&.identifier }
+        field(:assigned_at)
+        field(:unassigned_at)
         field(:created_at)
         field(:updated_at) do |a|
           [
@@ -40,7 +42,7 @@ module API
       view :v1_reassigned do
         include_view :v1
 
-        field(:status) { |_| Application::REASSIGNED }
+        field(:status) { Application::REASSIGNED }
       end
     end
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -174,6 +174,13 @@ shared:
     - metadata
     - created_at
     - updated_at
+  :application_lead_providers:
+    - id
+    - application_id
+    - lead_provider_id
+    - current
+    - assigned_at
+    - unassigned_at
   :applications:
     - id
     - user_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -113,11 +113,7 @@
   :lead_providers:
   - email
   :application_lead_providers:
-  - id
-  - application_id
   - created_at
-  - current
-  - lead_provider_id
   - updated_at
   :application_events:
   - type

--- a/db/migrate/20260529121944_add_assignment_timestamp_to_application_lead_provider_table.rb
+++ b/db/migrate/20260529121944_add_assignment_timestamp_to_application_lead_provider_table.rb
@@ -1,0 +1,6 @@
+class AddAssignmentTimestampToApplicationLeadProviderTable < ActiveRecord::Migration[8.1]
+  def change
+    add_column :application_lead_providers, :assigned_at, :datetime
+    add_column :application_lead_providers, :unassigned_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_21_102746) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_29_121944) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -110,9 +110,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_102746) do
 
   create_table "application_lead_providers", force: :cascade do |t|
     t.bigint "application_id"
+    t.datetime "assigned_at"
     t.datetime "created_at", null: false
     t.boolean "current", default: false
     t.bigint "lead_provider_id"
+    t.datetime "unassigned_at"
     t.datetime "updated_at", null: false
     t.index ["application_id", "lead_provider_id"], name: "idx_on_application_id_lead_provider_id_f38fa4893f", unique: true
     t.index ["application_id"], name: "index_application_lead_providers_on_application_id"

--- a/lib/tasks/update_assignments.rake
+++ b/lib/tasks/update_assignments.rake
@@ -1,0 +1,12 @@
+namespace :assignments do
+  desc "update application lead_provider"
+  task update: :environment do
+    ApplicationLeadProvider.find_each do |alp|
+      alp.assigned_at = alp.application&.created_at
+      unless alp.current
+        alp.unassigned_at = Time.zone.now
+      end
+      alp.save!
+    end
+  end
+end

--- a/public/api/docs/v1/swagger.yaml
+++ b/public/api/docs/v1/swagger.yaml
@@ -125,6 +125,8 @@ paths:
                         funded_place: true
                         created_at: '2021-05-31T02:21:32.000Z'
                         updated_at: '2021-05-31T02:22:32.000Z'
+                        assigned_at: '2021-05-31T02:22:32.000Z'
+                        unassigned_at: '2021-05-31T02:22:32.000Z'
                         schedule_identifier: tte-reception-autumn
               schema:
                 "$ref": "#/components/schemas/ApplicationResponse"
@@ -206,6 +208,8 @@ paths:
                         funded_place:
                         created_at: '2021-05-31T02:21:32.000Z'
                         updated_at: '2021-05-31T02:22:32.000Z'
+                        assigned_at: '2021-05-31T02:22:32.000Z'
+                        unassigned_at: '2021-05-31T02:22:32.000Z'
                         schedule_identifier: tte-reception-autumn
               schema:
                 "$ref": "#/components/schemas/ApplicationResponse"
@@ -269,6 +273,8 @@ paths:
                         funded_place: true
                         created_at: '2021-05-31T02:21:32.000Z'
                         updated_at: '2021-05-31T02:22:32.000Z'
+                        assigned_at: '2021-05-31T02:22:32.000Z'
+                        unassigned_at: '2021-05-31T02:22:32.000Z'
                         schedule_identifier: tte-reception-autumn
               schema:
                 "$ref": "#/components/schemas/ApplicationResponse"
@@ -350,6 +356,8 @@ paths:
                         funded_place: true
                         created_at: '2021-05-31T02:21:32.000Z'
                         updated_at: '2021-05-31T02:22:32.000Z'
+                        assigned_at: '2021-05-31T02:22:32.000Z'
+                        unassigned_at: '2021-05-31T02:22:32.000Z'
                         schedule_identifier: tte-reception-autumn
               schema:
                 "$ref": "#/components/schemas/ApplicationResponse"
@@ -431,6 +439,8 @@ paths:
                         funded_place: true
                         created_at: '2021-05-31T02:21:32.000Z'
                         updated_at: '2021-05-31T02:22:32.000Z'
+                        assigned_at: '2021-05-31T02:22:32.000Z'
+                        unassigned_at: '2021-05-31T02:22:32.000Z'
                         schedule_identifier: tte-reception-autumn
               schema:
                 "$ref": "#/components/schemas/ApplicationResponse"
@@ -512,6 +522,8 @@ paths:
                         funded_place:
                         created_at: '2021-05-31T02:21:32.000Z'
                         updated_at: '2021-05-31T02:22:32.000Z'
+                        assigned_at: '2021-05-31T02:22:32.000Z'
+                        unassigned_at: '2021-05-31T02:22:32.000Z'
                         schedule_identifier: tte-reception-autumn
               schema:
                 "$ref": "#/components/schemas/ApplicationResponse"
@@ -593,6 +605,8 @@ paths:
                         funded_place: true
                         created_at: '2021-05-31T02:21:32.000Z'
                         updated_at: '2021-05-31T02:22:32.000Z'
+                        assigned_at: '2021-05-31T02:22:32.000Z'
+                        unassigned_at: '2021-05-31T02:22:32.000Z'
                         schedule_identifier: tte-reception-autumn
               schema:
                 "$ref": "#/components/schemas/ApplicationResponse"
@@ -1501,6 +1515,18 @@ components:
               description: The date the application was last updated
               type: string
               nullable: false
+              format: date-time
+              example: '2021-05-31T02:22:32.000Z'
+            assigned_at:
+              description: The date the application was assigned to a lead provider
+              type: string
+              nullable: false
+              format: date-time
+              example: '2021-05-31T02:22:32.000Z'
+            unassigned_at:
+              description: The date the application was unassigned from a lead provider
+              type: string
+              nullable: true
               format: date-time
               example: '2021-05-31T02:22:32.000Z'
             schedule_identifier:

--- a/spec/factories/application_lead_providers.rb
+++ b/spec/factories/application_lead_providers.rb
@@ -4,5 +4,16 @@ FactoryBot.define do
   factory :application_lead_provider do
     application
     lead_provider
+
+    trait :current do
+      current { true }
+      assigned_at { Time.zone.now }
+    end
+
+    trait :unassigned do
+      current { false }
+      assigned_at { 1.month.ago }
+      unassigned_at { Time.zone.now }
+    end
   end
 end

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -31,8 +31,7 @@ FactoryBot.define do
 
     after(:create) do |application, evaluator|
       lead_provider = evaluator.lead_provider || LeadProvider.first || create(:lead_provider)
-      create(:application_lead_provider,
-             application:, lead_provider:, current: true)
+      create(:application_lead_provider, :current, application:, lead_provider:)
     end
 
     trait :with_state_change do
@@ -155,7 +154,11 @@ FactoryBot.define do
       end
       after(:create) do |application, eval|
         lead_provider = eval.old_lead_provider || create(:lead_provider)
-        application.application_lead_providers.create!(application:, lead_provider:)
+        application.application_lead_providers.create!(
+          application:,
+          lead_provider:,
+          assigned_at: application.created_at,
+        )
       end
     end
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -738,22 +738,36 @@ RSpec.describe Application do
   describe "#lead_provider=" do
     let(:lead_provider) { create(:lead_provider) }
     let(:another_lead_provider) { create(:lead_provider) }
-    let(:application) { create(:application, lead_provider:) }
+    let(:assignment_date) { 1.day.ago }
+    let(:application) do
+      travel_to(assignment_date) { create(:application, lead_provider:) }
+    end
 
     it "marks the current provider as previous and creates a new current provider link" do
       expect(application.application_lead_providers.count).to eq(1)
       expect(application.current_application_lead_provider.lead_provider).to eq(lead_provider)
       expect(application.current_application_lead_provider.current).to be(true)
+      expect(application.current_application_lead_provider.assigned_at.to_fs).to eq(assignment_date.to_fs)
+      expect(application.current_application_lead_provider.unassigned_at).to be_nil
 
       application.lead_provider = another_lead_provider
 
       application_lead_providers = application.application_lead_providers.reload
 
       expect(application_lead_providers.count).to eq(2)
-      expect(application_lead_providers.first.lead_provider).to eq(lead_provider)
-      expect(application_lead_providers.first.current).to be(false)
-      expect(application_lead_providers.last.lead_provider).to eq(another_lead_provider)
-      expect(application_lead_providers.last.current).to be(true)
+      previous = application_lead_providers.first
+      current = application_lead_providers.last
+
+      expect(previous.lead_provider).to eq(lead_provider)
+      expect(previous.current).to be(false)
+      expect(previous.assigned_at).to be_present
+      expect(previous.unassigned_at).to be_present
+
+      expect(current.lead_provider).to eq(another_lead_provider)
+      expect(current.current).to be(true)
+      expect(current.assigned_at).to be_present
+      expect(current.unassigned_at).to be_nil
+
       expect(application.reload.lead_provider).to eq(another_lead_provider)
     end
 

--- a/spec/serializers/api/application_serializer_spec.rb
+++ b/spec/serializers/api/application_serializer_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
   let(:schedule) { create(:schedule) }
   let(:course_cohort) { create(:course_cohort, course:, cohort:, schedule:) }
   let(:institution) { create(:institution, :for_school) }
-  let(:application) { build(:application, course_cohort:, institution:) }
+  let(:application) { create(:application, course_cohort:, institution:) }
+  let(:unassigned) { build(:application_lead_provider, :unassigned) }
   let(:v1_json) { JSON.parse(described_class.render(application, view: :v1, root: "data")) }
 
   describe "core attributes" do
@@ -75,6 +76,15 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
       expect(attributes["teacher_catchment_iso_country_code"]).to eq(application.teacher_catchment_iso_country_code)
     end
 
+    it "serializes the `assigned_at`" do
+      expect(attributes["assigned_at"]).to eq(application.current_application_lead_provider.assigned_at.rfc3339)
+    end
+
+    it "serializes the `unassigned_at`" do
+      application.assignment = unassigned
+      expect(attributes["unassigned_at"]).to eq(unassigned.unassigned_at.rfc3339)
+    end
+
     describe "cohort serialization" do
       it "serializes the `cohort`" do
         cohort.start_year = 2025
@@ -93,7 +103,7 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
       end
 
       context "when `school` is `nil`" do
-        let(:application) { build(:application, cohort:, course:, institution: nil) }
+        let(:application) { create(:application, cohort:, course:, institution: nil) }
 
         it { expect(attributes["institution_reference_number"]).to be_nil }
         it { expect(attributes["institution_type"]).to be_nil }

--- a/spec/services/applications/change_lead_provider_spec.rb
+++ b/spec/services/applications/change_lead_provider_spec.rb
@@ -4,16 +4,23 @@ RSpec.describe Applications::ChangeLeadProvider, type: :model do
   let(:old_provider) { create(:lead_provider) }
   let(:new_provider) { create(:lead_provider) }
   let(:application) { create(:application, :pending, lead_provider: old_provider) }
+  let(:new_assignment_date) { Time.zone.now }
+  let(:old_application_lead_provider) { build(:application_lead_provider, :unassigned, application:, lead_provider: old_provider) }
 
   subject(:service) { described_class.new(application:, new_provider:) }
 
   describe ".call" do
     before do
-      subject.call
+      travel_to(new_assignment_date) do
+        subject.call
+      end
     end
 
     it do
+      application.assignment = old_application_lead_provider
       expect(application.reload.lead_provider).to eq(new_provider)
+      expect(application.assigned_at.to_fs).to eq(new_assignment_date.to_fs)
+      expect(application.unassigned_at.to_fs).to eq(new_assignment_date.to_fs)
       expect(application.status).to eq(Application::PENDING)
       expect(application.application_lead_providers.previous.last.lead_provider).to eq(old_provider)
 

--- a/spec/swagger_schemas/models/application.rb
+++ b/spec/swagger_schemas/models/application.rb
@@ -151,6 +151,20 @@ APPLICATION = {
             format: :"date-time",
             example: "2021-05-31T02:22:32.000Z",
           },
+          assigned_at: {
+            description: "The date the application was assigned to a lead provider",
+            type: :string,
+            nullable: false,
+            format: :"date-time",
+            example: "2021-05-31T02:22:32.000Z",
+          },
+          unassigned_at: {
+            description: "The date the application was unassigned from a lead provider",
+            type: :string,
+            nullable: true,
+            format: :"date-time",
+            example: "2021-05-31T02:22:32.000Z",
+          },
           schedule_identifier: {
             description: "The new schedule of the participant",
             nullable: true,


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#431
Fixes DFE-Digital/teacher-training-entitlement-board#439


### Changes proposed in this pull request

`unassigned_at` field were missing from the API specification 
`assigned_at` field add for full auditability


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [X] Adds/removes database fields
- [X] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [X] DfE Analytics platform
- [X] API

### Data Integrity

Does this change affects existing data:
- [X] Plan data migration

</details>