### PR TITLE
Change course name for registration

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -781,12 +781,12 @@ en:
       show:
   course:
     embedded_sentence:
-      default: the %{course_name} TTE
-      title: "%{course_name} TTE"
+      default: the %{course_name}
+      title: "%{course_name}"
     short_code:
       tte-early-years: TTEEY
     name:
-      tte-early-years: Early Years
+      tte-early-years: Excellence in Reception Teaching
     outcome:
       passed_html: <a href="/certificates" class="govuk-link">Download your certificate</a>
   funding_details:

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Happy journeys", :with_default_lead_provider, :with_default_sched
       expect_check_answers_page_to_have_answers(
         {
           "Course start" => "In #{application_course_start_date}",
-          "Course" => "Early Years",
+          "Course" => "Excellence in Reception Teaching",
           "Provider" => LeadProvider.first.name,
           "Workplace" => "open manchester school – street 1, manchester",
           "Work setting" => "State-funded nursery, pre-school, school or academy trust",
@@ -86,7 +86,7 @@ RSpec.feature "Happy journeys", :with_default_lead_provider, :with_default_sched
     if User.last.applications.count == 1
       navigate_to_page(path: "/applications/#{User.last.applications.last.ecf_id}", submit_form: false) do
         expect(page).to have_text(LeadProvider.first.name)
-        expect(page).to have_text("Early Years")
+        expect(page).to have_text("Excellence in Reception Teaching")
       end
     else
       navigate_to_page(path: "/applications", submit_form: false) do

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature "Happy journeys", :with_default_lead_provider, :with_default_sched
     else
       navigate_to_page(path: "/applications", submit_form: false) do
         expect(page).to have_text(LeadProvider.first.name)
-        expect(page).to have_text("Early Years")
+        expect(page).to have_text("Excellence in Reception Teaching")
       end
     end
 

--- a/spec/jobs/emails/send_application_submission_email_job_spec.rb
+++ b/spec/jobs/emails/send_application_submission_email_job_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Emails::SendApplicationSubmissionEmailJob, type: :job do
         to: application.user.email,
         full_name: application.user.full_name,
         provider_name: application.lead_provider.name,
-        course_name: "the Early Years TTE",
+        course_name: "the Excellence in Reception Teaching",
         ecf_id: application.ecf_id,
       )
 


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#467

For the assessment we'd like to change the course name to "Excellence in Reception Teaching".

### Changes proposed in this pull request

Update the locale file, factories, seeds and specs
