### PR TITLE
Change course name to reflect NPD naming

### DIFF
--- a/app/jobs/crons/send_deferral_expiring_notification_emails_job.rb
+++ b/app/jobs/crons/send_deferral_expiring_notification_emails_job.rb
@@ -13,7 +13,7 @@ class Crons::SendDeferralExpiringNotificationEmailsJob < CronJob
       GenericMailer.with(
         to: application.user.email,
         full_name: application.user.full_name,
-        course_name: application.course.title_embedded_course_name,
+        course_name: application.course.name,
         deferral_date: application.deferred_at.to_fs(:govuk_date_only),
         ecf_id: application.ecf_id,
       ).deferral_expiring_notification.deliver_later

--- a/app/jobs/crons/send_registration_open_notification_emails_job.rb
+++ b/app/jobs/crons/send_registration_open_notification_emails_job.rb
@@ -13,7 +13,7 @@ class Crons::SendRegistrationOpenNotificationEmailsJob < CronJob
         GenericMailer.with(
           to: application.user.email,
           full_name: application.user.full_name,
-          course_name: application.course.title_embedded_course_name,
+          course_name: application.course.name,
           next_course_start_date: cohort.registration_starts_at.to_fs(:govuk),
           deferral_date: application.deferred_at.to_fs(:govuk_date_only),
           ecf_id: application.ecf_id,

--- a/app/jobs/emails/send_application_submission_email_job.rb
+++ b/app/jobs/emails/send_application_submission_email_job.rb
@@ -7,7 +7,7 @@ module Emails
         to: application.user.email,
         full_name: application.user.full_name,
         provider_name: application.lead_provider.name,
-        course_name: application.course.localise_sentence_embedded_course_name,
+        course_name: application.course.name,
         amount: application.raw_application_data["funding_amount"],
         ecf_id: application.ecf_id,
       ).application_submitted.deliver_now

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -13,39 +13,15 @@ class Course < ApplicationRecord
   scope :displayable, -> { where(display: true).order(:position) }
 
   IDENTIFIERS = %w[tte-early-years].freeze
+  # IDENTIFIERS = %w[npd-excellence-in-reception-teaching].freeze
 
   def self.reception
+    # Change this once we have sign-off from lead providers to change the identifier
+    # find_by(identifier: "npd-excellence-in-reception-teaching")
     find_by(identifier: "tte-early-years")
-  end
-
-  def course_short_code
-    I18n.t(identifier, scope: "course.short_code")
-  end
-
-  def localise_course_name
-    I18n.t(identifier, scope: "course.name")
-  end
-
-  # Returns either "the #{course_name} TTE"
-  def localise_sentence_embedded_course_name
-    I18n.t("course.embedded_sentence.default", course_name: localise_course_name)
   end
 
   def rebranded_alternative_courses
     [self]
-  end
-
-  def short_code
-    super.tap do |sc|
-      if sc.nil?
-        message = "A course short-code types mapping is missing: #{identifier}"
-        Rails.logger.warn(message)
-        Sentry.capture_message(message)
-      end
-    end
-  end
-
-  def title_embedded_course_name
-    I18n.t("course.embedded_sentence.title", course_name: localise_course_name)
   end
 end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -91,7 +91,7 @@ class RegistrationWizard
     array = []
 
     array << Answer.new("Course start", store["course_start"], :course_start_date)
-    array << Answer.new("Course", I18n.t(course.identifier, scope: "course.name"), :choose_your_course)
+    array << Answer.new("Course", course.name, :choose_your_course)
     array << Answer.new("Provider", lead_provider&.name, :choose_your_provider)
     array << Answer.new("Workplace in England", teacher_catchment_humanized, :teacher_catchment)
     array << Answer.new("Work setting", t("work_setting"), :work_setting)

--- a/app/services/applications/defer.rb
+++ b/app/services/applications/defer.rb
@@ -37,7 +37,7 @@ module Applications
         to: @application.user.email,
         full_name: @application.user.full_name,
         provider_name: @application.lead_provider.name,
-        course_name: @application.course.title_embedded_course_name,
+        course_name: @application.course.name,
         deferral_date: @application.deferred_at.to_fs(:govuk_date_only),
         ecf_id: @application.ecf_id,
       ).deferral_notification.deliver_later

--- a/app/services/applications/reject.rb
+++ b/app/services/applications/reject.rb
@@ -35,7 +35,7 @@ module Applications
         to: application.user.email,
         full_name: application.user.full_name,
         provider_name: application.lead_provider.name,
-        course_name: application.course.title_embedded_course_name,
+        course_name: application.course.name,
         cohort_date: application.cohort.name,
         sign_in_link: Rails.configuration.sign_in_link,
         ecf_id: application.ecf_id,

--- a/app/services/funding_eligibility.rb
+++ b/app/services/funding_eligibility.rb
@@ -60,9 +60,7 @@ class FundingEligibility
 
   def get_description_for_funding_status
     key = FUNDING_STATUS_CODE_DESCRIPTIONS.fetch(funding_eligiblity_status_code)
