### PR TITLE
Fix API/Applications status filter when application is reassigned

### DIFF
--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -70,17 +70,16 @@ module Applications
     def where_status_in(status)
       return if ignore?(filter: status)
 
-      if status == Application::REASSIGNED
-        scope.merge!(scope.where(current: false))
-      elsif status.is_a?(Array) && Application::REASSIGNED.in?(status)
-        filtered_status = extract_conditions(status, allowlist: Application::STATUSES)
+      filtered_status = extract_conditions(status, allowlist: Application::API_STATUSES)
 
-        scope.merge!(
-          scope.where(current: false)
-            .or(Application.where(status: filtered_status)),
-        )
+      if filtered_status == Application::REASSIGNED
+        scope.merge!(scope.previous)
+      elsif filtered_status.is_a?(Array) && Application::REASSIGNED.in?(filtered_status)
+        application_statuses = filtered_status - [Application::REASSIGNED]
+        application_status_scope = scope.current.merge(Application.where(status: application_statuses))
+        scope.merge!(scope.previous.or(application_status_scope))
       else
-        scope.merge!(Application.where(status: extract_conditions(status, allowlist: Application::STATUSES)))
+        scope.merge!(scope.current.merge(Application.where(status: filtered_status)))
       end
     end
 

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -59,20 +59,28 @@ RSpec.describe "Application endpoints", type: :request do
       let(:path) { api_v1_applications_path }
 
       context "with the old provider" do
-        before { create(:application, :pending, lead_provider: old_lead_provider) }
+        let!(:pending_application) { create(:application, :pending, lead_provider: old_lead_provider) }
 
         it "can see the applications list with reassigned status" do
-          api_get(path, lead_provider: old_lead_provider, params: { filter: { status: Application::REASSIGNED } })
-
-          expect(response_ids).to include(application.ecf_id)
-          expect(JSON.parse(response.body)["data"].size).to eq(1)
+          api_get(path, lead_provider: old_lead_provider)
+          expect(response_ids).to contain_exactly(application.ecf_id, pending_application.ecf_id)
           expect(JSON.parse(response.body)["data"].first["attributes"]["status"]).to eq(Application::REASSIGNED)
         end
 
         it "can filter the applications with reassigned status" do
-          api_get(path, lead_provider: old_lead_provider)
-          expect(response_ids).to include(application.ecf_id)
+          api_get(path, lead_provider: old_lead_provider, params: { filter: { status: Application::REASSIGNED } })
+
+          expect(response_ids).to contain_exactly(application.ecf_id)
+          expect(JSON.parse(response.body)["data"].size).to eq(1)
           expect(JSON.parse(response.body)["data"].first["attributes"]["status"]).to eq(Application::REASSIGNED)
+        end
+
+        it "filters applications with pending status correctly" do
+          api_get(path, lead_provider: old_lead_provider, params: { filter: { status: Application::PENDING } })
+
+          expect(response_ids).to contain_exactly(pending_application.ecf_id)
+          expect(JSON.parse(response.body)["data"].size).to eq(1)
+          expect(JSON.parse(response.body)["data"].first["attributes"]["status"]).to eq(Application::PENDING)
         end
       end
 


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#479

The API is returning reassigned applications for old providers when filtering by another status

### Changes proposed in this pull request

Fix the Applications::Query to correctly apply the filter

## Checklists:

Does this change affect any of these integrations?
- [X] API - Non breaking / no contract change
