### PR TITLE
Add admin screens for course-cohort-providers

### DIFF
--- a/app/controllers/admin/course_cohort_providers_controller.rb
+++ b/app/controllers/admin/course_cohort_providers_controller.rb
@@ -1,0 +1,44 @@
+module Admin
+  class CourseCohortProvidersController < AdminController
+    before_action :course
+    before_action :ensure_super_admin
+    before_action :course_cohort
+    before_action :lead_providers
+
+    def show; end
+
+    def update
+      if @course_cohort.update(course_cohort_params)
+        flash[:success] = "Course cohort providers updated"
+        redirect_to admin_course_path(@course)
+      else
+        render :show, status: :unprocessable_content
+      end
+    end
+
+  private
+
+    def course
+      @course ||= Course.find(params[:course_id])
+    end
+
+    def course_cohort
+      @course_cohort ||= @course.course_cohorts.find(params[:id])
+    end
+
+    def course_cohort_params
+      params.require(:course_cohort).permit(lead_provider_ids: [])
+    end
+
+    def lead_providers
+      @lead_providers ||= LeadProvider.order(:name)
+    end
+
+    def ensure_super_admin
+      return if current_admin.super_admin?
+
+      flash[:error] = "You must be a super admin to change course cohort providers"
+      redirect_to admin_course_path(@course)
+    end
+  end
+end

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -8,6 +8,9 @@ module Admin
 
     def show
       @course = Course.find(params[:id])
+      @course_cohorts = @course.course_cohorts
+                               .includes(:cohort, :schedule, course_cohort_providers: :lead_provider)
+                               .sort_by { |course_cohort| course_cohort.cohort.start_year }
     end
 
   private

--- a/app/views/admin/course_cohort_providers/show.html.erb
+++ b/app/views/admin/course_cohort_providers/show.html.erb
@@ -1,0 +1,39 @@
+<%= govuk_back_link href: admin_course_path(@course) %>
+
+<h1 class="govuk-heading-l">Add or remove providers</h1>
+
+<%=
+  govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "Course")
+      row.with_value(text: @course.name)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Cohort")
+      row.with_value(text: @course_cohort.cohort.name)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Schedule")
+      row.with_value(text: @course_cohort.schedule.name)
+    end
+  end
+%>
+
+<%= form_with model: @course_cohort, url: admin_course_course_cohort_provider_path(@course, @course_cohort), method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_check_boxes(
+    :lead_provider_ids,
+    @lead_providers,
+    :id,
+    :name,
+    legend: { text: "Providers", size: "m" },
+  ) %>
+
+  <div class="govuk-button-group">
+    <%= f.govuk_submit "Save providers" %>
+    <%= govuk_link_to("Cancel", admin_course_path(@course), class: "govuk-link--no-visited-state") %>
+  </div>
+<% end %>

--- a/app/views/admin/courses/show.html.erb
+++ b/app/views/admin/courses/show.html.erb
@@ -31,3 +31,50 @@
     end
   end
 %>
