### PR TITLE
[412] Update email address 

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < Mail::Notify::Mailer
-  default from: "teacher-training-entitlement@digital.education.gov.uk"
+  default from: "continuing-professional-development@digital.education.gov.uk"
   layout "mailer"
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 class ApplicationMailer < Mail::Notify::Mailer
-  default from: "continuing-professional-development@digital.education.gov.uk"
+  # We use Gov.uk Notify to send emails, and the `default from:` is ignored
+  # default from: "continuing-professional-development@digital.education.gov.uk"
   layout "mailer"
 end

--- a/app/views/generic_mailer/change_provider.text.erb
+++ b/app/views/generic_mailer/change_provider.text.erb
@@ -25,7 +25,7 @@ You've registered for a course which starts in <%= params[:cohort_date] %>.
 Tell us about your experience using the registration service by [completing a short feedback form](<%= params[:feedback_link] %>).
 
 # Get help
-Email continuing-professional-development@education.gov.uk
+Email continuing-professional-development@digital.education.gov.uk
 
 Regards,
 The Teacher Continuing Professional Development Team

--- a/maintenance_page/html/index.html
+++ b/maintenance_page/html/index.html
@@ -101,7 +101,7 @@
             <div>
               <h2 class="govuk-heading-m">Get help</h2>
               <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                <li>Email: <a class="govuk-link app-!-overflow-break-word govuk-footer__link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20support">becomingateacher@digital.education.gov.uk</a></li>
+                <li>Email: <a class="govuk-link app-!-overflow-break-word govuk-footer__link" href="mailto:continuing-professional-development@digital.education.gov.uk?subject=Register%20trainee%20teachers%20support">continuing-professional-development@digital.education.gov.uk</a></li>
                 <li>We aim to respond within 5 working days, or one working day for more urgent queries</li>
               </ul>
             </div>


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#412

Update email address on all email forms to 
[continuing-professional-development@digital.education.gov.uk](mailto:continuing-professional-development@digital.education.gov.uk)

### Changes proposed in this pull request
- [x] Default mailer 'from' is ignored, commented out with a note
- [x] Change provider email
- [x] Maintenance page 

[What has been changed?]

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
