### PR TITLE
[458] Add page titles for accessibility

### DIFF
--- a/app/views/applications/change_provider/check_answers/index.html.erb
+++ b/app/views/applications/change_provider/check_answers/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("applications.change_provider.check_answers.title") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: application_change_provider_providers_path(application.ecf_id)) %>

--- a/app/views/applications/change_provider/contact_us/index.html.erb
+++ b/app/views/applications/change_provider/contact_us/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("applications.change_provider.start.title", course_name: application.course.name) %>
+
 <h1 class="govuk-heading-l">
   <%= t("applications.change_provider.start.title", course_name: application.course.name) %>
 </h1>

--- a/app/views/applications/change_provider/providers/index.html.erb
+++ b/app/views/applications/change_provider/providers/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("applications.change_provider.providers.form.title") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: application_change_provider_start_index_path(application.ecf_id)) %>

--- a/app/views/applications/change_provider/start/index.html.erb
+++ b/app/views/applications/change_provider/start/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("applications.change_provider.start.title", course_name: application.course.name) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">

--- a/app/views/email_updates/create.html.erb
+++ b/app/views/email_updates/create.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("helpers.title.email_updates.create") %>
+
 <div class="govuk-panel govuk-panel--confirmation">
   <h1 class="govuk-panel__title">You've signed up for email updates</h1>
 </div>

--- a/app/views/interest_notification_sign_up/new.html.erb
+++ b/app/views/interest_notification_sign_up/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("helpers.title.interest_notification_sign_up.new") %>
+
 <div class="govuk-grid-row">
   <h1 class="govuk-heading-xl">Register interest in NPD course</h1>
   <%= form_with model: @notification_form, url: registration_interest_sign_up_path do |f| %>

--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -1,10 +1,6 @@
 <head>
   <meta charset="utf-8">
-  <% if content_for?(:title) %>
-    <title><%= content_for(:title) %></title>
-  <% else %>
-    <title><%= default_page_title %></title>
-  <% end %>
+  <title><%= [content_for(:title).presence || default_page_title, "NPD", "GOV.UK"].compact.join(" - ") %></title>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
   <%# canonical_tag %>

--- a/app/views/pages/closed_registration_exception.html.erb
+++ b/app/views/pages/closed_registration_exception.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("helpers.title.pages.closed_registration_exception") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Register late for a national professional qualification (NPQ)</h1>

--- a/app/views/registration_wizard/cannot_register_yet.html.erb
+++ b/app/views/registration_wizard/cannot_register_yet.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("helpers.title.registration_wizard.cannot_register_yet") %>
+
 <%=
   render(
     'registration_wizard/shared/copy_page',

--- a/app/views/registration_wizard/check_answers.html.erb
+++ b/app/views/registration_wizard/check_answers.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("helpers.title.registration_wizard.check_answers") %>
+
 <%=
   render(
     'registration_wizard/shared/copy_page',

--- a/app/views/registration_wizard/childcare_provider_not_in_england.html.erb
+++ b/app/views/registration_wizard/childcare_provider_not_in_england.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("helpers.title.registration_wizard.childcare_provider_not_in_england") %>
+
 <%=
   render(
     'registration_wizard/shared/copy_page',

--- a/app/views/registration_wizard/closed.html.erb
+++ b/app/views/registration_wizard/closed.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("helpers.title.registration_wizard.closed") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Registration has closed temporarily</h1>

--- a/app/views/registration_wizard/possible_funding.html.erb
+++ b/app/views/registration_wizard/possible_funding.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("helpers.title.registration_wizard.possible_funding") %>
+
 <%=
   render(
     'registration_wizard/shared/copy_page',

--- a/app/views/registration_wizard/registration_submitted.html.erb
+++ b/app/views/registration_wizard/registration_submitted.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("helpers.title.registration_wizard.registration_submitted") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation">

--- a/app/views/registration_wizard/school_not_in_england.html.erb
+++ b/app/views/registration_wizard/school_not_in_england.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("helpers.title.registration_wizard.school_not_in_england") %>
+
 <%=
   render(
     'registration_wizard/shared/copy_page',

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t("helpers.title.registration_wizard.start") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -883,6 +883,9 @@ en:
     title:
       registration_wizard:
         service_title: "Register for a National Professional Development (NPD) course"
+        start: Check funding eligibility and register
+        registration_submitted: Registration submitted
+        closed: Registration has closed temporarily
         get_an_identity: Get an identity
         choose_your_course: Choose a TTE course
         course_start_date: Choose your course start date
@@ -909,6 +912,12 @@ en:
         national_insurance_number_optional: National Insurance number (optional)
         change_your_course_or_provider: Change your course or provider
         choose_a_tte_and_provider: Choose a TTE course and provider
+      email_updates:
+        create: You've signed up for email updates
+      interest_notification_sign_up:
+        new: Register interest in NPD course
+      pages:
+        closed_registration_exception: Register late for a national professional qualification (NPQ)
     legend:
       applications_change_cohort:
         cohort_id: Choose a cohort


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#458

Tester has observed that when viewing the page, the page title is not descriptive. It is expected that the page has a descriptive and informative page title.

### Changes proposed in this pull request

Adding non-admin page titles in the format: `PAGE-NAME - NPD - GOV.UK`

e.g. 
`<title>Course Start Date - NPD - GOV.UK</title> `

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
