### PR TITLE
Fix bug in registration around funding/work setting

### DIFF
--- a/app/forms/questionnaires/work_setting.rb
+++ b/app/forms/questionnaires/work_setting.rb
@@ -33,38 +33,8 @@ module Questionnaires
     end
 
     def after_save
-      if other?
-        wizard.store.delete("funding")
-        wizard.store.delete("institution_id")
-        return
-      end
-
-      return if state_funded_instition? || private_institution?
-
-      # we are inferring `works_in_school` and `works_in_childcare` to maintain
-      # consistency with older records
-
-      case work_setting
-      when *SCHOOL_SETTINGS
-        wizard.store["works_in_school"] = "yes"
-        wizard.store["works_in_childcare"] = "no"
-
-        %w[kind_of_nursery has_ofsted_urn institution_id].each { |field| wizard.store.delete(field) }
-      when *CHILDCARE_SETTINGS
-        wizard.store["works_in_childcare"] = "yes"
-        wizard.store["works_in_school"] = "no"
-
-        wizard.store.delete("institution_id")
-      when *OTHER_SETTINGS, *ANOTHER_SETTING_SETTINGS
-        wizard.store["works_in_school"] = "no"
-        wizard.store["works_in_childcare"] = "no"
-
-        %w[funding kind_of_nursery has_ofsted_urn institution_id].each do |field|
-          wizard.store.delete(field)
-        end
-      else
-        raise(ArgumentError, "invalid work setting #{work_setting}")
-      end
+      wizard.store.delete("funding")
+      wizard.store.delete("institution_id")
     end
 
     def requirements_met?

--- a/spec/controllers/registration_wizard_controller_spec.rb
+++ b/spec/controllers/registration_wizard_controller_spec.rb
@@ -91,6 +91,28 @@ RSpec.describe RegistrationWizardController do
       expect(session["registration_store"]["course_start_date"]).to eql("yes")
     end
 
+    context "when updating the work setting step" do
+      let(:wizard_params) { { work_setting: Institution::STATE_FUNDED_INSTITUTION } }
+      let(:make_request) { patch :update, params: { step: "work-setting", registration_wizard: wizard_params } }
+
+      before do
+        session["registration_store"] = {
+          "funding" => "school",
+          "institution_id" => "123",
+        }
+      end
+
+      it "deletes funding from the session" do
+        make_request
+        expect(session["registration_store"]).not_to have_key("funding")
+      end
+
+      it "deletes institution_id from the session" do
+        make_request
+        expect(session["registration_store"]).not_to have_key("institution_id")
+      end
+    end
+
     context "when step is being skipped" do
       before do
         allow(RegistrationWizard).to receive(:new).and_return(wizard)

--- a/spec/forms/questionnaires/work_setting_spec.rb
+++ b/spec/forms/questionnaires/work_setting_spec.rb
@@ -47,4 +47,30 @@ RSpec.describe Questionnaires::WorkSetting, type: :model do
       it { is_expected.to eq :choose_school }
     end
   end
+
+  describe "#after_save" do
+    subject(:form) { described_class.new(wizard:) }
+
+    let(:wizard) { RegistrationWizard.new(current_step: :work_setting, store:, request: nil, current_user: build_stubbed(:user)) }
+    let(:store) do
+      {
+        "funding" => "school",
+        "institution_id" => "123",
+        "teacher_catchment" => "england",
+      }
+    end
+
+    it "deletes funding from the wizard store" do
+      expect { form.after_save }.to change { store.key?("funding") }.from(true).to(false)
+    end
+
+    it "deletes institution_id from the wizard store" do
+      expect { form.after_save }.to change { store.key?("institution_id") }.from(true).to(false)
+    end
+
+    it "leaves other answers in the wizard store" do
+      form.after_save
+      expect(store["teacher_catchment"]).to eq("england")
+    end
+  end
 end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#489

During the registration flow when changing work setting it is remembering the funding & instituion choice.

### Changes proposed in this pull request

Alter the WorkSetting#after_save method to always wipe funding and institution_id when choosing work setting