### PR TITLE
Ensure delayed_job will run on review apps

### DIFF
--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -6,8 +6,10 @@ namespace :db do
     CronJob.subclasses.each(&:schedule)
   end
 
-  # schedule cron jobs automatically when starting workers
-  %w[jobs:work].each do |task|
-    Rake::Task[task].enhance(["db:schedule_jobs"])
+  # schedule cron jobs automatically when starting workers (skip on review apps)
+  unless Rails.env.review?
+    %w[jobs:work].each do |task|
+      Rake::Task[task].enhance(["db:schedule_jobs"])
+    end
   end
 end


### PR DESCRIPTION
### Context

On review apps, the job to "schedule cron jobs automaticall" runs before the database is setup, and errors. Then delayed_job doesn't run.

https://dfe-teacher-services.sentry.io/issues/7554923376/

### Changes proposed in this pull request

We don't need scheduled tasks to run review apps, so we can bypass this and delayed job should start as expected.

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
