### PR TITLE
Fix translation errors

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -86,7 +86,7 @@ module API
 
       errors = [{
         title: "Participant ID has been changed",
-        detail: I18n.t("participant_id.changed", **participant_id_change.i18n_params),
+        detail: I18n.t("participant_id_changed", **participant_id_change.i18n_params),
         participant_id_changes: [API::ParticipantIdChangeSerializer.render_as_hash(participant_id_change)],
       }]
 

--- a/app/controllers/applications/change_provider/start_controller.rb
+++ b/app/controllers/applications/change_provider/start_controller.rb
@@ -2,13 +2,12 @@ module Applications
   module ChangeProvider
     class StartController < ::Applications::ApplicationsController
       include MultiStepFormSession
+      before_action :ensure_can_change_provider
 
       before_action :set_form
       storing_form_session_as :change_provider
 
-      def index
-        redirect_to application_path(application.ecf_id) unless application.can_change_provider?
-      end
+      def index; end
 
       def create
         render :index, status: :unprocessable_content and return unless @form.valid?
@@ -23,6 +22,10 @@ module Applications
       end
 
     private
+
+      def ensure_can_change_provider
+        redirect_to application_path(application.ecf_id) unless application.can_change_provider?
+      end
 
       def set_form
         @form = Applications::ChangeProvider::StartForm.new(form_params)

--- a/app/forms/applications/change_provider/start_form.rb
+++ b/app/forms/applications/change_provider/start_form.rb
@@ -22,10 +22,7 @@ module Applications
       end
 
       def confirmation_blank_message
-        I18n.t(
-          "applications.change_provider.start.application_#{application.status}.form.blank",
-          default: I18n.t("applications.change_provider.start.form.blank"),
-        )
+        I18n.t("applications.change_provider.start.application_#{application.status}.form.blank")
       end
     end
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -463,7 +463,7 @@ en:
             status:
               unchanged: Status must be different
         applications/change_funding_eligibility:
-          <<: *shared_change_funding_eligibility        
+          <<: *shared_change_funding_eligibility
         applications/revert_to_pending:
           attributes:
             change_status_to_pending:
@@ -493,7 +493,7 @@ en:
             provider_must_be_different: Application has {lead_provider_name} already as provider
             previously_changed_to_provider: Application has previously had {lead_provider_name} as provider
           attributes:
-            application_cannot_change_provider: Application status must be pending or accepted to change provider              
+            application_cannot_change_provider: Application status must be pending or accepted to change provider
         eligibility_lists/update:
           attributes:
             file:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
   cannot_create_completed_declaration: Could not create completed declaration. Contact the DfE for support.
   application_not_updateable: Application is no longer updateable
   application_not_found: Application could not be found
-
+  participant_id_changed: "The participant_id '%{from_participant_id}' has been replaced with '%{to_participant_id}'."
   errors:
     email: &email
       invalid: Enter an email address in the correct format, like name@example.com
@@ -25,6 +25,8 @@ en:
       blank: Enter an ECF ID
       taken: ECF ID must be unique
     attributes:
+      statement:
+        must_be_output_fee_true: Statement must have output fee
       trn:
         invalid: TRN must only contain numbers
         blank: TRN can't be blank
@@ -111,6 +113,8 @@ en:
           blank: Please select a provider
           different_provider: Please choose a different provider to your current provider
       check_answers:
+        fail:
+          title: We encountered an error whilst changing provider
         title: Check your answer and submit
         new_provider: Provider
         success:
@@ -454,8 +458,12 @@ en:
               <<: *application
         admin/applications/change_funding_eligibility_form:
           <<: *shared_change_funding_eligibility
+        admin/applications/change_status_form:
+          attributes:
+            status:
+              unchanged: Status must be different
         applications/change_funding_eligibility:
-          <<: *shared_change_funding_eligibility
+          <<: *shared_change_funding_eligibility        
         applications/revert_to_pending:
           attributes:
             change_status_to_pending:
@@ -478,12 +486,14 @@ en:
               declarations_present: Cannot change cohort for an application with declarations
             application:
               <<: *application
+            course_cohort:
+              not_found: Course cohort cannot be found
         applications/change_lead_provider:
           base:
             provider_must_be_different: Application has {lead_provider_name} already as provider
             previously_changed_to_provider: Application has previously had {lead_provider_name} as provider
           attributes:
-            application_cannot_change_provider: Application status must be pending or accepted to change provider
+            application_cannot_change_provider: Application status must be pending or accepted to change provider              
         eligibility_lists/update:
           attributes:
             file:

--- a/spec/factories/course_cohorts.rb
+++ b/spec/factories/course_cohorts.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :course_cohort do
-    course
+    association :course, factory: :"tte-early-years"
     cohort
 
     schedule do

--- a/spec/requests/applications/change_provider/start_spec.rb
+++ b/spec/requests/applications/change_provider/start_spec.rb
@@ -57,10 +57,7 @@ RSpec.describe "Applications::ChangeProvider::Start", type: :request do
 
       it "redirects to the application page" do
         post url, params: { form: { confirmation: "1" } }
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(response).to render_template(:index)
-        expect(assigns[:form]).not_to be_nil
-        expect(assigns[:form].errors[:cannot_change_provider]).to eq([I18n.t("applications.change_provider.start.form.cannot_change_provider")])
+        expect(response).to redirect_to(application_path(application.ecf_id))
       end
     end
   end

--- a/spec/support/shared_examples/participant_id_change_support.rb
+++ b/spec/support/shared_examples/participant_id_change_support.rb
@@ -19,7 +19,7 @@ RSpec.shared_examples "an API endpoint that checks participant_id change" do
     expect(parsed_response["errors"]).to eq([
       {
         "title" => "Participant ID has been changed",
-        "detail" => I18n.t("participant_id.changed", **participant_id_change.i18n_params),
+        "detail" => I18n.t("participant_id_changed", **participant_id_change.i18n_params),
         "participant_id_changes" => [
           {
             "from_participant_id" => participant_id_change.from_participant_id,


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#469

We're not raising errors in test rails env when translations are missing.
This fixes that, and the specs which were consequently failing.

### Changes proposed in this pull request

- Add missing translations to en.yml
- Fix specs