-    course_name = course.localise_sentence_embedded_course_name
-
-    I18n.t(key, course_name:).html_safe if key
+    I18n.t(key, course_name: course.name).html_safe if key
   end
 
 private

--- a/app/views/applications/applications/_active_application_table.html.erb
+++ b/app/views/applications/applications/_active_application_table.html.erb
@@ -1,7 +1,7 @@
 <%=
   govuk_summary_list(
     card: {
-      title: application.course.title_embedded_course_name,
+      title: application.course.name,
       actions: [govuk_link_to("View details", application_path(application.ecf_id))],
     },
   ) do |sl|

--- a/app/views/applications/applications/_course_details.html.erb
+++ b/app/views/applications/applications/_course_details.html.erb
@@ -2,7 +2,7 @@
   govuk_summary_list(card: { title: "Course details" }) do |sl|
     sl.with_row do |row|
       row.with_key(text: "Course")
-      row.with_value(text: application.course.title_embedded_course_name)
+      row.with_value(text: application.course.name)
     end
 
     sl.with_row do |row|

--- a/app/views/applications/applications/_expired_application_table.html.erb
+++ b/app/views/applications/applications/_expired_application_table.html.erb
@@ -1,5 +1,5 @@
 <%=
-  govuk_summary_list(card: { title: application.course.title_embedded_course_name }) do |sl|
+  govuk_summary_list(card: { title: application.course.name }) do |sl|
     sl.with_row do |row|
       row.with_key(text: "Provider")
       row.with_value(text: application.lead_provider.name)

--- a/app/views/applications/applications/show.html.erb
+++ b/app/views/applications/applications/show.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 <% end %>
 <span class="govuk-caption-m">Submitted <%= application.created_at.to_date.to_fs(:govuk_short) %></span>
-<h1 class="govuk-heading-xl">Your <%= application.course.title_embedded_course_name %> registration</h1>
+<h1 class="govuk-heading-xl">Your <%= application.course.name %> registration</h1>
 
 <p class="govuk-body"><strong>Application ID:</strong> <%= application.ecf_id %></p>
 

--- a/app/views/registration_wizard/possible_funding/_eligible_for_scholarship_funding.html.erb
+++ b/app/views/registration_wizard/possible_funding/_eligible_for_scholarship_funding.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-xl">Funding</h1>
 
-<p class="govuk-body">You’re eligible for scholarship funding for <%= course.localise_sentence_embedded_course_name %>, but this does not guarantee a funded place is available.</p>
+<p class="govuk-body">You’re eligible for scholarship funding for <%= course.name %>, but this does not guarantee a funded place is available.</p>
 
 <p class="govuk-body">Your provider must confirm they can offer you a funded place, after you apply to them.</p>

--- a/app/views/registration_wizard/possible_funding/_eligible_for_scholarship_funding_not_tsf.html.erb
+++ b/app/views/registration_wizard/possible_funding/_eligible_for_scholarship_funding_not_tsf.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-xl">Funding</h1>
 
-<p class="govuk-body">You’re eligible for scholarship funding for <%= course.localise_sentence_embedded_course_name %>, but this does not guarantee a funded place is available.</p>
+<p class="govuk-body">You’re eligible for scholarship funding for <%= course.name %>, but this does not guarantee a funded place is available.</p>
 
 <p class="govuk-body">Your provider must confirm they can offer you a funded place, after you apply to them.</p>

--- a/app/views/registration_wizard/possible_funding/_lead_mentor.html.erb
+++ b/app/views/registration_wizard/possible_funding/_lead_mentor.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-xl">Funding</h1>
 
-<p class="govuk-body">You’re eligible for scholarship funding for <%= course.localise_sentence_embedded_course_name %>, but this does not guarantee a funded place is available.</p>
+<p class="govuk-body">You’re eligible for scholarship funding for <%= course.name %>, but this does not guarantee a funded place is available.</p>
 
 <p class="govuk-body">Your provider must confirm they can offer you a funded place, after you apply to them.</p>

--- a/app/views/registration_wizard/possible_funding/_private_childcare_provider.html.erb
+++ b/app/views/registration_wizard/possible_funding/_private_childcare_provider.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-xl">Funding</h1>
 
-<p class="govuk-body">You’re eligible for scholarship funding for <%= course.localise_sentence_embedded_course_name %>, but this does not guarantee a funded place is available.</p>
+<p class="govuk-body">You’re eligible for scholarship funding for <%= course.name %>, but this does not guarantee a funded place is available.</p>
 
 <p class="govuk-body">Your provider must confirm they can offer you a funded place, after you apply to them.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -789,14 +789,6 @@ en:
       show:
     users:
       show:
-  course:
-    embedded_sentence:
-      default: the %{course_name}
-      title: "%{course_name}"
-    short_code:
-      tte-early-years: TTEEY
-    name:
-      tte-early-years: Excellence in Reception Teaching
     outcome:
       passed_html: <a href="/certificates" class="govuk-link">Download your certificate</a>
   funding_details:

