### PR TITLE
Move registration cohort selection to be driven from course

### DIFF
--- a/app/controllers/applications/change_provider/providers_controller.rb
+++ b/app/controllers/applications/change_provider/providers_controller.rb
@@ -21,10 +21,8 @@ module Applications
     private
 
       def providers
-        @providers ||= LeadProvider
-          .for(course: application.course)
-          .alphabetical
-          .reject { |p| p.id == application.lead_provider.id }
+        @providers ||= application.course_cohort.lead_providers.alphabetical
+                        .reject { |p| p.id == application.lead_provider.id }
       end
 
       def set_form

--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -105,7 +105,7 @@ private
   def check_duplicate_applications
     return unless @wizard.current_step.to_s == "course_start_date"
 
-    active_applications = current_user.active_applications_for(course:, cohort: Cohort.current)
+    active_applications = current_user.active_applications_for(course:, cohort: course.next_open_cohort)
     return if active_applications.empty?
 
     flash[:alert] = {

--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -8,7 +8,7 @@ class RegistrationWizardController < PublicPagesController
   rescue_from FundingEligibility::MissingMandatoryInstitution, with: :redirect_to_institution_picker
   rescue_from RegistrationWizard::RemovedStep, with: :redirect_to_course_start_date
 
-  helper_method :course
+  helper_method :course, :course_cohort
 
   def show
     @form.flag_as_changing_answer if params[:changing_answer] == "1"
@@ -104,8 +104,9 @@ private
 
   def check_duplicate_applications
     return unless @wizard.current_step.to_s == "course_start_date"
+    return unless course_cohort
 
-    active_applications = current_user.active_applications_for(course:, cohort: course.next_open_cohort)
+    active_applications = current_user.applications.active_applications.where(course_cohort:)
     return if active_applications.empty?
 
     flash[:alert] = {
@@ -140,5 +141,9 @@ private
 
   def course
     @course ||= Course.reception
+  end
+
+  def course_cohort
+    @course_cohort ||= CourseCohort.next_open_for(course:)
   end
 end

--- a/app/forms/questionnaires/choose_your_provider.rb
+++ b/app/forms/questionnaires/choose_your_provider.rb
@@ -48,7 +48,7 @@ module Questionnaires
   private
 
     def providers
-      @providers ||= LeadProvider.for(course:)
+      @providers ||= course_cohort.lead_providers.alphabetical
     end
 
     def lead_provider
@@ -56,6 +56,7 @@ module Questionnaires
     end
 
     delegate :course,
+             :course_cohort,
              :inside_catchment?,
              to: :query_store
 

--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -64,7 +64,7 @@ module Questionnaires
     end
 
     def application_course_start_date
-      @application_course_start_date ||= Course.reception.next_cohort_start_date
+      @application_course_start_date ||= query_store.course_cohort&.name || "Registration closed"
     end
   end
 end

--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -1,7 +1,6 @@
 module Questionnaires
   class CourseStartDate < Base
     class Form < QuestionTypes::RadioButtonGroup
-      include ApplicationHelper
       def type
         "radio_button_group"
       end
@@ -51,7 +50,7 @@ module Questionnaires
 
     def next_step
       if course_start_date == "yes"
-        wizard.store["course_start"] = "In #{application_course_start_date}"
+        wizard.store["course_start"] = application_course_start_date
         wizard.current_user.update!(notify_user_for_future_reg: false)
         :choose_your_provider
       else
@@ -62,6 +61,10 @@ module Questionnaires
 
     def previous_step
       :start
+    end
+
+    def application_course_start_date
+      @application_course_start_date ||= Course.reception.next_cohort_start_date
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,18 +30,6 @@ module ApplicationHelper
     Rails.configuration.x.tracking_pixels_enabled && cookies["consented-to-cookies"] == "accept"
   end
 
-  def application_course_start_date
-    "October 2026"
-  end
-
-  def application_next_course_start_date
-    "Spring 2027"
-  end
-
-  def application_started_confirmed_by_date
-    "Spring 2027"
-  end
-
   def show_otp_code_in_ui(current_env, admin)
     return unless current_env.in?(%w[development review staging]) && admin.present?
 

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -50,7 +50,7 @@ class Cohort < ApplicationRecord
   end
 
   def name
-    start_year.to_s
+    description
   end
 
 private

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -40,20 +40,13 @@ class Cohort < ApplicationRecord
     order(registration_starts_at: :desc).where(registration_starts_at: ..timestamp).first!
   end
 
-  def self.course_start_date
-    if Time.zone.now.month.between?(1, 3)
-      "January to March #{current.start_year}"
-    else
-      "October #{current.start_year}"
-    end
+  def registration_open?
+    Time.zone.today > registration_starts_at &&
+      (registration_ends_at.nil? || Time.zone.today <= registration_ends_at)
   end
 
-  def self.next_course_start_date
-    if Time.zone.now.month.between?(1, 3)
-      "October #{current.start_year}"
-    else
-      "January to March #{current.start_year + 1}"
-    end
+  def registration_upcoming?
+    registration_starts_at > Time.zone.today
   end
 
   def name

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -20,30 +20,6 @@ class Course < ApplicationRecord
       find_by(identifier: "tte-early-years")
   end
 
-  def next_open_cohort
-    @next_open_cohort ||= begin
-      cohorts = course_cohorts.includes(:cohort).map(&:cohort).select { |c| c.start_year >= Time.zone.now.year }
-      cohorts.select(&:registration_open?).min_by(&:registration_starts_at) ||
-        cohorts.select(&:registration_upcoming?).min_by(&:registration_starts_at)
-    end
-  end
-
-  def next_cohort_start_date
-    return "Registration closed" if next_open_cohort.nil?
-
-    next_open_cohort.name
-  end
-
-  def application_started_confirmed_by_date
-    return "Registration closed" if next_open_cohort.nil?
-
-    if next_open_cohort.registration_ends_at.between?(9, 11)
-      "Spring #{next_open_cohort.registration_ends_at.year + 1}"
-    else
-      "Summer #{next_open_cohort.registration_ends_at.year}"
-    end
-  end
-
   def rebranded_alternative_courses
     [self]
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -16,9 +16,32 @@ class Course < ApplicationRecord
   # IDENTIFIERS = %w[npd-excellence-in-reception-teaching].freeze
 
   def self.reception
-    # Change this once we have sign-off from lead providers to change the identifier
-    # find_by(identifier: "npd-excellence-in-reception-teaching")
-    find_by(identifier: "tte-early-years")
+    find_by(identifier: "npd-excellence-in-reception-teaching") ||
+      find_by(identifier: "tte-early-years")
+  end
+
+  def next_open_cohort
+    @next_open_cohort ||= begin
+      cohorts = course_cohorts.includes(:cohort).map(&:cohort).select { |c| c.start_year >= Time.zone.now.year }
+      cohorts.select(&:registration_open?).min_by(&:registration_starts_at) ||
+        cohorts.select(&:registration_upcoming?).min_by(&:registration_starts_at)
+    end
+  end
+
+  def next_cohort_start_date
+    return "Registration closed" if next_open_cohort.nil?
+
+    next_open_cohort.name
+  end
+
+  def application_started_confirmed_by_date
+    return "Registration closed" if next_open_cohort.nil?
+
+    if next_open_cohort.registration_ends_at.between?(9, 11)
+      "Spring #{next_open_cohort.registration_ends_at.year + 1}"
+    else
+      "Summer #{next_open_cohort.registration_ends_at.year}"
+    end
   end
 
   def rebranded_alternative_courses

--- a/app/models/course_cohort.rb
+++ b/app/models/course_cohort.rb
@@ -12,4 +12,20 @@ class CourseCohort < ApplicationRecord
   validates :course_id, uniqueness: { scope: :cohort_id }
 
   delegate :name, to: :cohort
+
+  def self.next_open_for(course:)
+    course_cohorts = course.course_cohorts.includes(:cohort).select do |course_cohort|
+      course_cohort.cohort.start_year >= Time.zone.now.year
+    end
+
+    course_cohorts.select { |course_cohort| course_cohort.cohort.registration_open? }
+                  .min_by { |course_cohort| course_cohort.cohort.registration_starts_at } ||
+      course_cohorts.select { |course_cohort| course_cohort.cohort.registration_upcoming? }
+                    .min_by { |course_cohort| course_cohort.cohort.registration_starts_at }
+  end
+
+  def application_started_confirmed_by_date
+    date = schedule.training_ends_at
+    "#{date.month.between?(1, 4) ? 'Spring' : 'Summer'} #{date.year}"
+  end
 end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -17,13 +17,6 @@ class LeadProvider < ApplicationRecord
 
   scope :alphabetical, -> { order(name: :asc) }
 
-  def self.for(course:, cohort: nil)
-    course_cohorts = { course_id: course.id, cohort_id: cohort&.id || course.next_open_cohort }
-    LeadProvider.joins(course_cohort_providers: :course_cohort)
-                .where(course_cohorts:)
-                .alphabetical
-  end
-
   def next_output_fee_statement(cohort)
     statements.next_output_fee_statements.where(cohort:).first
   end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -18,7 +18,7 @@ class LeadProvider < ApplicationRecord
   scope :alphabetical, -> { order(name: :asc) }
 
   def self.for(course:, cohort: nil)
-    course_cohorts = { course_id: course.id, cohort_id: cohort&.id || Cohort.current.id }
+    course_cohorts = { course_id: course.id, cohort_id: cohort&.id || course.next_open_cohort }
     LeadProvider.joins(course_cohort_providers: :course_cohort)
                 .where(course_cohorts:)
                 .alphabetical

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,13 +103,6 @@ class User < ApplicationRecord
     update!(refresh_token: nil, refresh_token_updated_at: nil)
   end
 
-  def active_applications_for(course:, cohort:)
-    applications
-      .active_applications
-      .joins(:course_cohort)
-      .where(course_cohorts: { course_id: course.id, cohort_id: cohort.id })
-  end
-
 private
 
   def change_unsubscribe_key_on_update_email_status

--- a/app/services/handle_submission_for_store.rb
+++ b/app/services/handle_submission_for_store.rb
@@ -8,7 +8,7 @@ class HandleSubmissionForStore
   def call
     ActiveRecord::Base.transaction do
       @application = user.applications.create!(
-        course_cohort: CourseCohort.find_by!(course:, cohort: Cohort.current),
+        course_cohort: CourseCohort.find_by!(course:, cohort: course.next_open_cohort),
         application_lead_providers: [ApplicationLeadProvider.new(current: true, lead_provider_id: store["lead_provider_id"])],
         institution: (institution_from_store if inside_catchment?),
         ukprn:,

--- a/app/services/handle_submission_for_store.rb
+++ b/app/services/handle_submission_for_store.rb
@@ -8,7 +8,7 @@ class HandleSubmissionForStore
   def call
     ActiveRecord::Base.transaction do
       @application = user.applications.create!(
-        course_cohort: CourseCohort.find_by!(course:, cohort: course.next_open_cohort),
+        course_cohort:,
         application_lead_providers: [ApplicationLeadProvider.new(current: true, lead_provider_id: store["lead_provider_id"])],
         institution: (institution_from_store if inside_catchment?),
         ukprn:,
@@ -53,7 +53,8 @@ private
     @query_store ||= RegistrationQueryStore.new(store:)
   end
 
-  delegate :inside_catchment?,
+  delegate :course_cohort,
+           :inside_catchment?,
            to: :query_store
 
   def primary_establishment

--- a/app/services/registration_query_store.rb
+++ b/app/services/registration_query_store.rb
@@ -82,6 +82,10 @@ class RegistrationQueryStore
     @course ||= Course.reception
   end
 
+  def course_cohort
+    @course_cohort ||= CourseCohort.next_open_for(course:)
+  end
+
   def lead_provider
     @lead_provider ||= LeadProvider.find_by(id: store["lead_provider_id"])
   end

--- a/app/services/registration_query_store.rb
+++ b/app/services/registration_query_store.rb
@@ -83,12 +83,13 @@ class RegistrationQueryStore
   end
 
   def course_cohort
-    if store["course_cohort_id"].nil?
-      @course_cohort = CourseCohort.next_open_for(course:)
-      store["course_cohort_id"] = @course_cohort.id
-    end
+    @course_cohort ||= CourseCohort.find_by(id: store["course_cohort_id"]) || assign_course_cohort
+  end
 
-    @course_cohort ||= CourseCohort.find_by(id: store["course_cohort_id"])
+  def assign_course_cohort
+    CourseCohort.next_open_for(course:).tap do |course_cohort|
+      store["course_cohort_id"] = course_cohort.id
+    end
   end
 
   def lead_provider

--- a/app/services/registration_query_store.rb
+++ b/app/services/registration_query_store.rb
@@ -83,7 +83,12 @@ class RegistrationQueryStore
   end
 
   def course_cohort
-    @course_cohort ||= CourseCohort.next_open_for(course:)
+    if store["course_cohort_id"].nil?
+      @course_cohort = CourseCohort.next_open_for(course:)
+      store["course_cohort_id"] = @course_cohort.id
+    end
+
+    @course_cohort ||= CourseCohort.find_by(id: store["course_cohort_id"])
   end
 
   def lead_provider

--- a/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
+++ b/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
@@ -296,7 +296,7 @@ module ValidTestDataGenerators
 
       attrs = {
         start_year: cohort_year,
-        description: "#{cohort_year} #{registration_starts_at.strftime('%B')}",
+        description: "#{registration_starts_at.strftime('%B')} #{cohort_year}",
         registration_starts_at:,
         funding_cap: true,
       }

--- a/app/views/admin/cohorts/show.html.erb
+++ b/app/views/admin/cohorts/show.html.erb
@@ -8,11 +8,6 @@
     end
 
     sl.with_row do |row|
-      row.with_key(text: "Description")
-      row.with_value(text: @cohort.description)
-    end
-
-    sl.with_row do |row|
       row.with_key(text: "Start year")
       row.with_value(text: @cohort.start_year)
     end

--- a/app/views/applications/applications/_course_details.html.erb
+++ b/app/views/applications/applications/_course_details.html.erb
@@ -48,11 +48,11 @@
       sl.with_row do |row|
         row.with_key(text: "Course start")
         row.with_value do
-          concat application_course_start_date.titleize
+          concat application.raw_application_data['course_start']
 
           if application.pending_status? || application.accepted_status? || application.rejected_status?
             text = application.eligible_for_funding ? "eligible_for_funding" : "not_eligible_for_funding"
-            concat tag.p(I18n.t("course_start_details.#{text}", date: application_started_confirmed_by_date), class: "govuk-!-margin-top-2 govuk-!-margin-bottom-0")
+            concat tag.p(I18n.t("course_start_details.#{text}", date: application.course.application_started_confirmed_by_date), class: "govuk-!-margin-top-2 govuk-!-margin-bottom-0")
           end
         end
       end

--- a/app/views/applications/applications/_course_details.html.erb
+++ b/app/views/applications/applications/_course_details.html.erb
@@ -52,7 +52,7 @@
 
           if application.pending_status? || application.accepted_status? || application.rejected_status?
             text = application.eligible_for_funding ? "eligible_for_funding" : "not_eligible_for_funding"
-            concat tag.p(I18n.t("course_start_details.#{text}", date: application.course.application_started_confirmed_by_date), class: "govuk-!-margin-top-2 govuk-!-margin-bottom-0")
+            concat tag.p(I18n.t("course_start_details.#{text}", date: application.course_cohort.application_started_confirmed_by_date), class: "govuk-!-margin-top-2 govuk-!-margin-bottom-0")
           end
         end
       end

--- a/app/views/registration_wizard/cannot_register_yet.html.erb
+++ b/app/views/registration_wizard/cannot_register_yet.html.erb
@@ -8,7 +8,7 @@
     ) do
 %>
   <h1 class="govuk-heading-xl">You cannot register yet</h1>
-  <p class="govuk-body">Registrations are currently open for courses starting in <%= @wizard.query_store.course.next_cohort_start_date %>.</p>
+  <p class="govuk-body">Registrations are currently open for courses starting in <%= @wizard.query_store.course_cohort&.name || "Registration closed" %>.</p>
 
   <h2 class="govuk-heading-m">Stay informed</h2>
 

--- a/app/views/registration_wizard/cannot_register_yet.html.erb
+++ b/app/views/registration_wizard/cannot_register_yet.html.erb
@@ -8,8 +8,7 @@
     ) do
 %>
   <h1 class="govuk-heading-xl">You cannot register yet</h1>
-
-  <p class="govuk-body">Registrations are currently open for courses starting in <%= application_course_start_date %>.</p>
+  <p class="govuk-body">Registrations are currently open for courses starting in <%= @wizard.query_store.course.next_cohort_start_date %>.</p>
 
   <h2 class="govuk-heading-m">Stay informed</h2>
 

--- a/app/views/registration_wizard/course_start_date.html.erb
+++ b/app/views/registration_wizard/course_start_date.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-xl"><%= t("helpers.title.registration_wizard.course_start_date") %></h1>
 
-<p class="govuk-body"><%= t("helpers.title.registration_wizard.course_start_date_sub", date: application_course_start_date) %>.</p>
+<p class="govuk-body"><%= t("helpers.title.registration_wizard.course_start_date_sub", date: @form.application_course_start_date) %>.</p>
 
 <%=
   render(

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -28,7 +28,8 @@
     <%= govuk_warning_text(text: "You must register with DfE before you apply with a provider.") %>
 
     <ul class="govuk-list govuk-list--bullet">
-      <% LeadProvider.for(course:).each do |provider| %>
+      <% providers = course_cohort ? course_cohort.lead_providers.alphabetical : LeadProvider.none %>
+      <% providers.each do |provider| %>
         <li><%= govuk_link_to provider.name, provider.url %></li>
       <% end %>
     </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -500,6 +500,8 @@ en:
               schedule_not_found: There is no schedule for the current course in the
                 specified cohort
               declarations_present: Cannot change cohort for an application with declarations
+            course_cohort:
+              not_found: Cannot find course cohort for give new cohort/course
             application:
               <<: *application
             course_cohort:

--- a/spec/accessibility/registration_wizard_spec.rb
+++ b/spec/accessibility/registration_wizard_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Registration wizard templates", :axe, type: :view do
       next_step_path: "check-answers",
       current_step: :teacher_catchment,
       course: course_stub,
+      query_store: OpenStruct.new(course: course_stub),
       store: store_stub,
       answers: answers_stub,
     )
@@ -33,6 +34,7 @@ RSpec.describe "Registration wizard templates", :axe, type: :view do
     OpenStruct.new(
       identifier: "the-course",
       name: "The course",
+      next_cohort_start_date: "October 2026",
     )
   end
 

--- a/spec/accessibility/registration_wizard_spec.rb
+++ b/spec/accessibility/registration_wizard_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Registration wizard templates", :axe, type: :view do
       next_step_path: "check-answers",
       current_step: :teacher_catchment,
       course: course_stub,
-      query_store: OpenStruct.new(course: course_stub),
+      query_store: OpenStruct.new(course: course_stub, course_cohort: course_cohort_stub),
       store: store_stub,
       answers: answers_stub,
     )
@@ -35,6 +35,13 @@ RSpec.describe "Registration wizard templates", :axe, type: :view do
       identifier: "the-course",
       name: "The course",
       next_cohort_start_date: "October 2026",
+    )
+  end
+
+  let(:course_cohort_stub) do
+    OpenStruct.new(
+      name: "October 2026",
+      lead_providers: LeadProvider.none,
     )
   end
 
