### PR TITLE
New registration submitted page

### DIFF
--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -2,8 +2,8 @@ class RegistrationWizardController < PublicPagesController
   before_action :registration_closed
   before_action :set_wizard
   before_action :set_form
-  before_action :check_end_of_journey, only: %i[update]
   before_action :check_duplicate_applications, only: %i[update]
+  before_action :ensure_can_render_step, only: :show
 
   rescue_from FundingEligibility::MissingMandatoryInstitution, with: :redirect_to_institution_picker
   rescue_from RegistrationWizard::RemovedStep, with: :redirect_to_course_start_date
@@ -14,9 +14,6 @@ class RegistrationWizardController < PublicPagesController
     @form.flag_as_changing_answer if params[:changing_answer] == "1"
 
     @wizard.before_render
-
-    return redirect_to registration_wizard_show_path(@wizard.next_step_path) if @wizard.skip_step?
-    return redirect_to root_path unless @form.requirements_met?
 
     render @wizard.current_step
 
@@ -68,6 +65,14 @@ class RegistrationWizardController < PublicPagesController
 
 private
 
+  def ensure_can_render_step
+    return redirect_to root_path unless @form.requirements_met?
+    return redirect_to registration_wizard_show_path(@wizard.next_step_path) if @wizard.skip_step?
+
+    redirect_to root_path if store.except("current_user_id").blank? &&
+      !params[:step].in?(RegistrationWizard::VALID_BLANK_STEPS)
+  end
+
   def redirect_to_course_start_date
     redirect_to registration_wizard_show_path("course-start-date")
   end
@@ -109,17 +114,6 @@ private
     }
 
     redirect_to application_path(active_applications.last.ecf_id)
-  end
-
-  def check_end_of_journey
-    return unless @form.valid? && @form.last_step?
-
-    @wizard.save!
-    flash[:notice] = {
-      title: "Registration successfully submitted",
-      message: "Check the details of your registration and find out more about applying with your provider",
-    }
-    redirect_to application_path(current_user.applications.last.ecf_id)
   end
 
   def registration_closed

--- a/app/forms/questionnaires/check_answers.rb
+++ b/app/forms/questionnaires/check_answers.rb
@@ -4,17 +4,17 @@ module Questionnaires
       :share_provider
     end
 
-    def next_step; end
+    def next_step
+      :registration_submitted
+    end
 
     def last_step?
-      true
+      false
     end
 
     def after_save
       wizard.store["funding_amount"] = nil
-
       wizard.store["submitted"] = true
-      wizard.session["clear_tra_login"] = true
 
       HandleSubmissionForStore.new(store: wizard.store).call
     end

--- a/app/forms/questionnaires/registration_submitted.rb
+++ b/app/forms/questionnaires/registration_submitted.rb
@@ -1,0 +1,19 @@
+module Questionnaires
+  class RegistrationSubmitted < Base
+    def previous_step; end
+
+    def next_step; end
+
+    def last_step?
+      true
+    end
+
+    def requirements_met?
+      true
+    end
+
+    def after_save
+      wizard.session["clear_tra_login"] = true
+    end
+  end
+end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -165,7 +165,7 @@ private
 
   def t(key)
     I18n.t(store[key], scope: "helpers.label.registration_wizard.#{key}_options")
-  rescue StandardError => e
+  rescue StandardError
     key.to_s.humanize
   end
 end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -40,7 +40,6 @@ class RegistrationWizard
 
   class << self
     def validate_step!(step)
-      # raise "#{step.to_sym} #{VALID_REGISTRATION_STEPS.include?(step.to_sym)}"
       return step.to_sym if VALID_REGISTRATION_STEPS.include?(step.to_sym)
 
       raise InvalidStep, "Could not find step: #{step}"
@@ -165,7 +164,5 @@ private
 
   def t(key)
     I18n.t(store[key], scope: "helpers.label.registration_wizard.#{key}_options")
-  rescue StandardError
-    key.to_s.humanize
   end
 end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -24,9 +24,10 @@ class RegistrationWizard
     funding_your_course
     share_provider
     check_answers
+    registration_submitted
   ].freeze
 
-  REMOVED_REGISTRATION_STEPS = %i[].freeze
+  VALID_BLANK_STEPS = %w[closed start course-start-date registration-submitted].freeze
 
   attr_reader :current_step, :params, :store, :request, :current_user
 
@@ -39,9 +40,8 @@ class RegistrationWizard
 
   class << self
     def validate_step!(step)
