### PR TITLE
Fix API timestamp parser

### DIFF
--- a/app/controllers/concerns/api/filter_by_date.rb
+++ b/app/controllers/concerns/api/filter_by_date.rb
@@ -17,7 +17,7 @@ module API
 
       return if date_param.blank?
 
-      Time.iso8601(URI.decode_www_form_component(date_param))
+      Time.iso8601(URI::DEFAULT_PARSER.unescape(date_param))
     rescue ArgumentError
       raise ActionController::BadRequest, I18n.t(:invalid_date_filter, attribute: filter_name)
     end

--- a/spec/controllers/concerns/api/filter_by_date_spec.rb
+++ b/spec/controllers/concerns/api/filter_by_date_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe API::FilterByDate do
 
       it { expect { subject }.to raise_error(ActionController::BadRequest).with_message(I18n.t(:invalid_date_filter, attribute: :updated_since)) }
     end
+
+    context "when the updated_since filter includes a positive timezone offset" do
+      let(:updated_since_param) { "2022-02-01T10:30:00+01:00" }
+
+      it { is_expected.to eq(Time.iso8601(updated_since_param)) }
+    end
   end
 
   describe "#created_since" do


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#421

If an API user gave an "updated_since" timestamp filter which had a "+01:00" time component, then the string --> datetime parser doesn't actually cope with the time offset - it ignores it.

### Changes proposed in this pull request

Fix the timestamp filter module

### Integration Impact

Does this change affect any of these integrations?
- [X] API - though not a breaking change or contract change