### PR TITLE
[413] Update cookie policy

### DIFF
--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -52,10 +52,6 @@
       </tbody>
     </table>
 
-    <p class="govuk-body">
-      To register for an NPQ you need to create or sign in to your DfE Identity account. This uses <%= external_link_to "other cookies", :teaching_identity_cookies %>.
-    </p>
-
     <h2 class="govuk-heading-m">Analytics cookies (optional)</h2>
 
     <p class="govuk-body">


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#413

Remove content that links to DfE Identity from the Cookie Policy

### Changes proposed in this pull request

- removes 'To register for an NPQ you need to create or sign in to your DfE Identity account. This uses [other cookies](https://teaching-identity.education.gov.uk/cookies).'

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