--- a/db/seeds/base/add_courses.rb
+++ b/db/seeds/base/add_courses.rb
@@ -1,9 +1,10 @@
 course = Course.find_or_initialize_by(ecf_id: "7fbefdd4-dd2d-4a4f-8995-d59e525124b7")
 course.update!(
-  name: "TTE Early Years",
+  name: "Excellence in Reception Teaching",
   ecf_id: "7fbefdd4-dd2d-4a4f-8995-d59e525124b7",
+  # identifier: "npd-excellence-in-reception-teaching",
   identifier: "tte-early-years",
   course_group: "reception",
-  description: "The Early Years development TTE course is aimed at teachers who have completed their induction and are currently teaching reception age children, or plan to in the future.",
-  short_code: "TTEEY",
+  description: "The Excellence in Reception Teaching course is aimed at teachers who have completed their induction and are currently teaching reception age children, or plan to in the future.",
+  short_code: "NPDEIRT",
 )

--- a/spec/components/admin/course_payment_overview_component_spec.rb
+++ b/spec/components/admin/course_payment_overview_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Admin::CoursePaymentOverviewComponent, :revisit, type: :component
   let(:calculator) { ::Statements::CourseCalculator.new(contract:) }
   let(:statement) { create(:statement) }
   let(:paid_statement) { create(:statement, :paid) }
-  let(:course) { create(:course, :tte_early_years) }
+  let(:course) { create(:course, :npd_eirt) }
   let(:contract) { create(:contract, course:, statement:) }
 
   before do

--- a/spec/components/application_tally_component_spec.rb
+++ b/spec/components/application_tally_component_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe ApplicationTallyComponent, type: :component do
   let(:cohort) { create(:cohort, :current) }
   let(:course_cohort1) { create :course_cohort, cohort:, course: course_1 }
   let(:course_cohort2) { create :course_cohort, cohort:, course: course_2 }
-  let(:course_1) { create :course, :tte_early_years }
-  let(:course_2) { create :course }
+  let(:course_1) { create :course, name: "Course 1" }
+  let(:course_2) { create :course, name: "Course 2" }
 
   before do
     create(:application, course_cohort: course_cohort1)
@@ -21,8 +21,8 @@ RSpec.describe ApplicationTallyComponent, type: :component do
 
   it "returns the correct rows" do
     expect(subject.rows).to eq([
-      [course_2.name, 1],
       [course_1.name, 2],
+      [course_2.name, 1],
     ])
   end
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :course do
-    sequence(:name) { |n| "TTE Course #{n}" }
+    sequence(:name) { |n| "NPD Course #{n}" }
     sequence(:identifier) { |n| "identifier-#{n}" }
     ecf_id { SecureRandom.uuid }
     course_group { "reception" }
@@ -9,14 +9,17 @@ FactoryBot.define do
       Course.find_by(identifier:) || new(**attributes)
     end
 
-    trait :tte_early_years do
-      sequence(:name) { |n| "TTE Early Years Course #{n}" }
+    trait :npd_eirt do
+      sequence(:name) { |n| "Excellence in Reception Teaching #{n}" }
+      # identifier { "npd-excellence-in-reception-teaching" }
       identifier { "tte-early-years" }
       course_group { "reception" }
-      short_code { "TTEEY" }
+      short_code { "NPDEIRT" }
     end
 
-    factory :"tte-early-years", traits: [:tte_early_years]
+    factory :"npd-excellence-in-reception-teaching", traits: [:npd_eirt]
+    factory :"npd-eirt", traits: [:npd_eirt]
+    factory :"tte-early-years", traits: [:npd_eirt]
 
     transient do
       lead_provider { nil }

--- a/spec/features/admin/courses_spec.rb
+++ b/spec/features/admin/courses_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Listing and viewing courses", type: :feature do
   let(:courses_per_page) { Pagy::DEFAULT[:limit] }
 
   before do
-    create(:course, :tte_early_years)
+    create(:course, :npd_eirt)
     sign_in_as(create(:admin))
   end
 

--- a/spec/features/admin/finance/statement_payment_spec.rb
+++ b/spec/features/admin/finance/statement_payment_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Statement payment", :revisit, type: :feature do
   before do
     create(:declaration, :payable, statement:)
     # contracts needed to test queries in summary calculator are optimised
-    create(:contract, course: create(:course, :tte_early_years), statement:)
+    create(:contract, course: create(:course, :npd_eirt), statement:)
     statement.update!(state: "payable", deadline_date: Time.zone.yesterday)
     sign_in_as(create(:admin))
     visit(admin_finance_statement_path(statement))

--- a/spec/features/admin/finance/statement_spec.rb
+++ b/spec/features/admin/finance/statement_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Statement", :revisit, type: :feature do
 
   let!(:contracts) do
     [
-      create(:contract, course: create(:course, :tte_early_years), statement:),
+      create(:contract, course: create(:course, :npd_eirt), statement:),
     ]
   end
 

