### PR TITLE
Add missing include in Application::Query

### DIFF
--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -17,6 +17,7 @@ module Applications
                                  :schedule,
                                  :institution,
                                  :rejected_event,
+                                 :current_application_lead_provider,
                                  { course_cohort: %i[course cohort schedule] }],
                  )
                  .preload(application: { institution: :institutionable })


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#482

Issue introduces with the application auditable fields

### Changes proposed in this pull request

Add missing :current_application_lead_provider include