### PR TITLE
[487] Handle invalid refresh tokens 

### DIFF
--- a/app/jobs/refresh_user_token_job.rb
+++ b/app/jobs/refresh_user_token_job.rb
@@ -4,6 +4,11 @@ class RefreshUserTokenJob < ApplicationJob
 
     result = TeacherAuth::RefreshToken.new(user.refresh_token).call
 
+    if result == :invalid_token
+      user.clear_auth_tokens!
+      return
+    end
+
     return unless result
 
     user.update!(

--- a/app/jobs/request_trn_job.rb
+++ b/app/jobs/request_trn_job.rb
@@ -8,6 +8,12 @@ class RequestTrnJob < ApplicationJob
 
     # Get fresh access token
     tokens = TeacherAuth::RefreshToken.new(user.refresh_token).call
+
+    if tokens == :invalid_token
+      user.clear_auth_tokens!
+      return
+    end
+
     raise RefreshTokenError, "Failed to refresh token for user #{user.id}" unless tokens
 
     # Request TRN activation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,6 +99,10 @@ class User < ApplicationRecord
     trn.blank? && refresh_token.present?
   end
 
+  def clear_auth_tokens!
+    update!(refresh_token: nil, refresh_token_updated_at: nil)
+  end
+
   def active_applications_for(course:, cohort:)
     applications
       .active_applications

--- a/app/services/teacher_auth/refresh_token.rb
+++ b/app/services/teacher_auth/refresh_token.rb
@@ -24,9 +24,16 @@ module TeacherAuth
           access_token: response.parsed_response["access_token"],
           refresh_token: response.parsed_response["refresh_token"],
         }
+      elsif invalid_grant?(response)
+        Sentry::Metrics.count(
+          "teacher_auth.refresh_token.invalid_grant",
+          value: 1,
+          attributes: { status_code: response.code },
+        )
+        :invalid_token
       else
         Rails.logger.error("TeacherAuth::RefreshToken failed: #{response.code} - #{response.body}")
-        invalid_grant?(response) ? :invalid_token : nil
+        nil
       end
     end
 

--- a/app/services/teacher_auth/refresh_token.rb
+++ b/app/services/teacher_auth/refresh_token.rb
@@ -26,8 +26,16 @@ module TeacherAuth
         }
       else
         Rails.logger.error("TeacherAuth::RefreshToken failed: #{response.code} - #{response.body}")
-        nil
+        invalid_grant?(response) ? :invalid_token : nil
       end
+    end
+
+  private
+
+    def invalid_grant?(response)
+      return false unless response.code == 400
+
+      response.parsed_response["error"] == "invalid_grant"
     end
   end
 end

--- a/spec/jobs/refresh_user_token_job_spec.rb
+++ b/spec/jobs/refresh_user_token_job_spec.rb
@@ -69,5 +69,19 @@ RSpec.describe RefreshUserTokenJob, type: :job do
         }.not_to(change { user.reload.refresh_token })
       end
     end
+
+    context "when the token is invalid" do
+      let(:refresh_service) { instance_double(TeacherAuth::RefreshToken) }
+
+      before do
+        allow(TeacherAuth::RefreshToken).to receive(:new).and_return(refresh_service)
+        allow(refresh_service).to receive(:call).and_return(:invalid_token)
+      end
+
+      it "clears the user's auth tokens" do
+        expect(user).to receive(:clear_auth_tokens!)
+        described_class.perform_now(user)
+      end
+    end
   end
 end

--- a/spec/jobs/request_trn_job_spec.rb
+++ b/spec/jobs/request_trn_job_spec.rb
@@ -83,6 +83,22 @@ RSpec.describe RequestTrnJob, type: :job do
       end
     end
 
+    context "when the token is invalid" do
+      before do
+        allow(TeacherAuth::RefreshToken).to receive(:new).and_return(refresh_service)
+        allow(refresh_service).to receive(:call).and_return(:invalid_token)
+      end
+
+      it "clears the user's auth tokens" do
+        expect(user).to receive(:clear_auth_tokens!)
+        described_class.perform_now(user)
+      end
+
+      it "does not raise an error" do
+        expect { described_class.perform_now(user) }.not_to raise_error
+      end
+    end
+
     context "when activate TRN returns nil" do
       before { stub_trn_services(trn: nil) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -435,4 +435,13 @@ RSpec.describe User do
       expect(user.can_request_trn?).to be false
     end
   end
+
+  describe "#clear_auth_tokens!" do
+    let(:user) { create(:user, refresh_token: "token", refresh_token_updated_at: 1.day.ago) }
+
+    it "clears refresh_token and refresh_token_updated_at" do
+      user.clear_auth_tokens!
+      expect(user.reload).to have_attributes(refresh_token: nil, refresh_token_updated_at: nil)
+    end
+  end
 end

--- a/spec/services/teacher_auth/refresh_token_spec.rb
+++ b/spec/services/teacher_auth/refresh_token_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe TeacherAuth::RefreshToken do
       it "returns :invalid_token" do
         expect(subject).to eq(:invalid_token)
       end
+
+      it "records a Sentry metric" do
+        expect(Sentry::Metrics).to receive(:count).with(
+          "teacher_auth.refresh_token.invalid_grant",
+          value: 1,
+          attributes: { status_code: 400 },
+        )
+        subject
+      end
     end
 
     context "when the request fails" do

--- a/spec/services/teacher_auth/refresh_token_spec.rb
+++ b/spec/services/teacher_auth/refresh_token_spec.rb
@@ -27,10 +27,21 @@ RSpec.describe TeacherAuth::RefreshToken do
       end
     end
 
+    context "when the token is invalid" do
+      before do
+        stub_request(:post, %r{/oauth2/token})
+          .to_return(status: 400, body: { error: "invalid_grant" }.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "returns :invalid_token" do
+        expect(subject).to eq(:invalid_token)
+      end
+    end
+
     context "when the request fails" do
       before do
         stub_request(:post, %r{/oauth2/token})
-          .to_return(status: 400, body: { error: "invalid_grant" }.to_json)
+          .to_return(status: 500, body: "")
       end
 
       it "returns nil" do


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#487

When a refresh_token has expired or is otherwise invalid, background jobs keep trying to refresh it.

### Changes proposed in this pull request

Adds handling for an `invalid_grant` error (400) and clears the user's auth tokens

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