--- a/spec/features/admin/schedules_spec.rb
+++ b/spec/features/admin/schedules_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Managing schedules", :ecf_api_disabled, :no_js, :revisit, type: :
   end
 
   before do
-    create(:application, :accepted, schedule: schedules[1], cohort:, course: create(:course, :tte_early_years))
+    create(:application, :accepted, schedule: schedules[1], cohort:, course: create(:course, :npd_eirt))
     sign_in_as admin
   end
 

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "User administration", type: :feature do
     end
 
     scenario "shows a summary of each user application" do
-      applications = %i[tte_early_years]
+      applications = %i[npd_eirt]
         .map { create(:application, user:, course: create(:course, _1)) }
         .sort_by { [_1.created_at, _1.id] }
 

--- a/spec/features/audit_trail_spec.rb
+++ b/spec/features/audit_trail_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Recording audit trail via papertrail", :revisit, :versioning, typ
     end
 
     let(:raw_token) { "a-token" }
-    let(:course) { create(:course, :tte_early_years) }
+    let(:course) { create(:course, :npd_eirt) }
     let(:lead_provider) { create :lead_provider }
     let(:application) { create :application, lead_provider:, course:, cohort: }
 

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Happy journeys", :with_default_lead_provider, :with_default_sched
       expect_check_answers_page_to_have_answers(
         {
           "Course start" => "In #{application_course_start_date}",
-          "Course" => "Excellence in Reception Teaching",
+          "Course" => Course.last.name,
           "Provider" => LeadProvider.first.name,
           "Workplace" => "open manchester school – street 1, manchester",
           "Work setting" => "State-funded nursery, pre-school, school or academy trust",

--- a/spec/forms/questionnaires/choose_school_spec.rb
+++ b/spec/forms/questionnaires/choose_school_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Questionnaires::ChooseSchool, type: :model do
     let(:wizard) do
       RegistrationWizard.new(current_step:, store:, request:, current_user: create(:user))
     end
-    let(:course) { build_stubbed(:course, :tte_early_years) }
+    let(:course) { build_stubbed(:course, :npd_eirt) }
     let(:store) do
       {
         "course_identifier" => course.identifier.to_s,

--- a/spec/forms/questionnaires/choose_your_provider_spec.rb
+++ b/spec/forms/questionnaires/choose_your_provider_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
   let!(:cohort) { create(:cohort, :current) }
   let!(:lead_provider) { create(:lead_provider) }
-  let!(:course) { create(:course, :tte_early_years, lead_provider:) }
+  let!(:course) { create(:course, :npd_eirt, lead_provider:) }
 
   before { create(:course_cohort, course:, cohort:, lead_provider:) }
 

--- a/spec/forms/questionnaires/possible_funding_spec.rb
+++ b/spec/forms/questionnaires/possible_funding_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Questionnaires::PossibleFunding do
   end
 
   describe "#course" do
-    let!(:course) { create(:course, :tte_early_years) }
+    let!(:course) { create(:course, :npd_eirt) }
     let(:request) { nil }
 
     before do

--- a/spec/jobs/emails/send_application_submission_email_job_spec.rb
+++ b/spec/jobs/emails/send_application_submission_email_job_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Emails::SendApplicationSubmissionEmailJob, type: :job do
-  let(:course) { create(:course, :tte_early_years) }
+  let(:course) { create(:course, :npd_eirt) }
   let(:application) { create(:application, course:, raw_application_data: { "funding_amount" => "123" }) }
 
   subject(:job) { described_class.new(application:) }
@@ -17,7 +17,7 @@ RSpec.describe Emails::SendApplicationSubmissionEmailJob, type: :job do
         to: application.user.email,
         full_name: application.user.full_name,
         provider_name: application.lead_provider.name,
-        course_name: "the Excellence in Reception Teaching",
+        course_name: course.name,
         ecf_id: application.ecf_id,
       )
 

--- a/spec/lib/tasks/participant_outcome_spec.rb
+++ b/spec/lib/tasks/participant_outcome_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "particpant_outcome", :npq do
 
     let(:user) { create(:user) }
     let(:lead_provider) { create(:lead_provider) }
-    let(:course) { create(:course, :tte_early_years) }
+    let(:course) { create(:course, :npd_eirt) }
     let(:completion_date) { Date.new(2025, 8, 1).as_json }
     let(:application) { create(:application, :accepted, user:, course:, lead_provider:) }
     let(:declaration) { create(:declaration, :completed, user:, lead_provider:, course:, application:) }

--- a/spec/lib/tasks/update_application_spec.rb
+++ b/spec/lib/tasks/update_application_spec.rb
@@ -221,8 +221,8 @@ RSpec.describe "update_application", :revisit do
     let(:cohort) { create(:cohort, :current) }
     let(:schedule) { Schedule.where(cohort:, course_group: course.course_group).last }
     let(:application) { create(:application, course:, cohort:, schedule:) }
-    let(:course) { create(:course, :tte_early_years) }
-    let(:new_course) { create(:course, :tte_early_years) }
+    let(:course) { create(:course, :npd_eirt) }
+    let(:new_course) { create(:course, :npd_eirt) }
 
     it "updates the course of the application" do
       run_task

--- a/spec/mailers/previews/generic_mailer_preview.rb
+++ b/spec/mailers/previews/generic_mailer_preview.rb
@@ -4,7 +4,7 @@ class GenericMailerPreview < ActionMailer::Preview
       to: "test@example.com",
       full_name: "Jane Smith",
       provider_name: "Ambition Institute",
-      course_name: "TTE Course",
+      course_name: "NPD Course",
       amount: "£1,200",
       ecf_id: "abc-123-def-456",
     ).application_submitted
@@ -34,7 +34,7 @@ class GenericMailerPreview < ActionMailer::Preview
     GenericMailer.with(
       to: "test@example.com",
       full_name: "Jane Smith",
-      course_name: "Early Years TTE",
+      course_name: "Excellence in Reception Teaching",
       deferral_date: 11.months.ago.to_fs(:govuk_date_only),
       ecf_id: "abc-123-def-456",
     ).deferral_expiring_notification
@@ -45,7 +45,7 @@ class GenericMailerPreview < ActionMailer::Preview
       to: "test@example.com",
       full_name: "Jane Smith",
       provider_name: "Ambition Institute",
-      course_name: "Early Years TTE",
+      course_name: "Excellence in Reception Teaching",
       deferral_date: Date.current.to_fs(:govuk),
       ecf_id: "abc-123-def-456",
     ).deferral_notification
