### PR TITLE
Add admin page to edit lead provider

### DIFF
--- a/app/controllers/admin/lead_providers_controller.rb
+++ b/app/controllers/admin/lead_providers_controller.rb
@@ -30,7 +30,25 @@ module Admin
       end
     end
 
+    def edit
+      @lead_provider = LeadProvider.find(params[:id])
+    end
+
+    def update
+      @lead_provider = LeadProvider.find(params[:id])
+
+      if @lead_provider.update(lead_provider_params)
+        redirect_to admin_lead_provider_path(@lead_provider), flash: { success: "Provider updated" }
+      else
+        render :edit, status: :unprocessable_content
+      end
+    end
+
   private
+
+    def lead_provider_params
+      params.require(:lead_provider).permit(:name, :email, :hint, :url)
+    end
 
     def resources
       if @current_cohort

--- a/app/views/admin/lead_providers/_form.html.erb
+++ b/app/views/admin/lead_providers/_form.html.erb
@@ -1,0 +1,44 @@
+<%= form_with model: [:admin, lead_provider] do |form| %>
+  <%= form.govuk_error_summary %>
+
+  <%=
+    form.govuk_text_field :name,
+                          width: "two-thirds",
+                          label: {
+                            text: "Provider name",
+                            size: "m",
+                          }
+  %>
+
+  <%=
+    form.govuk_text_field :email,
+                          width: "two-thirds",
+                          label: {
+                            text: "Email address",
+                            size: "m",
+                          }
+  %>
+
+  <%=
+    form.govuk_text_field :url,
+                          width: "two-thirds",
+                          label: {
+                            text: "Website URL",
+                            size: "m",
+                          }
+  %>
+
+  <%=
+    form.govuk_text_field :hint,
+                          width: "two-thirds",
+                          label: {
+                            text: "Hint text",
+                            size: "m",
+                          }
+  %>
+
+  <div class="govuk-button-group">
+    <%= form.govuk_submit "Save provider details" %>
+    <%= govuk_link_to "Cancel", admin_lead_provider_path(lead_provider), class: "govuk-link--no-visited-state" %>
+  </div>
+<% end %>

--- a/app/views/admin/lead_providers/edit.html.erb
+++ b/app/views/admin/lead_providers/edit.html.erb
@@ -1,0 +1,5 @@
+<%= govuk_back_link href: admin_lead_provider_path(@lead_provider) %>
+
+<h1 class="govuk-heading-l">Edit provider details</h1>
+
+<%= render "form", lead_provider: @lead_provider %>

--- a/app/views/admin/lead_providers/show.html.erb
+++ b/app/views/admin/lead_providers/show.html.erb
@@ -9,6 +9,24 @@
 
 <h1 class="govuk-heading-l"><%= @lead_provider.name %></h1>
 
+<%=
+  govuk_summary_list do |summary_list|
+    summary_list.with_row do |row|
+      row.with_key(text: "Email address")
+      row.with_value(text: @lead_provider.email.presence || "Not set")
+    end
+
+    summary_list.with_row do |row|
+      row.with_key(text: "Website URL")
+      row.with_value(text: @lead_provider.url.presence || "Not set")
+    end
+  end
+%>
+
+<p class="govuk-body">
+  <%= govuk_button_link_to "Edit provider details", edit_admin_lead_provider_path(@lead_provider) %>
+</p>
+
 <%= govuk_tabs do |tabs| %>
     <%= tabs.with_tab(label: "Applications") do %>
         <%= render partial: "applications",  locals: { applications: @applications, pagy: @pagy_applications } %>

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -161,7 +161,7 @@ namespace :admin do
     end
   end
 
-  resources :lead_providers, only: %i[index show], path: "providers" do
+  resources :lead_providers, only: %i[index show edit update], path: "providers" do
     concerns :cohortable, index: "lead_providers#index", show: "lead_providers#show"
   end
   resources :admins, only: %i[index]

--- a/spec/features/admin/lead_providers_spec.rb
+++ b/spec/features/admin/lead_providers_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature "Listing and viewing course providers", type: :feature do
     cohort_2024 = create(:cohort, start_year: 2024)
     cohort_2023 = create(:cohort, start_year: 2023)
     lead_provider = LeadProvider.order(:name).first
+    lead_provider.update!(url: "https://example.com/provider")
     delivery_partner_25 = create(:delivery_partner, lead_providers: { cohort_2025 => lead_provider })
     delivery_partner_24 = create(:delivery_partner, lead_providers: { cohort_2024 => lead_provider })
     delivery_partner_23 = create(:delivery_partner, lead_providers: { cohort_2023 => lead_provider })
@@ -31,6 +32,8 @@ RSpec.feature "Listing and viewing course providers", type: :feature do
     click_link(lead_provider.name)
 
     expect(page).to have_css(".govuk-heading-l", text: lead_provider.name)
+    expect(page).to have_text(lead_provider.email)
+    expect(page).to have_text(lead_provider.url)
 
     find("#tab_delivery-partners").click
     expect(page).to have_table(with_rows: [{ "Delivery partner" => delivery_partner_25.name }])
@@ -42,5 +45,38 @@ RSpec.feature "Listing and viewing course providers", type: :feature do
     click_link("2023 to 2024")
     find("#tab_delivery-partners").click
     expect(page).to have_table(with_rows: [{ "Delivery partner" => delivery_partner_23.name }])
+  end
+
+  scenario "editing course provider details" do
+    lead_provider = LeadProvider.order(:name).first
+
+    visit(admin_lead_provider_path(lead_provider))
+    click_on("Edit provider details")
+
+    fill_in("Provider name", with: "Updated Provider")
+    fill_in("Email address", with: "updated-provider@example.com")
+    fill_in("Website URL", with: "https://example.com/provider")
+    fill_in("Hint text", with: "Updated hint text")
+    click_on("Save provider details")
+
+    expect(page).to have_text("Provider updated")
+    expect(page).to have_css(".govuk-heading-l", text: "Updated Provider")
+
+    lead_provider.reload
+    expect(lead_provider.name).to eq("Updated Provider")
+    expect(lead_provider.email).to eq("updated-provider@example.com")
+    expect(lead_provider.url).to eq("https://example.com/provider")
+    expect(lead_provider.hint).to eq("Updated hint text")
+  end
+
+  scenario "editing course provider with invalid details" do
+    lead_provider = LeadProvider.order(:name).first
+
+    visit(edit_admin_lead_provider_path(lead_provider))
+    fill_in("Provider name", with: "")
+    click_on("Save provider details")
+
+    expect(page).to have_css("h1", text: "Edit provider details")
+    expect(page).to have_text("can't be blank")
   end
 end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#378

Add admin screen to update lead provider details like website & email

### Changes proposed in this pull request

- Alter admin/lead_providers controller to add edit/update methods
- Add edit view
- Alter show viiew to display email & url

