### PR TITLE
Schedule cron jobs on queue start

### DIFF
--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -5,4 +5,9 @@ namespace :db do
     Dir.glob(glob).each { |file| require file }
     CronJob.subclasses.each(&:schedule)
   end
+
+  # schedule cron jobs automatically when starting workers
+  %w[jobs:work].each do |task|
+    Rake::Task[task].enhance(["db:schedule_jobs"])
+  end
 end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#502


### Changes proposed in this pull request

Load schedule jobs before worker queue started