@@ -73,7 +73,7 @@ class GenericMailerPreview < ActionMailer::Preview
     GenericMailer.with(
       to: "test@example.com",
       full_name: "Jane Smith",
-      course_name: "Early Years TTE",
+      course_name: "Excellence in Reception Teaching",
       next_course_start_date: Date.current.to_fs(:govuk),
       deferral_date: 3.months.ago.to_fs(:govuk_date_only),
       ecf_id: "abc-123-def-456",
@@ -84,7 +84,7 @@ class GenericMailerPreview < ActionMailer::Preview
     GenericMailer.with(
       to: "test@example.com",
       full_name: "Jane Smith",
-      course_name: "Early Years TTE",
+      course_name: "Excellence in Reception Teaching",
       provider_name: "Ambition Institute",
       cohort_date: "Autumn 2026",
       sign_in_link: "https://signin.service.gov.uk",

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -8,27 +8,4 @@ RSpec.describe Course do
     it { is_expected.to validate_uniqueness_of(:identifier).with_message("Identifier already exists, enter a unique one") }
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
   end
-
-  describe "#short_code" do
-    let(:course) { create(:course, :tte_early_years) }
-
-    it "returns the short code" do
-      expect(course.short_code).to eq("TTEEY")
-    end
-
-    context "when a NPQ course short code is missing from the mapping" do
-      let(:course) { create(:course, identifier: "npq-anything") }
-
-      it "logs an error" do
-        expect(Rails.logger).to receive(:warn)
-        expect(Sentry).to receive(:capture_message)
-
-        course.short_code
-      end
-
-      it "returns nil" do
-        expect(course.short_code).to be_nil
-      end
-    end
-  end
 end

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -740,7 +740,7 @@ RSpec.describe Declaration, type: :model do
 
   describe "#duplicate_declarations" do
     let(:cohort) { create(:cohort, :current) }
-    let(:course) { create(:course, :tte_early_years) }
+    let(:course) { create(:course, :npd_eirt) }
     let(:schedule) { create(:schedule, :npq_leadership_autumn, cohort:) }
     let(:application) { create(:application, :accepted, cohort:, course:) }
     let(:participant) { application.user }
@@ -761,7 +761,7 @@ RSpec.describe Declaration, type: :model do
 
         context "when declarations have been made for a different course", :npq do
           before do
-            course = create(:course, :tte_early_years)
+            course = create(:course, :npd_eirt)
             other_application = create(:application, :accepted, course:, cohort:, user: other_user)
             create(:declaration, application: other_application)
           end
@@ -805,7 +805,7 @@ RSpec.describe Declaration, type: :model do
 
     context "when declarations have been made for a different course", :npq do
       before do
-        course = create(:course, :tte_early_years)
+        course = create(:course, :npd_eirt)
         other_application = create(:application, :accepted, course:, cohort:, user: participant)
         create(:declaration, application: other_application)
       end

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RegistrationWizard do
   let(:user) { create(:user) }
   let(:current_step) { "share_provider" }
 
-  before { create(:course, :tte_early_years) }
+  before { create(:course, :npd_eirt) }
 
   describe "#current_step" do
     it "returns current step" do

--- a/spec/requests/api/docs/v1/applications_spec.rb
+++ b/spec/requests/api/docs/v1/applications_spec.rb
@@ -3,7 +3,7 @@ require "swagger_helper"
 
 RSpec.describe "Applications endpoint", openapi_spec: "v1/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
-  let(:course) { create(:course, :tte_early_years) }
+  let(:course) { create(:course, :npd_eirt) }
   let(:schedule) { create(:schedule, :tte_reception_autumn) }
   let(:course_cohort) { create(:course_cohort, course:, schedule:) }
   let(:application) { create(:application, lead_provider:, course_cohort:) }

--- a/spec/requests/api/docs/v1/declarations_spec.rb
+++ b/spec/requests/api/docs/v1/declarations_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Declarations endpoint", openapi_spec: "v1/swagger.yaml", type: :
       end
       let(:lead_provider) { create(:lead_provider) }
       let(:cohort) { create(:cohort, :current) }
-      let(:course_cohort) { create(:course_cohort, cohort:, course: create(:course, :tte_early_years)) }
+      let(:course_cohort) { create(:course_cohort, cohort:, course: create(:course, :npd_eirt)) }
       let(:application) { create(:application, :accepted, course_cohort:) }
       let(:delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
       let(:secondary_delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }

--- a/spec/requests/api/docs/v1/participant_outcomes_spec.rb
+++ b/spec/requests/api/docs/v1/participant_outcomes_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Participant Outcomes endpoint", openapi_spec: "v1/swagger.yaml",
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "reception") || create(:course_group, name: "reception") }
-  let(:course) { create(:course, :tte_early_years) }
+  let(:course) { create(:course, :npd_eirt) }
   let(:schedule) { create(:schedule, :tte_reception_autumn, cohort:) }
   let(:cohort) { create(:cohort, :current, funding_cap: true) }
   let(:application) do

--- a/spec/requests/api/docs/v1/participants/outcomes_spec.rb
+++ b/spec/requests/api/docs/v1/participants/outcomes_spec.rb
@@ -4,7 +4,7 @@ require "swagger_helper"
 RSpec.describe "Participant Outcomes endpoint", :npq, openapi_spec: "v1/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
-  let(:course) { create(:course, :tte_early_years) }
+  let(:course) { create(:course, :npd_eirt) }
   let(:schedule) { create(:schedule, :tte_reception_autumn, cohort:) }
   let(:cohort) { create(:cohort, :current, funding_cap: true) }
   let(:application) do

--- a/spec/requests/api/docs/v1/participants_spec.rb
+++ b/spec/requests/api/docs/v1/participants_spec.rb
@@ -4,7 +4,7 @@ require "swagger_helper"
 RSpec.describe "Participants endpoint", openapi_spec: "v1/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
-  let(:course) { create(:course, :tte_early_years) }
+  let(:course) { create(:course, :npd_eirt) }
   let(:cohort) { create(:cohort, :current) }
   let(:schedule) { create(:schedule, :tte_reception_autumn, cohort:) }
   let(:user) { create(:user, :with_verified_trn) }

--- a/spec/requests/api/v1/schedules_spec.rb
+++ b/spec/requests/api/v1/schedules_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Schedule endpoints", type: :request do
 
   describe "GET /api/v1/schedules" do
     let(:cohort) { create(:cohort, :current) }
-    let(:course) { create(:course, :tte_early_years) }
+    let(:course) { create(:course, :npd_eirt) }
     let(:schedule) { create(:schedule, :tte_reception_autumn, cohort:) }
     let!(:course_cohort) { create(:course_cohort, course:, cohort:, schedule:, lead_providers: [current_lead_provider]) }
 

--- a/spec/serializers/api/application_serializer_spec.rb
+++ b/spec/serializers/api/application_serializer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe API::ApplicationSerializer, type: :serializer do
   let(:user) { application.user }
-  let(:course) { create(:course, :tte_early_years) }
+  let(:course) { create(:course, :npd_eirt) }
   let(:cohort) { create(:cohort, :current) }
   let(:schedule) { create(:schedule) }
   let(:course_cohort) { create(:course_cohort, course:, cohort:, schedule:) }

--- a/spec/services/contracts/change_per_participant_spec.rb
+++ b/spec/services/contracts/change_per_participant_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Contracts::ChangePerParticipant, type: :model do
 
   let(:lead_provider) { create(:lead_provider) }
   let(:statement) { create(:statement, lead_provider:) }
-  let(:course) { create(:course, :tte_early_years) }
+  let(:course) { create(:course, :npd_eirt) }
   let(:last_months_statement) { create(:statement, lead_provider:, for_date: 1.month.ago) }
   let!(:last_months_contract) { create(:contract, statement: last_months_statement, course:) }
   let(:this_months_statement) { create(:statement, lead_provider:, for_date: Time.zone.today) }

--- a/spec/services/declarations/change_delivery_partner_spec.rb
+++ b/spec/services/declarations/change_delivery_partner_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Declarations::ChangeDeliveryPartner, type: :model do
   let(:lead_provider) { create(:lead_provider) }
   let(:cohort) { create(:cohort, :current) }
-  let(:course_cohort) { create(:course_cohort, cohort:, course: create(:course, :tte_early_years)) }
+  let(:course_cohort) { create(:course_cohort, cohort:, course: create(:course, :npd_eirt)) }
   let(:application) { create(:application, :accepted, course_cohort:) }
   let(:delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
   let(:secondary_delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }

--- a/spec/services/exporters/contracts_spec.rb
+++ b/spec/services/exporters/contracts_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Exporters::Contracts do
   let(:lead_provider) { create(:lead_provider, name: "Some Lead Provider") }
   let(:lead_provider_2) { create(:lead_provider, name: "Another Provider") }
   let(:course) { create(:course) }
-  let(:course_2) { create(:course, :tte_early_years) }
+  let(:course_2) { create(:course, :npd_eirt) }
 
   let(:cohort) { create(:cohort, :current) }
   let(:statement) { create(:statement, cohort:, lead_provider:) }

--- a/spec/services/funding_eligibility_spec.rb
+++ b/spec/services/funding_eligibility_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe FundingEligibility do
   let(:institution) { nil }
   let(:work_setting) { nil }
   let(:kind_of_nursery) { nil }
-  let(:course) { build(:course, :tte_early_years) }
+  let(:course) { build(:course, :npd_eirt) }
   let(:query_store) { RegistrationQueryStore.new(store:) }
 
   describe "#funding_eligiblity_status_code" do

--- a/spec/services/handle_submission_for_store_spec.rb
+++ b/spec/services/handle_submission_for_store_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe HandleSubmissionForStore do
   let(:school) { create(:school, :funding_eligible_establishment_type_code) }
   let(:private_childcare_provider) { create(:private_childcare_provider, :on_early_years_register) }
   let(:cohort) { create(:cohort, :current) }
-  let(:courses) { Course.where(identifier: "tte-early-years") }
-  let(:course) { courses.sample }
+  let(:course) { Course.reception }
   let(:lead_provider) { LeadProvider.all.sample }
 
   let(:store) do
@@ -131,67 +130,6 @@ RSpec.describe HandleSubmissionForStore do
           "raw_application_data" => store.except("current_user_id"),
           "referred_by_return_to_teaching_adviser" => "no",
           "on_submission_trn" => "1234321",
-          "review_status" => nil,
-        })
-      end
-    end
-
-    context "when store includes information from the early years path", :npq do
-      let(:courses) { [Course.ehco] }
-      let(:store) do
-        {
-          "current_user_id" => user.id,
-          "course_identifier" => course.identifier,
-          "institution_id" => private_childcare_provider.institution.id,
-          "lead_provider_id" => lead_provider.id,
-          "works_in_childcare" => "yes",
-          "works_in_school" => "no",
-          "kind_of_nursery" => "private_nursery",
-          "teacher_catchment" => "england",
-          "work_setting" => "early_years_or_childcare",
-          "referred_by_return_to_teaching_adviser" => "no",
-          "on_submission_trn" => nil,
-        }
-      end
-
-      it "stores data from store" do
-        expect(stable_as_json(user.reload)).to match(expected_user_attributes)
-        expect(user.applications.reload.count).to eq 0
-        expect(stable_as_json(user.applications.last)).to match(nil)
-
-        subject.call
-
-        expect(stable_as_json(user.reload)).to match(expected_user_attributes)
-        expect(user.applications.reload.count).to eq 1
-        last_application = user.applications.last
-        expect(stable_as_json(last_application)).to match({
-          "course_cohort_id" => course_cohort.id,
-          "ecf_id" => last_application.ecf_id,
-          "eligible_for_funding" => false,
-          "funded_place" => nil,
-          "funding_choice" => nil,
-          "status" => "pending",
-          "participant_outcome_state" => nil,
-          "funding_eligiblity_status_code" => "not_new_headteacher_requesting_ehco",
-          "lead_provider_id" => lead_provider.id,
-          "notes" => nil,
-          "kind_of_nursery" => "private_nursery",
-          "institution_id" => private_childcare_provider.institution.id,
-          "targeted_support_funding_eligibility" => false,
-          "teacher_catchment" => "england",
-          "teacher_catchment_country" => "United Kingdom of Great Britain and Northern Ireland",
-          "teacher_catchment_iso_country_code" => "GBR",
-          "ukprn" => nil,
-          "number_of_pupils" => 0,
-          "primary_establishment" => false,
-          "user_id" => user.id,
-          "works_in_nursery" => nil,
-          "works_in_childcare" => true,
-          "works_in_school" => false,
-          "work_setting" => "early_years_or_childcare",
-          "raw_application_data" => store.except("current_user_id"),
-          "referred_by_return_to_teaching_adviser" => "no",
-          "on_submission_trn" => nil,
           "review_status" => nil,
         })
       end

