### PR TITLE
[387] Handle duplicate email addresses

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -13,43 +13,15 @@ class OmniauthController < Devise::OmniauthCallbacksController
       feature_flag_id: session["feature_flag_id"],
     ).call
 
-    # @user.persisted? checks that it exists and has been persisted to the database
-    # @user.save checks that any changes made to an existing record have been persisted to that persisted record
-    if @user.persisted? && (user_saved = @user.save)
-      session["user_id"] = @user.id
-      @user.set_closed_registration_feature_flag
-      sign_in_and_redirect @user
-    else
-      # we should never get here - as errors should have been previously handled
-      # TODO: need a feature test for the error scenario:
-      # - email has already been taken - but somehow user_id_with_clashing_email is nil
-      user_id_with_clashing_email = User.find_by(email: provider_data.info.email)&.id
-
-      send_error_to_sentry(
-        "Could not persist user after omniauth callback",
-        contexts: {
-          "Errors" => @user.errors.to_hash,
-          "Provider" => {
-            provider: provider_data.provider,
-            uid: provider_data.uid,
-            user_id_with_clashing_email:,
-          },
-          "User" => {
-            persisted: @user.persisted?,
-            saved: user_saved,
-            multibyte_email_characters: multibyte_email_characters(provider_data.info.email).join(" / "),
-          },
-        },
-      )
-
-      flash[:error] = failure_message
-      redirect_to failed_sign_in_path
-    end
+    session["user_id"] = @user.id
+    @user.set_closed_registration_feature_flag
+    sign_in_and_redirect @user
   rescue StandardError => e
-    id = @user.try(:id)
-    Rails.logger.info("[TeacherAuth] #{e} raised, user_id=#{id} uid=#{try_to_extract_user_uid}")
+    Rails.logger.info("[TeacherAuth] #{e} raised, user_id=#{@user.try(:id)} uid=#{try_to_extract_user_uid}")
+    Sentry.capture_exception(e)
 
-    raise e
+    flash[:error] = failure_message
+    redirect_to failed_sign_in_path
   end
 
   def failure
@@ -69,14 +41,6 @@ class OmniauthController < Devise::OmniauthCallbacksController
   end
 
 private
-
-  def multibyte_email_characters(email)
-    email.each_char.filter_map.with_index do |c, i|
-      next unless c.bytesize > 1
-
-      "Character #{i} = U+" + c.ord.to_s(16).upcase
-    end
-  end
 
   def send_error_to_sentry(message, contexts: {})
     Sentry.with_scope do |scope|

--- a/app/services/users/find_or_create_from_teacher_auth.rb
+++ b/app/services/users/find_or_create_from_teacher_auth.rb
@@ -18,6 +18,7 @@ module Users
       user_matched_using_trn = matching_users.first
 
       if user_matched_using_trn
+        merge_and_archive_clashing_email_user(user_matched_using_trn)
         user_matched_using_trn.update!(one_login_id:, provider: Omniauth::Strategies::TeacherAuth::NAME, email:, full_name:, feature_flag_id:)
         merge_and_archive_other_users(user_matched_using_trn, matching_users[1..])
         return user_matched_using_trn
@@ -26,10 +27,12 @@ module Users
       user_matched_using_one_login_id = User.find_by(provider: Omniauth::Strategies::TeacherAuth::NAME, one_login_id:)
 
       if user_matched_using_one_login_id
+        merge_and_archive_clashing_email_user(user_matched_using_one_login_id)
         user_matched_using_one_login_id.update!(user_attributes)
         return user_matched_using_one_login_id
       end
 
+      merge_and_archive_clashing_email_user(nil)
       create_user_with_provider_data
     end
 
@@ -44,6 +47,17 @@ module Users
     def merge_and_archive_other_users(user_to_keep, users_to_merge)
       users_to_merge.each do |user_to_merge|
         Users::MergeAndArchive.new(user_to_merge:, user_to_keep:).call(dry_run: false)
+      end
+    end
+
+    def merge_and_archive_clashing_email_user(user_to_keep)
+      clashing_user = User.find_by(email:)
+      return if clashing_user.nil? || clashing_user == user_to_keep
+
+      if user_to_keep && clashing_user.trn.blank?
+        Users::MergeAndArchive.new(user_to_merge: clashing_user, user_to_keep:).call(dry_run: false)
+      else
+        Users::Archiver.new(user: clashing_user).archive!
       end
     end
 

--- a/spec/requests/omniauth_spec.rb
+++ b/spec/requests/omniauth_spec.rb
@@ -69,13 +69,9 @@ RSpec.describe "Omniauth callbacks", type: :request do
         end
       end
 
