### PR TITLE
Prevent providers from withdrawing an accepted application

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -83,7 +83,6 @@ class Application < ApplicationRecord
   # pending   -> accepted  ; lead provider accepts application
   # pending   -> rejected  ; lead provider rejects application
   # accepted  -> started   ; lead provider sends started declaration
-  # accepted  -> withdrawn ; lead provider withdraws application
   # started   -> completed ; lead provider sends completed declaration
   # started   -> deferred  ; lead provider defers application
   # started   -> withdraw  ; lead provider withdraws application
@@ -96,7 +95,7 @@ class Application < ApplicationRecord
   STATUS_TRANSITIONS = {
     nil => [PENDING].freeze,
     PENDING => [ACCEPTED, REJECTED].freeze,
-    ACCEPTED => [STARTED, WITHDRAWN].freeze,
+    ACCEPTED => [STARTED].freeze,
     STARTED => [COMPLETED, DEFERRED, WITHDRAWN, ACCEPTED].freeze,
     DEFERRED => [STARTED, WITHDRAWN].freeze,
     REJECTED => [PENDING].freeze,

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -307,7 +307,9 @@ RSpec.describe "Application endpoints", type: :request do
       api_put(withdraw_api_v1_application_path(ecf_id: application.ecf_id), params:)
     end
 
-    context "when the application can be withdrawn" do
+    context "when the application is started" do
+      let(:application_status_trait) { :started }
+
       it_behaves_like "a successful api call"
 
       it "creates a withdrawn event" do
@@ -320,12 +322,19 @@ RSpec.describe "Application endpoints", type: :request do
 
     context "when the application is accepted" do
       let(:application_status_trait) { :accepted }
-      let(:application) { create(:application, application_status_trait, lead_provider: current_lead_provider, course_cohort:) }
 
-      it_behaves_like "a successful api call"
+      let(:expected_response) do
+        {
+          "errors" => [
+            { "title" => "application", "detail" => I18n.t("activemodel.errors.models.applications/withdraw.attributes.application.not_withdrawable") },
+          ],
+        }
+      end
+
+      it_behaves_like "an unprocessable content api call"
     end
 
-    context "when the application cannot be withdrawn" do
+    context "when the application is already withdrawn" do
       let(:application_status_trait) { :withdrawn }
       let(:expected_response) do
         {

--- a/spec/services/applications/withdraw_spec.rb
+++ b/spec/services/applications/withdraw_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Applications::Withdraw, type: :model do
-  subject(:service) { described_class.new(application:, reason:, admin_user: build(:admin)) }
+  subject(:service) { described_class.new(application:, reason:, admin_user:) }
 
-  let(:application) { create(:application, :accepted, :with_declaration) }
+  let(:admin_user) { build(:admin) }
+  let(:application) { create(:application, :started, :with_declaration) }
   let(:reason) { nil }
   let(:error_message_path) { "activemodel.errors.models.applications/withdraw.attributes" }
 
@@ -30,13 +31,33 @@ RSpec.describe Applications::Withdraw, type: :model do
     end
   end
 
-  context "when successfully withdrawing" do
+  context "when successfully withdrawing a started application" do
     let(:reason) { "other" }
-    let(:application) { create(:application, :accepted, :with_declaration) }
+    let(:application) { create(:application, :started, :with_declaration) }
 
     it do
       expect(service.errors).to be_blank
       expect(application.reload.status).to eq(Application::WITHDRAWN)
+    end
+  end
+
+  context "when not an admin user" do
+    let(:admin_user) { nil }
+    let(:reason) { "other" }
+
+    context "when successfully withdrawing a started application" do
+      let(:application) { create(:application, :started, :with_declaration) }
+
+      it do
+        expect(service.errors).to be_blank
+        expect(application.reload.status).to eq(Application::WITHDRAWN)
+      end
+    end
+
+    context "when withdrawing an accepted application" do
+      let(:application) { create(:application, :accepted) }
+
+      it { is_expected.to have_error(:application, :not_withdrawable) }
     end
   end
 end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#513

Currently we allow providers to withdraw accepted applications.
Advice from policy says that the correct process is for the provider to contact DfE in order to get the application reverted to pending, and then call the API to reject the application.

### Changes proposed in this pull request

- Remove withdrawn --> accepted transition from Application model
- Update specs