--- a/spec/services/participant_outcomes/void_spec.rb
+++ b/spec/services/participant_outcomes/void_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ParticipantOutcomes::Void, type: :model do
-  let(:course) { create(:course, :tte_early_years) }
+  let(:course) { create(:course, :npd_eirt) }
   let(:declaration) { create(:declaration, declaration_type, :paid, course:) }
   let(:declaration_type) { :completed }
 

--- a/spec/services/statements/query_spec.rb
+++ b/spec/services/statements/query_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Statements::Query do
       before do
         create(:statement_item, statement: statement1)
         create(:statement_item, statement: statement1)
-        create(:contract, course: create(:course, :tte_early_years), statement: statement1)
+        create(:contract, course: create(:course, :npd_eirt), statement: statement1)
         create(:contract, course: create(:course), statement: statement1)
       end
 

--- a/spec/services/statements/summary_calculator_spec.rb
+++ b/spec/services/statements/summary_calculator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Statements::SummaryCalculator, :revisit do
   let(:application) { create(:application, :accepted, :eligible_for_funding, course:, lead_provider:, cohort:) }
   let(:declaration_type) { "started" }
 
-  let!(:course) { create(:course, :tte_early_years) }
+  let!(:course) { create(:course, :npd_eirt) }
   let!(:contract) { create(:contract, course:, statement:) }
   let(:contract_template_monthly_service_fee) { nil }
 