@@ -77,7 +84,9 @@ RSpec.describe "Registration wizard templates", :axe, type: :view do
     assign(:wizard, wizard_stub)
     assign(:form, form_stub)
     course = course_stub
+    course_cohort = course_cohort_stub
     view.define_singleton_method(:course) { course }
+    view.define_singleton_method(:course_cohort) { course_cohort }
     allow(view).to receive_messages(current_user: user_stub, registration_wizard_form_url: "/registration/test")
   end
 

--- a/spec/components/admin/application_history_component_spec.rb
+++ b/spec/components/admin/application_history_component_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Admin::ApplicationHistoryComponent, :versioning, type: :component
   subject { render_inline described_class.new(record: application) }
 
   let(:application) { create(:application) }
-  let(:time_1) { Time.zone.local(2025, 1, 1, 13, 0, 0) }
-  let(:time_2) { Time.zone.local(2025, 1, 1, 14, 0, 0) }
-  let(:time_3) { Time.zone.local(2025, 1, 1, 15, 0, 0) }
-  let(:time_4) { Time.zone.local(2025, 1, 1, 16, 0, 0) }
+  let(:time_1) { Time.zone.local(2025, 3, 1, 13, 0, 0) }
+  let(:time_2) { Time.zone.local(2025, 3, 1, 14, 0, 0) }
+  let(:time_3) { Time.zone.local(2025, 3, 1, 15, 0, 0) }
+  let(:time_4) { Time.zone.local(2025, 3, 1, 16, 0, 0) }
   let(:cohort) { create(:cohort, start_year: 2024) }
   let(:older_cohort) { create(:cohort, start_year: 2023) }
   let(:whodunnit) { "AdminUser 1" }
