### PR TITLE
Enhance the course/cohort screens

### DIFF
--- a/app/controllers/admin/cohorts_controller.rb
+++ b/app/controllers/admin/cohorts_controller.rb
@@ -1,6 +1,7 @@
 class Admin::CohortsController < AdminController
   before_action :ensure_super_admin, except: %i[index show]
   before_action :cohort, only: %i[show edit update destroy]
+  before_action :set_back_path, only: %i[edit update]
 
   def index
     @pagy, @cohorts = pagy(Cohort.order_by_latest)
@@ -32,7 +33,7 @@ class Admin::CohortsController < AdminController
   def update
     if @cohort.update(cohort_params)
       flash[:success] = "Cohort updated"
-      redirect_to admin_cohort_path(@cohort)
+      redirect_to @back_path
     else
       render :form, status: :unprocessable_content
     end
@@ -60,13 +61,16 @@ private
       :registration_starts_at,
       :registration_ends_at,
       :funding_cap,
-      :suffix,
       :description,
     )
   end
 
   def cohort
     @cohort ||= Cohort.find(params[:id])
+  end
+
+  def set_back_path
+    @back_path = url_from(params[:redirect_to]) || admin_cohort_path(@cohort)
   end
 
   def ensure_super_admin

--- a/app/controllers/admin/cohorts_controller.rb
+++ b/app/controllers/admin/cohorts_controller.rb
@@ -58,6 +58,7 @@ private
   def cohort_params
     params.require(:cohort).permit(
       :start_year,
+      :suffix,
       :registration_starts_at,
       :registration_ends_at,
       :funding_cap,

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -7,7 +7,7 @@ module Admin
     end
 
     def show
-      @course = Course.find(params[:id])
+      @course = Course.includes(course_cohorts: :cohort).find(params[:id])
     end
 
   private

--- a/app/views/admin/cohorts/form.html.erb
+++ b/app/views/admin/cohorts/form.html.erb
@@ -1,5 +1,5 @@
 <% if @cohort.persisted? %>
-  <%= govuk_back_link href: admin_cohort_path(@cohort) %>
+  <%= govuk_back_link href: @back_path %>
 <% end %>
 
 <h1 class="govuk-heading-l">
@@ -10,7 +10,7 @@
   <% end %>
 </h1>
 
-<%= form_with model: [:admin, @cohort] do |f| %>
+<%= form_with model: [:admin, @cohort], url: @cohort.persisted? ? admin_cohort_path(@cohort, redirect_to: @back_path) : admin_cohorts_path do |f| %>
   <%= f.govuk_text_field :description %>
 
   <%= f.govuk_number_field :start_year,

--- a/app/views/admin/courses/show.html.erb
+++ b/app/views/admin/courses/show.html.erb
@@ -31,3 +31,35 @@
     end
   end
 %>
+
+<h2 class="govuk-heading-m">Course cohorts</h2>
+
+<%=
+  govuk_table do |table|
+    table.with_head do |header|
+      header.with_row do |row|
+        row.with_cell(text: "Cohort")
+        row.with_cell(text: "Registration start date")
+        row.with_cell(text: "Action")
+      end
+    end
+
+    table.with_body do |body|
+      @course.course_cohorts.sort_by { _1.cohort.registration_starts_at }.each do |course_cohort|
+        cohort = course_cohort.cohort
+
+        body.with_row do |row|
+          row.with_cell(text: cohort.description)
+          row.with_cell(text: cohort.registration_starts_at.to_fs(:govuk_short))
+          row.with_cell do
+            govuk_link_to(
+              "Edit",
+              edit_admin_cohort_path(cohort, redirect_to: admin_course_path(@course)),
+              class: "govuk-button govuk-!-margin-bottom-0",
+            )
+          end
+        end
+      end
+    end
+  end
+%>

--- a/spec/features/admin/cohorts_spec.rb
+++ b/spec/features/admin/cohorts_spec.rb
@@ -86,28 +86,28 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
       navigate_to_cohort
       click_on edit_button_text
 
-      new_description = "2025 to 2026 #{rand(100)}"
+      new_description = "2026 to 2027 #{rand(100)}"
       fill_in "Description", with: new_description
-      fill_in "Start year", with: "2025"
+      fill_in "Start year", with: "2026"
       fill_in "Suffix", with: "b"
       check "Funding cap", visible: :all
       within(".starts_at") do
         fill_in "Day", with: "6"
         fill_in "Month", with: "5"
-        fill_in "Year", with: "2025"
+        fill_in "Year", with: "2026"
       end
       expect { click_on "Update cohort" }.not_to(change(Cohort, :count))
       expect(page).to have_text("Cohort updated")
 
       cohort.reload
 
-      expect(cohort.identifier).to eq("2025b")
-      expect(cohort.name).to eq("2025b")
+      expect(cohort.identifier).to eq("2026b")
+      expect(cohort.name).to eq("2026b")
       expect(cohort.description).to eq(new_description)
-      expect(cohort.start_year).to be(2025)
+      expect(cohort.start_year).to be(2026)
       expect(cohort.suffix).to eq("b")
       expect(cohort.funding_cap).to be(true)
-      expect(cohort.registration_starts_at.to_date).to eq(Date.new(2025, 5, 6))
+      expect(cohort.registration_starts_at.to_date).to eq(Date.new(2026, 5, 6))
     end
 
     scenario "deletion" do

--- a/spec/features/admin/courses_spec.rb
+++ b/spec/features/admin/courses_spec.rb
@@ -4,10 +4,11 @@ RSpec.feature "Listing and viewing courses", type: :feature do
   include Helpers::AdminLogin
 
   let(:courses_per_page) { Pagy::DEFAULT[:limit] }
+  let(:admin_user) { create(:admin) }
 
   before do
     create(:course, :npd_eirt)
-    sign_in_as(create(:admin))
+    sign_in_as(admin_user)
   end
 
   scenario "viewing the list of courses" do
@@ -36,6 +37,7 @@ RSpec.feature "Listing and viewing courses", type: :feature do
     visit(admin_courses_path)
 
     course = Course.order(name: :asc).first
+    course_cohort = course.course_cohorts.first
 
     click_link(course.name)
 
@@ -48,5 +50,36 @@ RSpec.feature "Listing and viewing courses", type: :feature do
       expect(summary_list).to have_summary_item("Description", course.description)
       expect(summary_list).to have_summary_item("Display", "Yes")
     end
+
+    expect(page).to have_css("h2", text: "Course cohorts")
+    expect(page).to have_table(
+      with_rows: [
+        {
+          "Cohort" => course_cohort.cohort.description,
+          "Registration start date" => course_cohort.cohort.registration_starts_at.to_fs(:govuk_short),
+          "Action" => "Edit",
+        },
+      ],
+    )
+    expect(page).to have_link("Edit", href: edit_admin_cohort_path(course_cohort.cohort, redirect_to: admin_course_path(course)))
+  end
+
+  scenario "editing a cohort from the course details page returns to the course" do
+    admin_user.update!(super_admin: true)
+    course = Course.order(name: :asc).first
+    course_cohort = course.course_cohorts.first
+
+    visit(admin_course_path(course))
+    click_link("Edit")
+
+    expect(page).to have_current_path(edit_admin_cohort_path(course_cohort.cohort, redirect_to: admin_course_path(course)))
+    expect(page).to have_link("Back", href: admin_course_path(course))
+
+    fill_in "Description", with: "Updated cohort description"
+    click_on "Update cohort"
+
+    expect(page).to have_current_path(admin_course_path(course))
+    expect(page).to have_text("Cohort updated")
+    expect(course_cohort.cohort.reload.description).to eq("Updated cohort description")
   end
 end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#490

Add admin screens to enhance viewing/editing cohorts linked to courses

### Changes proposed in this pull request

- Alter admin/courses#show to show the linked cohorts
- Add links to edit cohorts from admin/courses#show