--- a/spec/services/valid_test_data_generators/applications_populater_spec.rb
+++ b/spec/services/valid_test_data_generators/applications_populater_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ValidTestDataGenerators::ApplicationsPopulater, :revisit, :with_d
   let(:cohort) { create(:cohort, :current) }
 
   before do
-    create(:course, :tte_early_years)
+    create(:course, :npd_eirt)
     allow(Rails).to receive(:env) { environment.inquiry }
   end
 

--- a/spec/support/helpers/bulk_operations.rb
+++ b/spec/support/helpers/bulk_operations.rb
@@ -15,7 +15,7 @@ module Helpers
     def declarations_file
       @declarations_file ||= begin
         cohort = Cohort.current
-        course = create(:course, :tte_early_years)
+        course = create(:course, :npd_eirt)
 
         lead_provider = create(:lead_provider)
         delivery_partner = create(:delivery_partner)

--- a/spec/support/helpers/statements_helper.rb
+++ b/spec/support/helpers/statements_helper.rb
@@ -9,7 +9,7 @@ module Helpers
       # examples use Course.first and Course.last
       before do
         Course.destroy_all
-        create(:course, :tte_early_years)
+        create(:course, :npd_eirt)
       end
     end
   end

--- a/spec/support/with_default_lead_provider.rb
+++ b/spec/support/with_default_lead_provider.rb
@@ -3,7 +3,7 @@ RSpec.shared_context "with default lead provider", shared_context: :metadata do
     cohort = Cohort.current
     lead_provider = LeadProvider.first || create(:lead_provider)
 