@@ -46,7 +46,7 @@ RSpec.describe Admin::ApplicationHistoryComponent, :versioning, type: :component
     end
 
     it "shows the date of each change" do
-      expect(subject).to have_css(".moj-timeline__byline", text: "by some user, 1 Jan 2025 2:00pm")
+      expect(subject).to have_css(".moj-timeline__byline", text: "by some user, 1 Mar 2025 2:00pm")
     end
 
     context "when the user is an Admin" do
@@ -143,7 +143,7 @@ RSpec.describe Admin::ApplicationHistoryComponent, :versioning, type: :component
 
     it "shows who made the change using the whodunnit string and the date of the change" do
       expect(subject).to have_text("Notes updated")
-      expect(subject).to have_text("by #{whodunnit}, 1 Jan 2025 4:00pm")
+      expect(subject).to have_text("by #{whodunnit}, 1 Mar 2025 4:00pm")
     end
 
     it "renders the note with a details component" do

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -108,7 +108,16 @@ FactoryBot.define do
     trait :previously_funded do
       after(:create) do |application|
         course = application.course.rebranded_alternative_courses.first
-        previous_cohort = create(:cohort, :unique, :with_funding_cap)
+        previous_registration_starts_at = application.cohort.registration_starts_at.prev_month
+        previous_registration_starts_at = application.cohort.registration_starts_at.next_month if previous_registration_starts_at.year < 2021
+
+        previous_cohort = Cohort.find_by(registration_starts_at: previous_registration_starts_at) ||
+          create(
+            :cohort,
+            :with_funding_cap,
+            start_year: previous_registration_starts_at.year,
+            registration_starts_at: previous_registration_starts_at,
+          )
 
         if previous_cohort == application.cohort
           previous_cohort = create(:cohort, :with_funding_cap,

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -1,31 +1,26 @@
 FactoryBot.define do
   factory :cohort do
     sequence(:start_year, 0) { |n| 2021 + n % 9 }
-    registration_starts_at { Date.new(start_year, 4, 3) }
+    registration_starts_at { Date.new(start_year, Date.current.month - 1, 3) }
+    registration_ends_at { registration_starts_at.advance(months: 2) }
     funding_cap { true }
-
-    description do
-      registration_starts_at.strftime("%B %Y")
-    end
-
-    identifier do
-      registration_starts_at.strftime("%Y-%B").downcase
-    end
+    description { registration_starts_at.strftime("%B %Y") }
+    identifier { registration_starts_at.strftime("%Y-%B") }
 
     initialize_with do
       Cohort.find_or_create_by(registration_starts_at:)
     end
 
     trait :current do
-      start_year { Date.current.month < 9 ? Date.current.year.pred : Date.current.year }
+      start_year { Date.current.year }
     end
 
     trait :next do
-      start_year { Date.current.month < 9 ? Date.current.year : Date.current.year.succ }
+      start_year { Date.current.year.succ }
     end
 
     trait :previous do
-      start_year { Date.current.month < 9 ? Date.current.year : (Date.current.year - 1) }
+      start_year { Date.current.year.pred }
     end
 
     trait :unique do
@@ -36,7 +31,6 @@ FactoryBot.define do
         Date.new(year, month, 3)
       end
       start_year { registration_starts_at.year }
-      description { "#{registration_starts_at.year} #{registration_starts_at.strftime('%B')}" }
     end
 
     trait :with_funding_cap do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
         rescue StandardError
           create(:cohort, :current)
         end
+
         schedule = CourseCohort.find_by(course:, cohort:)&.schedule || create(:schedule, cohort:)
         course.course_cohorts << create(:course_cohort, course:, cohort:, schedule:, lead_provider: evaluator.lead_provider)
       end

--- a/spec/features/admin/applications/applications_spec.rb
+++ b/spec/features/admin/applications/applications_spec.rb
@@ -343,7 +343,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
     click_button "Continue"
     expect(page).to have_css(".govuk-error-message", text: "Choose a cohort")
 
-    choose future_cohort.start_year.to_s, visible: :all
+    choose future_cohort.name, visible: :all
     click_button "Continue"
 
     within(".govuk-summary-list__row", text: "Schedule cohort") do |row|

--- a/spec/features/admin/cohorts_spec.rb
+++ b/spec/features/admin/cohorts_spec.rb
@@ -33,7 +33,6 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
 
     within(".govuk-summary-list") do |summary_list|
       expect(summary_list).to have_summary_item("Name", "2026")
-      expect(summary_list).to have_summary_item("Description", "April 2026")
       expect(summary_list).to have_summary_item("Start year", "2026")
       expect(summary_list).to have_summary_item("Registration start date", "1 April 2026")
       expect(summary_list).to have_summary_item("Funding cap", "Yes")
@@ -67,7 +66,7 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
 
       cohort = Cohort.order(created_at: :desc, id: :desc).first
       expect(cohort.identifier).to eq("2029-March")
-      expect(cohort.name).to eq("2029")
+      expect(cohort.name).to eq("2029 to 2030")
       expect(cohort.description).to eq("2029 to 2030")
       expect(cohort.start_year).to be(2029)
       expect(cohort.funding_cap).to be(true)
@@ -96,7 +95,7 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
       cohort.reload
 
       expect(cohort.identifier).to eq("2025-May")
-      expect(cohort.name).to eq("2025")
+      expect(cohort.name).to eq(new_description)
       expect(cohort.description).to eq(new_description)
       expect(cohort.start_year).to be(2025)
       expect(cohort.funding_cap).to be(true)

--- a/spec/features/admin/cohorts_spec.rb
+++ b/spec/features/admin/cohorts_spec.rb
@@ -4,8 +4,8 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
   include Helpers::AdminLogin
   include Helpers::FileHelper
 
-  let(:admin)  { create :admin }
-  let(:cohort) { Cohort.find_by! identifier: "2026-April" }
+  let(:admin) { create :admin }
+  let!(:cohort) { Cohort.find_by(identifier: "2026-April") || create(:cohort, start_year: 2026, registration_starts_at: Date.new(2026, 4, 1)) }
 
   let(:new_button_text)    { "New cohort" }
   let(:edit_button_text)   { "Edit cohort details" }
@@ -22,13 +22,8 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
     visit_index
 
     expect(Cohort.count).to be_positive
-
-    expect(page).to have_table(rows: [
-      ["April 2028", "3 April 2028", "Yes"],
-      ["April 2027", "3 April 2027", "Yes"],
-      ["April 2026", "3 April 2026", "Yes"],
-      ["April 2025", "3 April 2025", "Yes"],
-    ])
+    expected = Cohort.order_by_latest.map { |c| [c.description, c.registration_starts_at.to_date.to_fs(:govuk), "Yes"] }
+    expect(page).to have_table(rows: expected)
   end
 
   scenario "viewing details" do
@@ -40,7 +35,7 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
       expect(summary_list).to have_summary_item("Name", "2026")
       expect(summary_list).to have_summary_item("Description", "April 2026")
       expect(summary_list).to have_summary_item("Start year", "2026")
-      expect(summary_list).to have_summary_item("Registration start date", "3 April 2026")
+      expect(summary_list).to have_summary_item("Registration start date", "1 April 2026")
       expect(summary_list).to have_summary_item("Funding cap", "Yes")
     end
   end

--- a/spec/features/admin/courses_spec.rb
+++ b/spec/features/admin/courses_spec.rb
@@ -76,9 +76,7 @@ RSpec.feature "Listing and viewing courses", type: :feature do
   end
 
   context "when signed in as super admin" do
-    before do
-      sign_in_as(create(:super_admin))
-    end
+    let(:admin_user) { create(:super_admin) }
 
     scenario "editing a course name" do
       course = Course.first

--- a/spec/features/admin/courses_spec.rb
+++ b/spec/features/admin/courses_spec.rb
@@ -4,16 +4,14 @@ RSpec.feature "Listing and viewing courses", type: :feature do
   include Helpers::AdminLogin
 
   let(:courses_per_page) { Pagy::DEFAULT[:limit] }
+  let(:admin_user) { create(:admin) }
 
   before do
     create(:course, :npd_eirt)
+    sign_in_as(admin_user)
   end
 
   context "when signed in as admin" do
-    before do
-      sign_in_as(create(:admin))
-    end
-
     scenario "viewing the list of courses" do
       course = create(:course, name: "Course with multiple cohorts", identifier: "course-with-multiple-cohorts")
 

--- a/spec/features/admin/dashboards/courses_dashboard_spec.rb
+++ b/spec/features/admin/dashboards/courses_dashboard_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Viewing the courses dashboard", type: :feature do
   scenario "filtering courses dashboard by a single cohort updates application counts" do
     visit admin_dashboard_path("courses-dashboard")
 
-    select previous_cohort.start_year.to_s, from: "Search by cohort"
+    select previous_cohort.description, from: "Search by cohort"
     click_button "Search"
 
     expect(page).to have_content("Test Course")

--- a/spec/features/admin/dashboards/providers_dashboard_spec.rb
+++ b/spec/features/admin/dashboards/providers_dashboard_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Viewing the providers dashboard", type: :feature do
   scenario "filtering providers dashboard by a single cohort updates application counts" do
     visit admin_dashboard_path("providers-dashboard")
 
-    select previous_cohort.start_year.to_s, from: "Search by cohort"
+    select previous_cohort.description, from: "Search by cohort"
     click_button "Search"
 
     expect(page).to have_content("Test Provider")

--- a/spec/features/admin/finance/statement_change_per_participant_spec.rb
+++ b/spec/features/admin/finance/statement_change_per_participant_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Statement - change payment per participant", type: :feature do
 
     expect(page).to have_content("#{contract.course.name} payment per participant changed" \
                                  " for all #{statement.lead_provider.name} contracts"\
-                                 " in the #{statement.cohort.start_year} cohort" \
+                                 " in the #{statement.cohort.name} cohort" \
                                  " from #{Time.zone.today.strftime('%B %Y')} onwards")
     expect(contract.reload.per_participant).to eq(123)
     expect(future_contract.reload.per_participant).to eq(123)

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -26,7 +26,8 @@ RSpec.feature "Happy journeys", :with_default_lead_provider, :with_default_sched
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
       expect(page).to have_text("When do you want to start the course?")
-      page.choose("October 2026", visible: :all)
+
+      page.choose(Course.reception.next_cohort_start_date, visible: :all)
     end
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
@@ -57,7 +58,7 @@ RSpec.feature "Happy journeys", :with_default_lead_provider, :with_default_sched
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => Course.reception.next_cohort_start_date,
           "Course" => Course.last.name,
           "Provider" => LeadProvider.first.name,
           "Workplace" => "open manchester school – street 1, manchester",
@@ -140,7 +141,7 @@ RSpec.feature "Happy journeys", :with_default_lead_provider, :with_default_sched
       "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "funding_amount" => nil,
         "institution_id" => Institution.find_by(institution_reference_number: "100000").id.to_s,

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Happy journeys", :with_default_lead_provider, :with_default_sched
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
       expect(page).to have_text("When do you want to start the course?")
 
-      page.choose(Course.reception.next_cohort_start_date, visible: :all)
+      page.choose(CourseCohort.next_open_for(course: Course.reception).name, visible: :all)
     end
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
@@ -58,7 +58,7 @@ RSpec.feature "Happy journeys", :with_default_lead_provider, :with_default_sched
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => Course.reception.next_cohort_start_date,
+          "Course start" => CourseCohort.next_open_for(course: Course.reception).name,
           "Course" => Course.last.name,
           "Provider" => LeadProvider.first.name,
           "Workplace" => "open manchester school – street 1, manchester",
@@ -141,7 +141,7 @@ RSpec.feature "Happy journeys", :with_default_lead_provider, :with_default_sched
       "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "funding_amount" => nil,
         "institution_id" => Institution.find_by(institution_reference_number: "100000").id.to_s,

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -141,7 +141,8 @@ RSpec.feature "Happy journeys", :with_default_lead_provider, :with_default_sched
       "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
-        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
+        "course_cohort_id" => latest_application.course_cohort_id,
+        "course_start" => latest_application.course_cohort.name,
         "course_start_date" => "yes",
         "funding_amount" => nil,
         "institution_id" => Institution.find_by(institution_reference_number: "100000").id.to_s,

--- a/spec/features/journeys/reception_registration/other_setting_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/other_setting_in_england_spec.rb
@@ -45,6 +45,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
         "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
+        "course_cohort_id" => CourseCohort.next_open_for(course: Course.reception).id,
         "course_start_date" => "yes",
         "funding" => "another",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/other_setting_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/other_setting_in_england_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "funding" => "another",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/other_setting_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/other_setting_in_england_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "funding" => "another",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/other_setting_not_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/other_setting_not_in_england_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
         "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
+        "course_cohort_id" => CourseCohort.next_open_for(course: Course.reception).id,
         "course_start_date" => "yes",
         "funding" => "another",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/other_setting_not_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/other_setting_not_in_england_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "funding" => "another",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/other_setting_not_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/other_setting_not_in_england_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "funding" => "another",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_in_england_other_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_in_england_other_funded_spec.rb
@@ -45,6 +45,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
         "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
+        "course_cohort_id" => CourseCohort.next_open_for(course: Course.reception).id,
         "course_start_date" => "yes",
         "funding" => "another",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_in_england_other_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_in_england_other_funded_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "funding" => "another",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_in_england_other_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_in_england_other_funded_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "funding" => "another",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_in_england_self_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_in_england_self_funded_spec.rb
@@ -45,6 +45,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
         "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
+        "course_cohort_id" => CourseCohort.next_open_for(course: Course.reception).id,
         "course_start_date" => "yes",
         "funding" => "self",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_in_england_self_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_in_england_self_funded_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "funding" => "self",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_in_england_self_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_in_england_self_funded_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "funding" => "self",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_in_england_trust_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_in_england_trust_funded_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "funding" => "trust",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_in_england_trust_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_in_england_trust_funded_spec.rb
@@ -45,6 +45,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
         "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
+        "course_cohort_id" => CourseCohort.next_open_for(course: Course.reception).id,
         "course_start_date" => "yes",
         "funding" => "trust",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_in_england_trust_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_in_england_trust_funded_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "funding" => "trust",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_in_england_workplace_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_in_england_workplace_funded_spec.rb
@@ -45,6 +45,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
         "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
+        "course_cohort_id" => CourseCohort.next_open_for(course: Course.reception).id,
         "course_start_date" => "yes",
         "funding" => "school",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_in_england_workplace_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_in_england_workplace_funded_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "funding" => "school",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_in_england_workplace_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_in_england_workplace_funded_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "funding" => "school",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_not_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_not_in_england_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "funding" => "self",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_not_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_not_in_england_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
         "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
+        "course_cohort_id" => CourseCohort.next_open_for(course: Course.reception).id,
         "course_start_date" => "yes",
         "funding" => "self",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/private_setting_not_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_not_in_england_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "funding" => "self",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/state_funded_school_in_england_previously_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_in_england_previously_funded_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "funding" => "self",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/state_funded_school_in_england_previously_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_in_england_previously_funded_spec.rb
@@ -55,6 +55,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
         "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
+        "course_cohort_id" => CourseCohort.next_open_for(course: Course.reception).id,
         "course_start_date" => "yes",
         "funding" => "self",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/state_funded_school_in_england_previously_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_in_england_previously_funded_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "funding" => "self",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/state_funded_school_in_england_with_funded_place_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_in_england_with_funded_place_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "funding_amount" => nil,
         "institution_id" => institution.id.to_s,

--- a/spec/features/journeys/reception_registration/state_funded_school_in_england_with_funded_place_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_in_england_with_funded_place_spec.rb
@@ -51,6 +51,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
         "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
+        "course_cohort_id" => CourseCohort.next_open_for(course: Course.reception).id,
         "course_start_date" => "yes",
         "funding_amount" => nil,
         "institution_id" => institution.id.to_s,

--- a/spec/features/journeys/reception_registration/state_funded_school_in_england_with_funded_place_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_in_england_with_funded_place_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "funding_amount" => nil,
         "institution_id" => institution.id.to_s,

--- a/spec/features/journeys/reception_registration/state_funded_school_in_england_without_funded_place_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_in_england_without_funded_place_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "funding" => "school",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/state_funded_school_in_england_without_funded_place_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_in_england_without_funded_place_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "funding" => "school",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/state_funded_school_in_england_without_funded_place_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_in_england_without_funded_place_spec.rb
@@ -55,6 +55,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
         "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
+        "course_cohort_id" => CourseCohort.next_open_for(course: Course.reception).id,
         "course_start_date" => "yes",
         "funding" => "school",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/state_funded_school_not_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_not_in_england_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "funding" => "trust",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/state_funded_school_not_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_not_in_england_spec.rb
@@ -45,6 +45,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
         "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
+        "course_cohort_id" => CourseCohort.next_open_for(course: Course.reception).id,
         "course_start_date" => "yes",
         "funding" => "trust",
         "funding_amount" => nil,

--- a/spec/features/journeys/reception_registration/state_funded_school_not_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_not_in_england_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
       expect(application.raw_application_data).to match(
         "can_share_choices" => "1",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "funding" => "trust",
         "funding_amount" => nil,

--- a/spec/features/journeys/sad_paths/teacher_catchment_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/teacher_catchment_not_in_england_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Sad journey", :with_default_lead_provider, :with_default_schedule
     end
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      page.choose("October 2026", visible: :all)
+      page.choose(Course.reception.next_cohort_start_date, visible: :all)
     end
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do

--- a/spec/features/journeys/sad_paths/teacher_catchment_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/teacher_catchment_not_in_england_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Sad journey", :with_default_lead_provider, :with_default_schedule
     end
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      page.choose(Course.reception.next_cohort_start_date, visible: :all)
+      page.choose(CourseCohort.next_open_for(course: Course.reception).name, visible: :all)
     end
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do

--- a/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "Sad journeys", :npq, :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => Course.reception.next_cohort_start_date,
+          "Course start" => CourseCohort.next_open_for(course: Course.reception).name,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
@@ -131,7 +131,7 @@ RSpec.feature "Sad journeys", :npq, :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => Course.reception.next_cohort_start_date,
+        "course_start" => CourseCohort.next_open_for(course: Course.reception).name,
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_england_wrong_catchment",

--- a/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "Sad journeys", :npq, :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => Course.reception.next_cohort_start_date,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
@@ -131,7 +131,7 @@ RSpec.feature "Sad journeys", :npq, :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
+        "course_start" => Course.reception.next_cohort_start_date,
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_england_wrong_catchment",

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -30,7 +30,8 @@ RSpec.feature "Service is closed", type: :feature do
     page.click_button("Start now")
 
     expect(page).to have_text("Choose your course start date")
-    page.choose("Registration closed", visible: :all)
+    course_start_date = CourseCohort.next_open_for(course: Course.reception)&.name || "Registration closed"
+    page.choose(course_start_date, visible: :all)
 
     # Registration is now closed
     close_registration!

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Service is closed", type: :feature do
     page.click_button("Start now")
 
     expect(page).to have_text("Choose your course start date")
-    page.choose(Course.reception.next_cohort_start_date, visible: :all)
+    page.choose("Registration closed", visible: :all)
 
     # Registration is now closed
     close_registration!

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Service is closed", type: :feature do
     page.click_button("Start now")
 
     expect(page).to have_text("Choose your course start date")
-    page.choose(application_course_start_date, visible: :all)
+    page.choose(Course.reception.next_cohort_start_date, visible: :all)
 
     # Registration is now closed
     close_registration!

--- a/spec/features/time_zone_spec.rb
+++ b/spec/features/time_zone_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Showing Application timestamps in UK local time", type: :feature do
   include Helpers::AdminLogin
 
-  let(:winter_timestamp) { Time.utc(Time.zone.now.year, 1, 1, 8, 15) }
+  let(:winter_timestamp) { Time.utc(Time.zone.now.year, 3, 1, 8, 15) }
   let(:summer_timestamp) { Time.utc(Time.zone.now.year, 7, 1, 11, 15) }
   let(:winter_application) { create(:application) }
   let(:summer_application) { create(:application) }
@@ -34,7 +34,7 @@ RSpec.feature "Showing Application timestamps in UK local time", type: :feature 
 
       expect(page).to have_css("h1", text: "Applications")
 
-      expect(page).to have_css("td", text: "1 Jan #{Time.zone.now.year} 8:15am")
+      expect(page).to have_css("td", text: "1 Mar #{Time.zone.now.year} 8:15am")
       expect(page).to have_css("td", text: "1 Jul #{Time.zone.now.year} 12:15pm")
     end
   end

--- a/spec/forms/admin/applications/change_cohort_form_spec.rb
+++ b/spec/forms/admin/applications/change_cohort_form_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe Admin::Applications::ChangeCohortForm, type: :model do
   subject(:service) { described_class.new(application:, course_cohort_id:) }
 
   let(:application) { create(:application, course_cohort:) }
-  let(:course_cohort) { create(:course_cohort, cohort: cohort_2021) }
+  let(:course_cohort) { create(:course_cohort, cohort: create(:cohort, start_year: 2021)) }
   let(:course) { course_cohort.course }
-  let(:cohort_2021) { create(:cohort, start_year: 2021) }
   let(:new_cohort) { create(:cohort, start_year: 2025) }
   let(:new_course_cohort) { create(:course_cohort, course:, cohort: new_cohort) }
   let(:course_cohort_id) { new_course_cohort.id }
@@ -22,11 +21,13 @@ RSpec.describe Admin::Applications::ChangeCohortForm, type: :model do
     let(:cohort_2023) { create(:cohort, start_year: 2023) }
     let(:cohort_2024) { create(:cohort, start_year: 2024) }
 
-    let!(:cc_2022) { create(:course_cohort, course:, cohort: cohort_2022) }
-    let!(:cc_2023) { create(:course_cohort, course:, cohort: cohort_2023) }
+    before do
+      create(:course_cohort, course:, cohort: cohort_2022)
+      create(:course_cohort, course:, cohort: cohort_2023)
+    end
 
     it "includes all cohorts except the application's current cohort" do
-      expect(service.course_cohort_options).to eq [cc_2022, cc_2023, new_course_cohort]
+      expect(service.course_cohort_options.map(&:id).sort).to eq(course.course_cohorts.map(&:id).excluding(application.course_cohort_id).sort)
     end
   end
 end

--- a/spec/forms/questionnaires/choose_your_provider_spec.rb
+++ b/spec/forms/questionnaires/choose_your_provider_spec.rb
@@ -59,7 +59,8 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
     subject { form.options }
 
     let(:form) { described_class.new }
-    let(:expected_providers) { LeadProvider.for(course:).alphabetical }
+    let(:course_cohort) { CourseCohort.next_open_for(course:) }
+    let(:expected_providers) { course_cohort.lead_providers.alphabetical }
 
     before do
       form.wizard = RegistrationWizard.new(

--- a/spec/forms/questionnaires/choose_your_provider_spec.rb
+++ b/spec/forms/questionnaires/choose_your_provider_spec.rb
@@ -20,20 +20,26 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
         current_user: create(:user),
       )
     end
+    let(:lead_provider_id) { nil }
 
     before do
       subject.wizard = wizard
     end
 
+    subject { described_class.new(lead_provider_id:) }
+
     it { is_expected.to validate_presence_of(:lead_provider_id) }
 
-    it "lead provider must exist" do
-      subject.lead_provider_id = 0
-      subject.valid?
-      expect(subject.errors[:lead_provider_id]).to be_present
-      subject.lead_provider_id = lead_provider.id
-      subject.valid?
-      expect(subject.errors[:lead_provider_id]).to be_blank
+    context "No lead provider" do
+      let(:lead_provider_id) { 0 }
+
+      it { is_expected.to have_error(:lead_provider_id) }
+    end
+
+    context "With lead provider" do
+      let(:lead_provider_id) { lead_provider.id }
+
+      it { is_expected.not_to have_error(:lead_provider_id) }
     end
   end
 

--- a/spec/jobs/crons/send_registration_open_notification_emails_job_spec.rb
+++ b/spec/jobs/crons/send_registration_open_notification_emails_job_spec.rb
@@ -10,18 +10,19 @@ RSpec.describe Crons::SendRegistrationOpenNotificationEmailsJob, type: :job do
         registration_starts_at: Time.zone.yesterday.prev_year,
       )
     end
+    let(:course_cohort) { create(:course_cohort, course: Course.last, cohort: application_cohort) }
     let(:application) do
       create(
         :application,
         :deferred,
-        cohort: application_cohort,
+        course_cohort:,
         schedule: create(:schedule, cohort: application_cohort),
       )
     end
 
     before { create(:course_cohort, cohort:, course: application.course) }
 
-    it "enqueues an email for a deferred application when its course is on a cohort that opened yesterday" do
+    it "enqueues email for deferred applications when registration opened yesterday" do
       expect { described_class.perform_now }
         .to have_enqueued_mail(GenericMailer, :registration_open_notification)
     end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Application do
     end
 
     context "when the cohort does not have a funding cap" do
-      let(:cohort) { create(:cohort, :without_funding_cap) }
+      let(:cohort) { create(:cohort, :unique, :without_funding_cap) }
 
       subject { build(:application, :accepted, cohort:) }
 

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -168,6 +168,6 @@ RSpec.describe Cohort, type: :model do
   describe "#name" do
     subject { cohort.name }
 
-    it { is_expected.to eq cohort.start_year.to_s }
+    it { is_expected.to eq cohort.description }
   end
 end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -3,11 +3,12 @@ require "rails_helper"
 RSpec.describe Cohort, type: :model do
   let(:cohort) { create(:cohort) }
 
-  let :cohorts do
+  let(:cohorts) do
     (2024..2026).to_a.shuffle.flat_map do |start_year|
       [5, 8].shuffle.map do |month|
         registration_starts_at = Date.new(start_year, month, 10)
-        create :cohort, start_year:, registration_starts_at:, description: "#{start_year} #{Date::MONTHNAMES[month]}"
+        exist = Cohort.find_by(identifier: registration_starts_at.strftime("%Y-%B"))
+        exist || create(:cohort, start_year:, registration_starts_at:)
       end
     end
   end

--- a/spec/models/course_cohort_spec.rb
+++ b/spec/models/course_cohort_spec.rb
@@ -19,23 +19,27 @@ RSpec.describe CourseCohort do
     subject(:next_open_course_cohort) { described_class.next_open_for(course:) }
 
     let(:course) do
-      build(:course, identifier: "course-with-cohorts").tap(&:save!)
+      Course.create!(
+        name: "Course with cohorts",
+        identifier: "course-with-cohorts",
+        course_group: "reception",
+      )
     end
 
     around do |example|
-      travel_to(Date.new(2026, 6, 1)) { example.run }
+      travel_to(Date.new(2029, 6, 1)) { example.run }
     end
 
     it "returns the earliest course cohort with open registration" do
       later = create(
         :course_cohort,
         course:,
-        cohort: create(:cohort, start_year: 2026, registration_starts_at: Date.new(2026, 5, 1), registration_ends_at: Date.new(2026, 8, 1)),
+        cohort: create_cohort(Date.new(2029, 5, 1), registration_ends_at: Date.new(2029, 8, 1)),
       )
       earlier = create(
         :course_cohort,
         course:,
-        cohort: create(:cohort, start_year: 2026, registration_starts_at: Date.new(2026, 4, 1), registration_ends_at: Date.new(2026, 8, 1)),
+        cohort: create_cohort(Date.new(2029, 4, 1), registration_ends_at: Date.new(2029, 8, 1)),
       )
 
       expect(next_open_course_cohort).to eq(earlier)
@@ -46,16 +50,26 @@ RSpec.describe CourseCohort do
       later = create(
         :course_cohort,
         course:,
-        cohort: create(:cohort, start_year: 2026, registration_starts_at: Date.new(2026, 8, 1)),
+        cohort: create_cohort(Date.new(2029, 8, 1)),
       )
       earlier = create(
         :course_cohort,
         course:,
-        cohort: create(:cohort, start_year: 2026, registration_starts_at: Date.new(2026, 7, 1)),
+        cohort: create_cohort(Date.new(2029, 7, 1)),
       )
 
       expect(next_open_course_cohort).to eq(earlier)
       expect(next_open_course_cohort).not_to eq(later)
+    end
+
+    def create_cohort(registration_starts_at, registration_ends_at: registration_starts_at.advance(months: 2))
+      Cohort.create!(
+        start_year: registration_starts_at.year,
+        registration_starts_at:,
+        registration_ends_at:,
+        funding_cap: true,
+        description: registration_starts_at.strftime("%B %Y"),
+      )
     end
   end
 

--- a/spec/models/course_cohort_spec.rb
+++ b/spec/models/course_cohort_spec.rb
@@ -14,4 +14,68 @@ RSpec.describe CourseCohort do
   describe "validations" do
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive }
   end