-      context "when user creation fails" do
-        let(:invalid_user) { build(:user) }
-        let(:service) { instance_double(Users::FindOrCreateFromTeacherAuth, call: invalid_user) }
-
+      context "when the service raises an error" do
         before do
-          allow(Users::FindOrCreateFromTeacherAuth).to receive(:new).and_return(service)
-          allow(invalid_user).to receive(:persisted?).and_return(false)
+          allow(Users::FindOrCreateFromTeacherAuth).to receive(:new).and_raise(StandardError, "Something went wrong")
         end
 
         it "redirects to the failed sign in path" do

--- a/spec/services/users/find_or_create_from_teacher_auth_spec.rb
+++ b/spec/services/users/find_or_create_from_teacher_auth_spec.rb
@@ -182,4 +182,136 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
       end
     end
   end
+
+  describe "email clash handling" do
+    context "when another user already has the incoming email" do
+      context "when clashing user has no TRN" do
+        let(:clashing_user) { create(:user, email:, trn: nil) }
+
+        before { clashing_user }
+
+        context "when TRN matches an existing user" do
+          let(:user) { create(:user, trn:, email: "old@example.com") }
+
+          before { user }
+
+          it "archives the clashing user" do
+            make_request
+            expect(clashing_user.reload).to be_archived
+          end
+
+          it "updates the matched user with the new email" do
+            make_request
+            expect(user.reload.email).to eq(email)
+          end
+
+          context "when clashing user has applications" do
+            let!(:clashing_application) { create(:application, user: clashing_user) }
+
+            it "moves applications to the matched user" do
+              make_request
+              expect(clashing_application.reload.user).to eq(user)
+            end
+          end
+        end
+
+        context "when one_login_id matches an existing user" do
+          let(:trn) { nil }
+          let(:existing_user) { create(:user, :with_one_login_id, one_login_id: uid, email: "old@example.com") }
+
+          before { existing_user }
+
+          it "archives the clashing user" do
+            make_request
+            expect(clashing_user.reload).to be_archived
+          end
+
+          it "updates the matched user with the new email" do
+            make_request
+            expect(existing_user.reload.email).to eq(email)
+          end
+
+          context "when clashing user has applications" do
+            let!(:clashing_application) { create(:application, user: clashing_user) }
+
+            it "moves applications to the matched user" do
+              make_request
+              expect(clashing_application.reload.user).to eq(existing_user)
+            end
+          end
+        end
+
+        context "when creating a new user" do
+          let(:trn) { nil }
+
+          it "archives the clashing user" do
+            make_request
+            expect(clashing_user.reload).to be_archived
+          end
+
+          it "creates the new user with the email" do
+            make_request
+            expect(User.find_by(one_login_id: uid).email).to eq(email)
+          end
+        end
+      end
+
+      context "when clashing user has a TRN (different verified person)" do
+        let(:clashing_user) { create(:user, email:, trn: "9999999") }
+
+        before { clashing_user }
+
+        context "when TRN matches an existing user" do
+          let(:user) { create(:user, trn:, email: "old@example.com") }
+
+          before { user }
+
+          it "archives the clashing user" do
+            make_request
+            expect(clashing_user.reload).to be_archived
+          end
+
+          it "updates the matched user with the new email" do
+            make_request
+            expect(user.reload.email).to eq(email)
+          end
+
+          context "when clashing user has applications" do
+            let!(:clashing_application) { create(:application, user: clashing_user) }
+
+            it "does not move applications (different verified person)" do
+              make_request
+              expect(clashing_application.reload.user).to eq(clashing_user)
+            end
+          end
+        end
+
+        context "when one_login_id matches an existing user" do
+          let(:trn) { nil }
+          let(:existing_user) { create(:user, :with_one_login_id, one_login_id: uid, email: "old@example.com") }
+
+          before { existing_user }
+
+          it "archives the clashing user" do
+            make_request
+            expect(clashing_user.reload).to be_archived
+          end
+
+          it "updates the matched user with the new email" do
+            make_request
+            expect(existing_user.reload.email).to eq(email)
+          end
+
+          context "when clashing user has applications" do
+            let!(:clashing_application) { create(:application, user: clashing_user) }
+
+            it "does not move applications (different verified person)" do
+              make_request
+              expect(clashing_application.reload.user).to eq(clashing_user)
+            end
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#387

Some users may change their email address. The authentication flow must handle duplicate email scenarios safely and predictably.

### Changes proposed in this pull request

- Handle email clashes by merging/archiving conflicting users
- Clashing user with no TRN, merge applications & archive
- Clashing user with TRN, archive only (different verified person)
- Remove unreachable code

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
