### PR TITLE
Admin can no longer change status from accepted --> withdrawn

### DIFF
--- a/app/forms/admin/applications/change_status_form.rb
+++ b/app/forms/admin/applications/change_status_form.rb
@@ -26,10 +26,18 @@ module Admin
       end
 
       def status_options
-        OPTIONS.without(application&.status)
+        if application.accepted_status?
+          [Application::DEFERRED]
+        elsif application.started_status?
+          OPTIONS.without(Application::ACCEPTED)
+        else
+          OPTIONS.without(application&.status)
+        end
       end
 
       def reason_options
+        return REASON_OPTIONS.except(::Application::WITHDRAWN) if application.accepted_status?
+
         REASON_OPTIONS
       end
 

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -39,6 +39,12 @@ govuk_summary_list(card: { title: "Overview" }) do |sl|
     row.with_key(text: "Application status")
     row.with_value(text: @application.status.try(:humanize))
 
+    if @application.started_status?
+      row.with_action(
+        text: "Defer/Withdraw",
+        href: new_admin_applications_change_status_path(@application))
+    end
+    
     if @application.accepted_status? || @application.rejected_status?
       row.with_action(
         text: "Revert to Pending",
@@ -47,7 +53,7 @@ govuk_summary_list(card: { title: "Overview" }) do |sl|
 
       if @application.accepted_status?
         row.with_action(
-          text: "Defer/Withdraw",
+          text: "Defer",
           href: new_admin_applications_change_status_path(@application))
         elsif @application.deferred_status? || @application.withdrawn_status?
           row.with_action(

--- a/spec/features/admin/applications/applications_spec.rb
+++ b/spec/features/admin/applications/applications_spec.rb
@@ -262,7 +262,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
 
     within(".govuk-summary-list__row", text: "Application status") do |summary_list|
       expect(summary_list).to have_text "Accepted"
-      click_on "Defer/Withdraw"
+      click_on "Defer"
     end
 
     expect(page).to have_css("h1", text: "Change status")

--- a/spec/forms/admin/applications/change_status_form_spec.rb
+++ b/spec/forms/admin/applications/change_status_form_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Admin::Applications::ChangeStatusForm, type: :model do
 
       context "with status set to withdrawn" do
         let(:status) { Application::WITHDRAWN }
+        let(:application) { create(:application, :started) }
 
         it do
           expect(subject).to validate_inclusion_of(:reason)
@@ -79,6 +80,12 @@ RSpec.describe Admin::Applications::ChangeStatusForm, type: :model do
     context "when application set to active" do
       let(:application) { create(:application, :accepted, status: Application::ACCEPTED) }
 
+      it { expect(subject.status_options).to contain_exactly(Application::DEFERRED) }
+    end
+
+    context "when application set to started" do
+      let(:application) { create(:application, :started) }
+
       it { expect(subject.status_options).to contain_exactly(Application::DEFERRED, Application::WITHDRAWN) }
     end
 
@@ -96,18 +103,33 @@ RSpec.describe Admin::Applications::ChangeStatusForm, type: :model do
   end
 
   describe "#reason_options" do
-    it "groups by training status" do
-      expect(form.reason_options.keys).to contain_exactly(Application::DEFERRED, Application::WITHDRAWN)
+    context "when application set to active" do
+      it "only includes deferral reasons" do
+        expect(form.reason_options.keys).to contain_exactly(Application::DEFERRED)
+      end
+
+      it "has reasons for deferral" do
+        expect(form.reason_options[Application::DEFERRED])
+          .to match_array(::Applications::Defer::DEFERRAL_REASONS)
+      end
     end
 
-    it "has reasons for deferral" do
-      expect(form.reason_options[Application::DEFERRED])
-        .to match_array(::Applications::Defer::DEFERRAL_REASONS)
-    end
+    context "when application set to started" do
+      let(:application) { create(:application, :started) }
 
-    it "has reasons for withdrawn" do
-      expect(form.reason_options[Application::WITHDRAWN])
-        .to match_array(::Applications::Withdraw::WITHDRAWAL_REASONS)
+      it "groups by training status" do
+        expect(form.reason_options.keys).to contain_exactly(Application::DEFERRED, Application::WITHDRAWN)
+      end
+
+      it "has reasons for deferral" do
+        expect(form.reason_options[Application::DEFERRED])
+          .to match_array(::Applications::Defer::DEFERRAL_REASONS)
+      end
+
+      it "has reasons for withdrawn" do
+        expect(form.reason_options[Application::WITHDRAWN])
+          .to match_array(::Applications::Withdraw::WITHDRAWAL_REASONS)
+      end
     end
   end
 end

--- a/spec/requests/admin/applications/change_statuses_controller_spec.rb
+++ b/spec/requests/admin/applications/change_statuses_controller_spec.rb
@@ -7,11 +7,7 @@ RSpec.describe Admin::Applications::ChangeStatusesController, :ecf_api_disabled,
 
   subject { response }
 
-  let :application do
-    create(:application, :accepted).tap do |application|
-      create(:declaration, application:)
-    end
-  end
+  let(:application) { create(:application, :started, :with_declaration) }
 
   context "when logged in" do
     before { sign_in_as_admin }

--- a/spec/views/admin/applications/change_statuses/new.html.erb_spec.rb
+++ b/spec/views/admin/applications/change_statuses/new.html.erb_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe "admin/applications/change_statuses/new", type: :view do
     assign(:form, form)
   end
 
-  let(:application) { create(:application, :accepted) }
+  let(:application) { create(:application, :started) }
   let(:form) { Admin::Applications::ChangeStatusForm.new(id: application.id) }
   let(:form_path) { admin_applications_change_status_path(application) }
 
   it { is_expected.to have_css("h1", text: "Change status") }
 
   it { is_expected.to have_css(".govuk-inset-text p:first-of-type", text: application.user.id) }
-  it { is_expected.to have_css(".govuk-inset-text p:last-of-type", text: "Accepted") }
+  it { is_expected.to have_css(".govuk-inset-text p:last-of-type", text: "Started") }
   it { is_expected.to have_css(%(form[action="#{form_path}"]), count: 1) }
   it { is_expected.to have_css(%(.govuk-form-group fieldset label), text: "Deferred") }
   it { is_expected.to have_css(%(.govuk-form-group fieldset label), text: "Withdrawn") }

--- a/spec/views/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/admin/applications/show.html.erb_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "admin/applications/show.html.erb", type: :view do
 
       it do
         expect(subject).to have_link("Revert to Pending")
-        expect(subject).to have_link("Defer/Withdraw")
+        expect(subject).to have_link("Defer")
         expect(subject).not_to have_link("Accept")
       end
     end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#513

Currently we allow providers to withdraw accepted applications.
Advice from policy says that the correct process is for the provider to contact DfE in order to get the application reverted to pending, and then call the API to reject the application.
As such we no longer should support the admin moving an accepted application to withdrawb.

### Changes proposed in this pull request

- Update the Change Status controller/views to reflect new rules
- Update specs