+
+  describe ".next_open_for" do
+    subject(:next_open_course_cohort) { described_class.next_open_for(course:) }
+
+    let(:course) do
+      build(:course, identifier: "course-with-cohorts").tap(&:save!)
+    end
+
+    around do |example|
+      travel_to(Date.new(2026, 6, 1)) { example.run }
+    end
+
+    it "returns the earliest course cohort with open registration" do
+      later = create(
+        :course_cohort,
+        course:,
+        cohort: create(:cohort, start_year: 2026, registration_starts_at: Date.new(2026, 5, 1), registration_ends_at: Date.new(2026, 8, 1)),
+      )
+      earlier = create(
+        :course_cohort,
+        course:,
+        cohort: create(:cohort, start_year: 2026, registration_starts_at: Date.new(2026, 4, 1), registration_ends_at: Date.new(2026, 8, 1)),
+      )
+
+      expect(next_open_course_cohort).to eq(earlier)
+      expect(next_open_course_cohort).not_to eq(later)
+    end
+
+    it "returns the earliest upcoming course cohort when registration is not open" do
+      later = create(
+        :course_cohort,
+        course:,
+        cohort: create(:cohort, start_year: 2026, registration_starts_at: Date.new(2026, 8, 1)),
+      )
+      earlier = create(
+        :course_cohort,
+        course:,
+        cohort: create(:cohort, start_year: 2026, registration_starts_at: Date.new(2026, 7, 1)),
+      )
+
+      expect(next_open_course_cohort).to eq(earlier)
+      expect(next_open_course_cohort).not_to eq(later)
+    end
+  end
+
+  describe "#application_started_confirmed_by_date" do
+    subject(:confirmed_by_date) { course_cohort.application_started_confirmed_by_date }
+
+    let(:course_cohort) do
+      create(:course_cohort, schedule: create(:schedule, training_ends_at:, change_training_dates: false))
+    end
+
+    context "when training ends between January and April" do
+      let(:training_ends_at) { Date.new(2026, 4, 30) }
+
+      it { is_expected.to eq("Spring 2026") }
+    end
+
+    context "when training ends after April" do
+      let(:training_ends_at) { Date.new(2026, 8, 1) }
+
+      it { is_expected.to eq("Summer 2026") }
+    end
+  end
 end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe LeadProvider do
     let(:course) { create(:course, identifier: course_identifier) }
 
     context "with course npq-headship" do