+
+<hr class="govuk-section-break govuk-section-break--l">
+
+<h2 class="govuk-heading-m">Course cohorts</h2>
+
+<%=
+  govuk_table do |table|
+    table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(text: "Cohort")
+        row.with_cell(text: "Schedule")
+        row.with_cell(text: "Providers")
+        row.with_cell(text: "")
+      end
+    end
+
+    table.with_body do |body|
+      @course_cohorts.each do |course_cohort|
+        providers = course_cohort.course_cohort_providers.sort_by { _1.lead_provider.name }
+
+        body.with_row do |row|
+          row.with_cell(text: course_cohort.cohort.name)
+          row.with_cell(text: course_cohort.schedule.name)
+          row.with_cell do
+            if providers.any?
+              safe_join(
+                providers.map do |course_cohort_provider|
+                  tag.div(course_cohort_provider.lead_provider.name)
+                end,
+              )
+            else
+              "-"
+            end
+          end
+          row.with_cell do
+            if current_admin.super_admin? && course_cohort.cohort.registration_ends_at&.past? != true
+              govuk_link_to(
+                "Add/Remove providers",
+                admin_course_course_cohort_provider_path(@course, course_cohort),
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+%>

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -116,6 +116,7 @@ namespace :admin do
 
   resources :courses, only: %i[index show] do
     concerns :cohortable, index: "courses#index"
+    resources :course_cohort_providers, path: "course-cohort-providers", only: %i[show update]
   end
 
   resources :users, only: %i[index show]

--- a/spec/features/admin/courses_spec.rb
+++ b/spec/features/admin/courses_spec.rb
@@ -4,10 +4,11 @@ RSpec.feature "Listing and viewing courses", type: :feature do
   include Helpers::AdminLogin
 
   let(:courses_per_page) { Pagy::DEFAULT[:limit] }
+  let(:admin_account) { create(:admin) }
 
   before do
     create(:course, :npd_eirt)
-    sign_in_as(create(:admin))
+    sign_in_as(admin_account)
   end
 
   scenario "viewing the list of courses" do
@@ -36,6 +37,7 @@ RSpec.feature "Listing and viewing courses", type: :feature do
     visit(admin_courses_path)
 
     course = Course.order(name: :asc).first
+    course_cohort = course.course_cohorts.first
 
     click_link(course.name)
 
@@ -47,6 +49,48 @@ RSpec.feature "Listing and viewing courses", type: :feature do
       expect(summary_list).to have_summary_item("Position", course.position)
       expect(summary_list).to have_summary_item("Description", course.description)
       expect(summary_list).to have_summary_item("Display", "Yes")
+    end
+
+    expect(page).to have_css("h2", text: "Course cohorts")
+    expect(page).to have_content(course_cohort.cohort.name)
+    expect(page).to have_content(course_cohort.schedule.name)
+  end
+
+  context "when logged in as a super admin" do
+    let(:admin_account) { create(:super_admin) }
+
+    scenario "adding and removing providers from a course cohort" do
+      course = Course.order(name: :asc).first
+      course_cohort = course.course_cohorts.first
+      existing_lead_provider = course_cohort.lead_providers.first
+      lead_provider = create(:lead_provider, name: "A provider to add")
+
+      visit(admin_course_path(course))
+      click_link("Add/Remove providers")
+
+      uncheck existing_lead_provider.name, visible: :all
+      check lead_provider.name, visible: :all
+      click_button "Save providers"
+
+      expect(page).to have_content("Course cohort providers updated")
+      expect(course_cohort.lead_providers.reload).to contain_exactly(lead_provider)
+    end
+
+    scenario "cannot add or remove providers from a course cohort after registration has ended" do
+      course = Course.order(name: :asc).first
+      open_course_cohort = course.course_cohorts.first
+      closed_cohort = create(:cohort, :unique, registration_ends_at: 1.day.ago)
+      closed_course_cohort = create(:course_cohort, course:, cohort: closed_cohort)
+
+      visit(admin_course_path(course))
+
+      within("tr", text: open_course_cohort.cohort.name) do
+        expect(page).to have_link("Add/Remove providers")
+      end
+
+      within("tr", text: closed_course_cohort.cohort.name) do
+        expect(page).not_to have_link("Add/Remove providers")
+      end
     end
   end
 end

--- a/spec/requests/admin/course_cohort_providers_controller_spec.rb
+++ b/spec/requests/admin/course_cohort_providers_controller_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Admin::CourseCohortProvidersController, type: :request do
+  include Helpers::NPQSeparationAdminLogin
+
+  let(:course) { create(:course) }
+  let(:lead_provider) { create(:lead_provider) }
+  let!(:course_cohort) { create(:course_cohort, course:, lead_provider:) }
+
+  before { sign_in_as_admin(super_admin:) }
+
+  context "when logged in as super admin" do
+    let(:super_admin) { true }
+
+    describe "#show" do
+      before { get admin_course_course_cohort_provider_path(course, course_cohort) }
+
+      it { expect(response).to have_http_status(:success) }
+    end
+
+    describe "#update" do
+      let!(:new_lead_provider) { create(:lead_provider) }
+
+      it "updates the providers for the course cohort" do
+        patch admin_course_course_cohort_provider_path(course, course_cohort),
+              params: {
+                course_cohort: { lead_provider_ids: [new_lead_provider.id] },
+              }
+
+        expect(response).to redirect_to(admin_course_path(course))
+        expect(course_cohort.lead_providers.reload).to contain_exactly(new_lead_provider)
+      end
+    end
+  end
+
+  context "when logged in as normal admin" do
+    let(:super_admin) { false }
+
+    describe "#show" do
+      before { get admin_course_course_cohort_provider_path(course, course_cohort) }
+
+      it "redirects to the course page" do
+        expect(response).to redirect_to(admin_course_path(course))
+        expect(flash[:error]).to match(/You must be a super admin to change course cohort providers/i)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#505

There is no way to add/remove a provider from a course cohort unless you're on a rails console.

### Changes proposed in this pull request

Add admin screens to manage providers across course cohorts
