### PR TITLE
[474] Accessibility: Timeout dialog

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -11,6 +11,7 @@ $moj-images-path: "/";
 @import "govuk-frontend/dist/govuk/utilities/index";
 @import "govuk-frontend/dist/govuk/overrides/index";
 @import "@ministryofjustice/frontend/moj/components/timeline/timeline";
+@import "hmrc-frontend/hmrc/components/timeout-dialog/timeout-dialog";
 @import "accessible-autocomplete/src/autocomplete";
 @import "contents-list";
 @import "big-number";

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,13 @@
 class SessionsController < PublicPagesController
+  def extend_session
+    if session[:user_id].present?
+      session[:last_activity_at] = Time.current
+      head :ok
+    else
+      head :unauthorized
+    end
+  end
+
   def destroy
     admin = current_admin
     user = current_user

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -7,6 +7,7 @@ import accessibleAutocomplete from 'accessible-autocomplete';
 import institutionPicker from "./institution-picker";
 import cookieBanner from "./cookie-banner";
 import print from "./print";
+import HMRCFrontend from "hmrc-frontend/hmrc/all.js";
 
 Rails.start();
 import * as GOVUKFrontend from 'govuk-frontend'
@@ -16,6 +17,7 @@ window.GOVUKFrontend = GOVUKFrontend;
 
 window.onload = function init() {
   window.GOVUKFrontend.initAll();
+  HMRCFrontend.initAll();
 };
 
 if (document.querySelector('[data-picker="school"]')) {

--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -14,6 +14,19 @@
   <%= nonced_stylesheet_link_tag 'application', media: 'all' %>
   <%= nonced_javascript_include_tag 'application', defer: true %>
 
+  <% if session[:user_id].present? %>
+    <meta name="hmrc-timeout-dialog"
+          content="hmrc-timeout-dialog"
+          data-timeout="1800"
+          data-countdown="300"
+          data-keep-alive-url="<%= extend_session_path %>"
+          data-sign-out-url="<%= sign_out_user_path %>"
+          data-title="You're about to be signed out"
+          data-message="For your security, we will sign you out in"
+          data-keep-alive-button-text="Stay signed in"
+          data-sign-out-button-text="Sign out" />
+  <% end %>
+
   <%= nonced_style_tag do %>
     .hidden-element { display: none; visibility: hidden }
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
   get "/registration-interest/sign-up/confirm", to: "interest_notification_sign_up#confirm"
 
   get "/sign-in", to: "session_wizard#show", step: "sign_in"
+  get "/session/extend", to: "sessions#extend_session", as: "extend_session"
   match "/sign-out", to: "sessions#destroy", as: "sign_out_user", via: %i[get delete]
 
   get "/session/:step", to: "session_wizard#show", as: "session_wizard_show"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "file-loader": "^6.2.0",
     "govuk-country-and-territory-autocomplete": "^2.0.0",
     "govuk-frontend": "^5.8",
+    "hmrc-frontend": "^7.19.0",
     "mermaid": "^11.15.0",
     "rails-ujs": "^5.2.8",
     "sass": "^1.100.0",

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -3,6 +3,32 @@ require "rails_helper"
 RSpec.describe SessionsController do
   include Helpers::JourneyHelper
 
+  describe "#extend_session" do
+    context "when a user is signed in" do
+      let(:user) { create(:user) }
+
+      before do
+        session[:user_id] = user.id
+        session[:last_activity_at] = 20.minutes.ago
+      end
+
+      it "updates last_activity_at and returns ok" do
+        get :extend_session
+
+        expect(response).to have_http_status(:ok)
+        expect(session[:last_activity_at]).to be_within(1.second).of(Time.current)
+      end
+    end
+
+    context "when no user is signed in" do
+      it "returns unauthorized" do
+        get :extend_session
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
   context "when a user is signed in" do
     before do
       allow(controller).to receive(:current_user).and_return(create(:user))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2090,6 +2090,11 @@ govuk-frontend@^5.8:
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.14.0.tgz#d93f1ffa88b0696114509cab86e4ea474006f8e0"
   integrity sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==
 
+govuk-frontend@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-6.2.0.tgz#51ce06aa0e6d2c214749621fd12cedd77d4b1e33"
+  integrity sha512-PCRyQT+7kiV2dUz0Ku6Co+Nx4anOwJ7mAduXYbTQHK2krppBSynv9dBXtOYha/8j+LIzK7FqesTbJl9HD6ekHg==
+
 graceful-fs@^4.1.2, graceful-fs@^4.2.11, graceful-fs@^4.2.4:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
@@ -2111,6 +2116,14 @@ hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+hmrc-frontend@^7.19.0:
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/hmrc-frontend/-/hmrc-frontend-7.19.0.tgz#4a2be6beb4dc27bc67dcafd0890ea18a2abefba2"
+  integrity sha512-ORas1908ZOkr5Qc7FcnqUNd42X25ci9WKI3l7RMM+sfnjxoq5VP/xyZ9dzTkd4snS1d6c6EYzPaOGWeEk63wLQ==
+  dependencies:
+    accessible-autocomplete "^3.0.1"
+    govuk-frontend "^6.1.0"
 
 iconv-lite@0.6:
   version "0.6.3"


### PR DESCRIPTION

### Context

Fixes DFE-Digital/teacher-training-entitlement-board#474

Accessibility audit raised an issue that users are automatically signed out without any warning.

### Changes proposed in this pull request

After 25 minutes of inactivity, display a timeout dialog to warn the user that their session will expire in 5 minutes.
User can Extend their session or logout.

Based on:
https://design.tax.service.gov.uk/hmrc-design-patterns/service-timeout/

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
