### PR TITLE
Don't update user when application updated

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -313,5 +313,4 @@ private
       errors.add(:funded_place, :not_eligible)
     end
   end
-
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -49,7 +49,7 @@ class Application < ApplicationRecord
   scope :not_withdrawn, -> { where.not(status: WITHDRAWN).or(where(status: nil)) }
   scope :not_rejected, -> { where.not(status: REJECTED) }
 
-  attr_accessor :version_note, :skip_touch_user_if_changed, :admin_user, :assignment
+  attr_accessor :version_note, :admin_user, :assignment
 
   validates :ecf_id, uniqueness: { case_sensitive: false }
 
@@ -64,8 +64,6 @@ class Application < ApplicationRecord
   validates :funded_place, inclusion: { in: [true, false] }, if: :validate_funded_place?
   validate :funded_place_nil_for_cohort_with_ineligible_for_funding_cap
   validate :eligible_for_funded_place
-
-  after_commit :touch_user_if_changed
 
   STATUSES =
     [
@@ -316,10 +314,4 @@ private
     end
   end
 
-  def touch_user_if_changed
-    return if skip_touch_user_if_changed
-    return unless saved_change_to_status?
-
-    user.touch(time: updated_at)
-  end
 end

--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -55,9 +55,7 @@ module Applications
     def where_updated_since(updated_since)
       return if ignore?(filter: updated_since)
 
-      applications_updated_since = Application.where(updated_at: updated_since..)
-      users_updated_since = Application.where(users: { significantly_updated_at: updated_since.. })
-      scope.merge!(applications_updated_since.or(users_updated_since))
+      scope.merge!(Application.where(updated_at: updated_since..))
     end
 
     def where_participant_ids_in(participant_ids)

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -588,21 +588,10 @@ RSpec.describe Application do
     end
   end
 
-  describe "touch user when application changes" do
+  describe "updating the user when application changes" do
     let!(:old_datetime) { 6.months.ago }
     let(:user) { create(:user, updated_at: old_datetime) }
     let(:application) { create(:application, :pending, user:) }
-
-    context "when application is created" do
-      it "updates user.updated_at" do
-        freeze_time do
-          expect(user.updated_at).to be_within(1.second).of(old_datetime)
-
-          create(:application, user:)
-          expect(user.updated_at).to eq(Time.zone.now)
-        end
-      end
-    end
 
     context "when application is updated" do
       before do
@@ -613,7 +602,7 @@ RSpec.describe Application do
       end
 
       context "when status is changed" do
-        it "updates user.updated_at" do
+        it "does not update user.updated_at" do
           freeze_time do
             expect(user.updated_at).to be_within(1.second).of(old_datetime)
             expect(application.updated_at).to be_within(1.second).of(old_datetime)
@@ -621,21 +610,7 @@ RSpec.describe Application do
             application.rejected_status!
 
             expect(application.updated_at).to eq(Time.zone.now)
-            expect(user.updated_at).to eq(Time.zone.now)
-          end
-        end
-
-        context "when skip_touch_user_if_changed is true" do
-          it "does not update user.updated_at" do
-            freeze_time do
-              expect(user.updated_at).to be_within(1.second).of(old_datetime)
-              expect(application.updated_at).to be_within(1.second).of(old_datetime)
-
-              application.update!(status: Application::REJECTED, skip_touch_user_if_changed: true)
-
-              expect(application.updated_at).to eq(Time.zone.now)
-              expect(user.updated_at).to be_within(1.second).of(old_datetime)
-            end
+            expect(user.reload.updated_at).to be_within(1.second).of(old_datetime)
           end
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe User do
       expect(user.significantly_updated_at).to be_within(1.second).of(significantly_updated_at)
     end
 
-    context "when skip_touch_user_if_changed is true" do
+    context "when skip_touch_significantly_updated_at is true" do
       before { user.skip_touch_significantly_updated_at = true }
 
       it "does not update significantly_updated_at" do

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -50,26 +50,6 @@ RSpec.describe Applications::Query do
           end
         end
 
-        context "when user was updated recently" do
-          let(:user) { create(:user) }
-          let(:updated_since) { 7.days.ago }
-
-          it "filters by user.updated_at" do
-            application1 = travel_to(10.days.ago) do
-              create(:application, lead_provider:)
-            end
-            application2 = travel_to(5.days.ago) do
-              create(:application, lead_provider:)
-            end
-
-            expect(query.applications).to contain_exactly(application2)
-
-            application1.user.update!(updated_at: 12.days.ago, significantly_updated_at: 1.day.ago)
-
-            query2 = described_class.new(lead_provider:, updated_since: 2.days.ago)
-            expect(query2.applications).to contain_exactly(application1)
-          end
-        end
       end
 
       context "when filtering by cohort" do

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe Applications::Query do
             expect(query.applications).to contain_exactly(application)
           end
         end
-
       end
 
       context "when filtering by cohort" do

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -143,7 +143,6 @@ RSpec.describe Participants::Query do
             expect(query.participants).to contain_exactly(participant2, participant1)
 
             participant3.applications.first.update!(updated_at: Time.zone.now)
-            participant3.update!(updated_at: 5.days.ago) # to account for touch model changes
             expect(query.participants).to contain_exactly(participant2, participant1, participant3)
           end
         end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#421

NPQ didn't have a specific applications API endpoint so had to update participants (users) when an application
changed in order to retrieve applications updated since a certain date.
This is no longer required and introduces an oddity to the data model.

### Changes proposed in this pull request

- Remove the logic to update a user if an application changes status.
- Update the application/query used by the applications API
- Update specs

### Integration Impact

Does this change affect any of these integrations?
- [X] API - but non breaking change / no change to contract