+      # raise "#{step.to_sym} #{VALID_REGISTRATION_STEPS.include?(step.to_sym)}"
       return step.to_sym if VALID_REGISTRATION_STEPS.include?(step.to_sym)
-
-      raise RemovedStep, "This step has been removed: #{step}" if REMOVED_REGISTRATION_STEPS.include?(step.to_sym)
 
       raise InvalidStep, "Could not find step: #{step}"
     end
@@ -165,5 +165,7 @@ private
 
   def t(key)
     I18n.t(store[key], scope: "helpers.label.registration_wizard.#{key}_options")
+  rescue StandardError => e
+    key.to_s.humanize
   end
 end

--- a/app/views/registration_wizard/check_answers.html.erb
+++ b/app/views/registration_wizard/check_answers.html.erb
@@ -6,7 +6,6 @@
     ) do
 %>
   <h1 class="govuk-heading-xl">Check your answers and submit</h1>
-
   <%= render GovukComponent::SummaryListComponent.new do |component|
         @wizard.answers.each do |answer|
           component.with_row do |row|
@@ -21,7 +20,7 @@
             end
           end
         end
-  end %>
+    end %>
 
   <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
     <%= f.govuk_submit "Submit" %>

--- a/app/views/registration_wizard/registration_submitted.html.erb
+++ b/app/views/registration_wizard/registration_submitted.html.erb
@@ -1,0 +1,33 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Registration submitted
+      </h1>
+
+    </div>
+
+    <p class="govuk-body">We have sent you a confirmation email.</p>
+
+    <h2 class="govuk-heading-m">What happens next</h2>
+
+    <ol class="govuk-list govuk-list--number">
+      <li>We will notify your training provider of your registration</li>
+      <li>Your provider will contact you to complete their application</li>
+      <li>Your provider will confirm if they have a funded place to offer you</li>
+    </ol>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <% if current_user.applications.present? %>
+        <%= govuk_link_to "View your registration details", application_path(current_user.applications.last.ecf_id) %>
+      <% end %>
+    </p>
+    <hr>
+    <p class="govuk-body govuk-!-margin-top-6">
+      <%= govuk_link_to "What did you think of this service?", Rails.configuration.feedback_link, target: '_blank' %>
+      (takes 30 seconds)
+
+    </p>
+
+  </div>
+</div>

--- a/spec/forms/questionnaires/registration_submitted_spec.rb
+++ b/spec/forms/questionnaires/registration_submitted_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Questionnaires::RegistrationSubmitted do
+  subject(:form) { described_class.new(wizard:) }
+
+  let(:session) { {} }
+  let(:request) { ActionController::TestRequest.new({}, session, ApplicationController) }
+  let(:wizard) { RegistrationWizard.new(current_step: :registration_submitted, store: {}, request:, current_user: nil) }
+
+  describe "#previous_step" do
+    it { expect(form.previous_step).to be_nil }
+  end
+
+  describe "#next_step" do
+    it { expect(form.next_step).to be_nil }
+  end
+
+  describe "#last_step?" do
+    it { expect(form).to be_last_step }
+  end
+
+  describe "#requirements_met?" do
+    it { expect(form).to be_requirements_met }
+  end
+
+  describe "#after_save" do
+    it "flags the TRA login to be cleared" do
+      expect { form.after_save }.to change { session["clear_tra_login"] }.from(nil).to(true)
+    end
+  end
+end

--- a/spec/support/helpers/journey_assertion_helper.rb
+++ b/spec/support/helpers/journey_assertion_helper.rb
@@ -31,10 +31,10 @@ module Helpers
     end
 
     def expect_applicant_reached_end_of_journey(total_number_of_created_applications: 1)
-      expect_page_to_have(path: "/applications/#{latest_application.reload.ecf_id}", submit_form: false) do
-        expect(page).to have_content("Registration successfully submitted")
-        expect(page).to have_text("Registration successfully submitted")
-        expect(page).to have_text("Application ID: #{latest_application.ecf_id}")
+      expect_page_to_have(path: "/registration/registration-submitted") do
+        expect(page).to have_text("Registration submitted")
+        expect(page).to have_text("We will notify your training provider of your registration")
+        expect(page).to have_link("View your registration details", href: application_path(latest_application.ecf_id))
       end
 
       expect(User.count).to be(1)


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#389

Add in a "registration submitted" page after "check answers"

### Changes proposed in this pull request

- Alter wizard & controller to add new "registration submitted" step
- Ensure that going "back" after the "check answers" page is not allowed after submission
- Add new step form & html