-    course = Course.find_by(identifier: "tte-early-years") || create(:course, :tte_early_years)
+    course = Course.find_by(identifier: "npd-excellence-in-reception-teaching") || create(:course, :npd_eirt)
 
     course_cohort = course.course_cohorts.find_by(cohort:)
     unless course_cohort

--- a/spec/views/admin/finance/statements/print_dfe_user.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/print_dfe_user.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "admin/finance/statements/print_dfe_user", :revisit, type: :view 
   subject { render }
 
   let(:rendered) { Capybara.string(subject) }
-  let(:contract) { create(:contract, course: create(:course, :tte_early_years), statement:) }
+  let(:contract) { create(:contract, course: create(:course, :npd_eirt), statement:) }
   let(:special_contract) { create(:contract, contract_template: create(:contract_template, special_course: true), statement:) }
   let(:statement) { create(:statement, :open, month: Time.zone.today.month, year: Time.zone.today.year) }
   let(:admin_user) { create(:admin) }

--- a/spec/views/admin/finance/statements/print_provider.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/print_provider.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "admin/finance/statements/print_provider", type: :view do
   subject { render }
 
   let(:rendered) { Capybara.string(subject) }
-  let(:contract) { create(:contract, course: create(:course, :tte_early_years), statement:) }
+  let(:contract) { create(:contract, course: create(:course, :npd_eirt), statement:) }
   let(:special_contract) { create(:contract, contract_template: create(:contract_template, special_course: true), statement:) }
   let(:statement) { build(:statement, month: Time.zone.today.month, year: Time.zone.today.year) }
   let(:admin_user) { create(:admin) }

--- a/spec/views/admin/finance/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/show.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "admin/finance/statements/show", type: :view do
   subject { Capybara.string(render) }
 
   let(:contract) { create(:contract, course:, statement:) }
-  let(:course) { create(:course, :tte_early_years) }
+  let(:course) { create(:course, :npd_eirt) }
 
   before do
     assign(:statement, statement)


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#477

Align the course details/tests/factories with the NPD naming and move away from "TTE"

### Changes proposed in this pull request

Remove as much TTE references as possible in tests, factories, translations and course model

### Out of scope

We can't change the identifier at the moment because it's exposed to the LPs.