-      let(:course_identifier) { "npq-headship" }
+      let(:course_identifier) { "tte-early-years" }
 
       it "returns expected lead providers" do
         expect(subject).to eq(LeadProvider.pluck(:name))

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -13,20 +13,6 @@ RSpec.describe LeadProvider do
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
   end
 
-  describe "#for" do
-    subject { described_class.for(course:).map(&:name) }
-
-    let(:course) { create(:course, identifier: course_identifier) }
-
-    context "with course npq-headship" do
-      let(:course_identifier) { "tte-early-years" }
-
-      it "returns expected lead providers" do
-        expect(subject).to eq(LeadProvider.pluck(:name))
-      end
-    end
-  end
-
   describe "#next_output_fee_statement" do
     let(:cohort) { create(:cohort, :current) }
     let(:lead_provider) { next_output_fee_statement.lead_provider }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,38 +3,6 @@ require "rails_helper"
 RSpec.describe User do
   subject { create(:user) }
 
-  describe "#active_applications_for(course:)" do
-    let!(:cohort) { create(:cohort, :current) }
-    let(:course) { create(:course) }
-    let(:course_cohort) { create(:course_cohort, course:, cohort:) }
-    let(:user) { create(:user) }
-    let!(:application) { create(:application, :accepted, user:, course_cohort:) }
-
-    context "when there are active applications for the current cohort and course" do
-      it do
-        expect(user.active_applications_for(course:, cohort:)).to eq([application])
-      end
-    end
-
-    context "when there are active applications for a different cohort but same course" do
-      let(:previous_cohort) { create(:cohort, :previous) }
-      let(:course_cohort) { create(:course_cohort, course:, cohort: previous_cohort) }
-      let!(:application) { create(:application, :accepted, user:, course_cohort:) }
-
-      it do
-        expect(user.active_applications_for(course:, cohort:)).to be_blank
-      end
-    end
-
-    context "when there are active applications for the current cohort and but not the specified course" do
-      let(:another_course) { create(:course) }
-
-      it do
-        expect(user.active_applications_for(course: another_course, cohort:)).to be_blank
-      end
-    end
-  end
-
   describe "relationships" do
     it { is_expected.to have_many(:applications).dependent(:destroy) }
     it { is_expected.to have_many(:participant_id_changes).order("created_at desc") }

