### PR TITLE
[508] Completed application cannot be resumed

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -78,13 +78,27 @@ class Application < ApplicationRecord
 
   API_STATUSES = STATUSES + [REASSIGNED = "reassigned".freeze].freeze
 
+  # status transitions details
+  # nil       -> pending   ; application creation
+  # pending   -> accepted  ; lead provider accepts application
+  # pending   -> rejected  ; lead provider rejects application
+  # accepted  -> started   ; lead provider sends started declaration
+  # accepted  -> withdrawn ; lead provider withdraws application
+  # started   -> completed ; lead provider sends completed declaration
+  # started   -> deferred  ; lead provider defers application
+  # started   -> withdraw  ; lead provider withdraws application
+  # started   -> accepted  ; lead provider voids started declaration
+  # deferred  -> started   ; lead provider resumes application
+  # deferred  -> withdrawn ; cron job ExpireDeferredApplication
+  # rejected  -> pending   ; admin console `revert pending` action
+  # completed -> started   ; lead provider voids completed declaration
+  #
   STATUS_TRANSITIONS = {
     nil => [PENDING].freeze,
     PENDING => [ACCEPTED, REJECTED].freeze,
-    ACCEPTED => [STARTED, COMPLETED, WITHDRAWN].freeze,
+    ACCEPTED => [STARTED, WITHDRAWN].freeze,
     STARTED => [COMPLETED, DEFERRED, WITHDRAWN, ACCEPTED].freeze,
     DEFERRED => [STARTED, WITHDRAWN].freeze,
-    WITHDRAWN => [STARTED].freeze,
     REJECTED => [PENDING].freeze,
     COMPLETED => [STARTED].freeze,
   }.freeze

--- a/app/services/applications/resume.rb
+++ b/app/services/applications/resume.rb
@@ -8,8 +8,7 @@ module Applications
 
     attr_reader :application
 
-    validate :not_already_started
-    validate :not_already_accepted
+    validate :application_status
     validate :incompatible_course
     validate :cohort_not_in_training
     validate :cohort_exists
@@ -30,12 +29,10 @@ module Applications
 
   private
 
-    def not_already_started
-      add_error(:base, :already_started) if @application.started_status?
-    end
+    def application_status
+      return if @application.deferred_status?
 
-    def not_already_accepted
-      add_error(:base, :already_accepted) if @application.accepted_status?
+      add_error(:base, :application_status)
     end
 
     def incompatible_course

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -400,8 +400,7 @@ en:
         applications/resume:
           attributes:
             base:
-              already_started: The application is already started
-              already_accepted: The application is already accepted
+              application_status: The application status is not resumable
               cohort_not_in_training: Selected schedule is not currently in training
               cohort_missing: Cohort for the selected schedule cannot be found
               incompatible_schedule: Selected schedule is for a different course than

--- a/spec/requests/api/docs/v1/applications_spec.rb
+++ b/spec/requests/api/docs/v1/applications_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe "Applications endpoint", openapi_spec: "v1/swagger.yaml", type: :
                       "#/components/schemas/DeclarationResponse",
                       "#/components/schemas/DeclarationCompletedRequest" do
         let(:application) do
-          create(:application, :accepted, :with_declaration, course_cohort:, lead_provider:)
+          create(:application, :started, :with_declaration, course_cohort:, lead_provider:)
         end
         let(:resource) { application }
         let(:declaration_date) { schedule.training_starts_at + 1.hour }

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe "Application endpoints", type: :request do
       let(:expected_response) do
         {
           "errors" => [
-            { "title" => "base", "detail" => I18n.t("activemodel.errors.models.applications/resume.attributes.base.already_started") },
+            { "title" => "base", "detail" => I18n.t("activemodel.errors.models.applications/resume.attributes.base.application_status") },
           ],
         }
       end

--- a/spec/services/applications/resume_spec.rb
+++ b/spec/services/applications/resume_spec.rb
@@ -31,10 +31,12 @@ RSpec.describe Applications::Resume, type: :model do
   end
 
   describe "errors scenarios" do
-    context "when application is not deferred" do
-      let(:application) { create(:application, :accepted, :with_declaration, course_cohort:) }
+    (Application::STATUSES - [Application::DEFERRED]).each do |status|
+      context "when application is #{status}" do
+        let(:application) { create(:application, status, :with_declaration, course_cohort:) }
 
-      it { expect { service.call }.not_to change(application, :status) }
+        it { expect { service.call }.not_to change(application, :status) }
+      end
     end
 
     context "when course cohort has a different course than application" do

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Declarations::Create, type: :model do
   describe "completed declaration" do
     let(:declaration_type) { "completed" }
     let!(:application) do
-      create(:application, :accepted, :with_declaration, course_cohort:, lead_provider:)
+      create(:application, :started, :with_declaration, course_cohort:, lead_provider:)
     end
 
     describe "happy paths" do


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#508


### Changes proposed in this pull request

- Add application status transition details basic doc
- Add application resume status validation
- Remove un-necessary application status transitions:
   accepted  -> completed
   withdrawn -> started


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [X] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>

<!-- Message of single commit: -->