### PR TITLE
Fix bug in change provider when cannot find provider

### DIFF
--- a/app/controllers/applications/change_provider/change_provider_controller.rb
+++ b/app/controllers/applications/change_provider/change_provider_controller.rb
@@ -1,0 +1,15 @@
+module Applications
+  module ChangeProvider
+    class ChangeProviderController < ::Applications::ApplicationsController
+      before_action :ensure_can_change_provider
+
+    private
+
+      def ensure_can_change_provider
+        redirect_to applications_path and return unless application
+
+        redirect_to application_path(application.ecf_id) unless application.can_change_provider?
+      end
+    end
+  end
+end

--- a/app/controllers/applications/change_provider/check_answers_controller.rb
+++ b/app/controllers/applications/change_provider/check_answers_controller.rb
@@ -1,13 +1,11 @@
 module Applications
   module ChangeProvider
-    class CheckAnswersController < ::Applications::ApplicationsController
+    class CheckAnswersController < ChangeProviderController
       include MultiStepFormSession
 
       storing_form_session_as :change_provider
 
       def index
-        redirect_to application_path(application.ecf_id) and return unless application.can_change_provider?
-
         redirect_to application_change_provider_start_index_path(application.ecf_id) and return if new_provider.nil?
       end
 

--- a/app/controllers/applications/change_provider/check_answers_controller.rb
+++ b/app/controllers/applications/change_provider/check_answers_controller.rb
@@ -1,6 +1,6 @@
 module Applications
   module ChangeProvider
-    class CheckAnswersController < ChangeProviderController
+    class CheckAnswersController < ::Applications::ChangeProvider::ChangeProviderController
       include MultiStepFormSession
 
       storing_form_session_as :change_provider

--- a/app/controllers/applications/change_provider/contact_us_controller.rb
+++ b/app/controllers/applications/change_provider/contact_us_controller.rb
@@ -1,6 +1,6 @@
 module Applications
   module ChangeProvider
-    class ContactUsController < ChangeProviderController
+    class ContactUsController < ::Applications::ChangeProvider::ChangeProviderController
       def index; end
     end
   end

--- a/app/controllers/applications/change_provider/contact_us_controller.rb
+++ b/app/controllers/applications/change_provider/contact_us_controller.rb
@@ -1,6 +1,6 @@
 module Applications
   module ChangeProvider
-    class ContactUsController < ::Applications::ApplicationsController
+    class ContactUsController < ChangeProviderController
       def index; end
     end
   end

--- a/app/controllers/applications/change_provider/providers_controller.rb
+++ b/app/controllers/applications/change_provider/providers_controller.rb
@@ -1,6 +1,6 @@
 module Applications
   module ChangeProvider
-    class ProvidersController < ChangeProviderController
+    class ProvidersController < ::Applications::ChangeProvider::ChangeProviderController
       include MultiStepFormSession
 
       before_action :set_form

--- a/app/controllers/applications/change_provider/providers_controller.rb
+++ b/app/controllers/applications/change_provider/providers_controller.rb
@@ -1,14 +1,12 @@
 module Applications
   module ChangeProvider
-    class ProvidersController < ::Applications::ApplicationsController
+    class ProvidersController < ChangeProviderController
       include MultiStepFormSession
 
       before_action :set_form
       storing_form_session_as :change_provider
 
-      def index
-        redirect_to application_path(application.ecf_id) unless application.can_change_provider?
-      end
+      def index; end
 
       def create
         render :index, status: :unprocessable_content and return unless @form.valid?

--- a/app/controllers/applications/change_provider/start_controller.rb
+++ b/app/controllers/applications/change_provider/start_controller.rb
@@ -1,6 +1,6 @@
 module Applications
   module ChangeProvider
-    class StartController < ChangeProviderController
+    class StartController < ::Applications::ChangeProvider::ChangeProviderController
       include MultiStepFormSession
 
       before_action :set_form

--- a/app/controllers/applications/change_provider/start_controller.rb
+++ b/app/controllers/applications/change_provider/start_controller.rb
@@ -1,8 +1,7 @@
 module Applications
   module ChangeProvider
-    class StartController < ::Applications::ApplicationsController
+    class StartController < ChangeProviderController
       include MultiStepFormSession
-      before_action :ensure_can_change_provider
 
       before_action :set_form
       storing_form_session_as :change_provider
@@ -22,10 +21,6 @@ module Applications
       end
 
     private
-
-      def ensure_can_change_provider
-        redirect_to application_path(application.ecf_id) unless application.can_change_provider?
-      end
 
       def set_form
         @form = Applications::ChangeProvider::StartForm.new(form_params)

--- a/spec/requests/applications/change_provider/start_spec.rb
+++ b/spec/requests/applications/change_provider/start_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe "Applications::ChangeProvider::Start", type: :request do
         expect(response).to redirect_to(application_path(application.ecf_id))
       end
     end
+
+    context "when application cannot be found" do
+      let(:url) { "/applications/#{SecureRandom.uuid}/change-provider/start" }
+
+      it "redirects to the applications page" do
+        get url
+
+        expect(response).to redirect_to(applications_path)
+      end
+    end
   end
 
   describe "POST /applications/:application_id/change-provider/start" do


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#515

### Changes proposed in this pull request

Add defensive code to redirect user back to applications list if they land on a change provider
step when the application cannot be found

Check before each action in the change provider steps that the application can be found and can change provider