--- a/spec/serializers/api/application_serializer_spec.rb
+++ b/spec/serializers/api/application_serializer_spec.rb
@@ -87,7 +87,6 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
 
     describe "cohort serialization" do
       it "serializes the `cohort`" do
-        cohort.start_year = 2025
         expect(attributes["cohort"]).to eq(cohort.start_year.to_s)
       end
     end

--- a/spec/services/api_tests/completed_declaration_spec.rb
+++ b/spec/services/api_tests/completed_declaration_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe APITests::CompletedDeclaration, type: :model do
   let(:has_passed) { "true" }
   let(:api_response) { instance_double(HTTParty::Response, code: 200, parsed_response: { "message" => "ok" }) }
   # let(:declaration_date) { (application.declarations.started.last.declaration_date + 1.day).in_time_zone("UTC") }
-  let(:declaration_date) { application.schedule.training_ends_at.in_time_zone("UTC") }
+  let(:declaration_date) { (application.declarations.started.last.declaration_date + 1.day).in_time_zone("UTC") }
 
   let(:expected_body) do
     {

--- a/spec/services/applications/change_cohort_spec.rb
+++ b/spec/services/applications/change_cohort_spec.rb
@@ -3,20 +3,23 @@
 require "rails_helper"
 
 RSpec.describe Applications::ChangeCohort, type: :service do
-  subject(:service) { described_class.new(application:, new_cohort:) }
-
-  let(:cohort_2021) { create(:cohort, start_year: 2021) }
-  let(:course_cohort) { create(:course_cohort, cohort: cohort_2021) }
+  let(:override_declarations_check) { false }
   let(:error_message_path) { "activemodel.errors.models.applications/change_cohort.attributes.base" }
-  let(:new_cohort) { create(:cohort, start_year: 2025) }
-  let(:new_course_cohort) { create(:course_cohort, cohort: new_cohort) }
+  let(:current_cohort) { create(:cohort, start_year: 2025) }
+  let(:new_cohort) { current_cohort }
+  let(:course_cohort) { create(:course_cohort, cohort: current_cohort) }
   let(:application) { create(:application, course_cohort:) }
 
-  before { subject.call }
+  subject(:service) { described_class.new(application:, new_cohort:, override_declarations_check:) }
+
+  before do
+    create(:course_cohort, cohort: new_cohort)
+    subject.call
+  end
 
   describe "validation" do
-    context "when the new cohort start_year is different to the current cohort start year" do
-      let(:new_cohort) { application.cohort }
+    context "when the new cohort start_year is the same" do
+      let(:new_cohort) { create(:cohort, start_year: 2025) }
 
       it do
         expect(subject).not_to be_valid
@@ -25,12 +28,15 @@ RSpec.describe Applications::ChangeCohort, type: :service do
     end
 
     context "when the new cohort start_year is different" do
+      let(:new_cohort) { create(:cohort, start_year: 2026) }
+
       it do
         expect(subject.errors).to be_blank
       end
     end
 
     context "when the application has declarations" do
+      let(:new_cohort) { create(:cohort, start_year: 2026) }
       let(:application) { create(:application, :with_declaration, course_cohort:) }
 
       it do
@@ -39,11 +45,11 @@ RSpec.describe Applications::ChangeCohort, type: :service do
       end
 
       context "when override_declarations_check is true" do
-        subject(:service) { described_class.new(application:, new_cohort:, override_declarations_check: true) }
+        let(:override_declarations_check) { true }
 
-        before { application.course_cohort = course_cohort }
-
-        it { is_expected.to be_valid }
+        it do
+          expect(application.reload.course_cohort.cohort).to eq(new_cohort)
+        end
       end
     end
   end

--- a/spec/services/cohorts/copy_delivery_partners_spec.rb
+++ b/spec/services/cohorts/copy_delivery_partners_spec.rb
@@ -2,8 +2,12 @@ require "rails_helper"
 
 RSpec.describe Cohorts::CopyDeliveryPartners do
   describe "#copy" do
-    let!(:previous_cohort) { create(:cohort, start_year: 2024) }
-    let(:cohort) { create(:cohort, start_year: 2025) }
+    let!(:previous_cohort) do
+      create(:cohort, start_year: 2029, registration_starts_at: Date.new(2029, 1, 1))
+    end
+    let(:cohort) do
+      create(:cohort, start_year: 2029, registration_starts_at: Date.new(2029, 2, 1))
+    end
     let(:service) { described_class.new(cohort) }
 
     let(:lead_provider_1) { create(:lead_provider) }

--- a/spec/services/handle_submission_for_store_spec.rb
+++ b/spec/services/handle_submission_for_store_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe HandleSubmissionForStore do
   let!(:course_cohort) { create(:course_cohort, course:, cohort:) }
 
   before do
-    travel_to(Date.new(cohort.start_year, 9, 26))
     allow_any_instance_of(School).to receive(:pp50?).and_return(false)
   end
 

--- a/spec/services/schedules/query_spec.rb
+++ b/spec/services/schedules/query_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Schedules::Query do
   let(:sort) { nil }
 
   let(:course_cohort1) { create(:course_cohort, course: create(:course, identifier: "other")) }
-  let(:course_cohort2) { create(:course_cohort, cohort: create(:cohort, start_year: "2021", registration_starts_at: Date.new(2021, 9, 1))) }
+  let(:course_cohort2) { create(:course_cohort, cohort: create(:cohort, start_year: 2021, registration_starts_at: Date.new(2021, 9, 1))) }
 
   describe "#course_cohorts" do
     before do

--- a/spec/services/valid_test_data_generators/api_test_scenarios_seeder_spec.rb
+++ b/spec/services/valid_test_data_generators/api_test_scenarios_seeder_spec.rb
@@ -162,8 +162,11 @@ RSpec.describe ValidTestDataGenerators::APITestScenariosSeeder do
           seeder.call
 
           course = Course.find_by!(identifier: "tte-early-years")
-          primary_course_cohort = CourseCohort.find_by(course:, cohort: Cohort.find_by(registration_starts_at: Date.new(cohort_year, 7, 1)))
-          secondary_course_cohort = CourseCohort.find_by(course:, cohort: Cohort.find_by(registration_starts_at: Date.new(cohort_year + 1, 7, 1)))
+          cohort_start_dates = seeder.cohort_start_dates.take(4)
+          primary_cohort = Cohort.find_by!(registration_starts_at: cohort_start_dates[0])
+          secondary_cohort = Cohort.find_by!(registration_starts_at: cohort_start_dates[2])
+          primary_course_cohort = CourseCohort.find_by!(course:, cohort: primary_cohort)
+          secondary_course_cohort = CourseCohort.find_by!(course:, cohort: secondary_cohort)
 
           expect(lead_provider.updateable_applications.where(course_cohort: primary_course_cohort).count).to eq(11)
           expect(lead_provider.updateable_applications.where(course_cohort: secondary_course_cohort).count).to eq(1)

--- a/spec/support/helpers/reception_registration_path_helper.rb
+++ b/spec/support/helpers/reception_registration_path_helper.rb
@@ -8,7 +8,7 @@ module Helpers
 
     def choose_current_course_start_date
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        page.choose(application_course_start_date, visible: :all)
+        page.choose(Course.reception.next_cohort_start_date, visible: :all)
       end
     end
 

--- a/spec/support/helpers/reception_registration_path_helper.rb
+++ b/spec/support/helpers/reception_registration_path_helper.rb
@@ -8,7 +8,7 @@ module Helpers
 
     def choose_current_course_start_date
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        page.choose(Course.reception.next_cohort_start_date, visible: :all)
+        page.choose(CourseCohort.next_open_for(course: Course.reception).name, visible: :all)
       end
     end
 


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#490

Spike to investigate how we're selecting the cohort an application registration is linked to.

### Changes proposed in this pull request

This spike investigates linking cohort selection to the course rather than using the static Cohort#current method.
It also adds registration_ends_at to the factories/seeds and fixes specs around those changes