### PR TITLE
Don't hide previous providers in change provider flow

### DIFF
--- a/app/controllers/applications/change_provider/providers_controller.rb
+++ b/app/controllers/applications/change_provider/providers_controller.rb
@@ -27,7 +27,6 @@ module Applications
           .for(course: application.course)
           .alphabetical
           .reject { |p| p.id == application.lead_provider.id }
-          .reject { |p| p.id.in?(application.application_lead_providers.map(&:lead_provider_id)) }
       end
 
       def set_form

--- a/app/services/applications/change_lead_provider.rb
+++ b/app/services/applications/change_lead_provider.rb
@@ -4,7 +4,6 @@ module Applications
     include ActiveModel::Validations
 
     validate :application_can_change_provider
-    validate :not_previously_changed_to_provider
     validate :new_provider_is_different
 
     attr_reader :application
@@ -60,12 +59,6 @@ module Applications
       return if @application.can_change_provider?
 
       errors.add(:application, :application_cannot_change_provider)
-    end
-
-    def not_previously_changed_to_provider
-      if @application.application_lead_providers.pluck(:lead_provider_id).include?(@new_provider.id)
-        errors.add(:base, :previously_changed_to_provider)
-      end
     end
 
     def new_provider_is_different

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -484,7 +484,6 @@ en:
         applications/change_lead_provider:
           base:
             provider_must_be_different: Application has {lead_provider_name} already as provider
-            previously_changed_to_provider: Application has previously had {lead_provider_name} as provider
           attributes:
             application_cannot_change_provider: Application status must be pending or accepted to change provider
         eligibility_lists/update:

--- a/spec/services/applications/change_lead_provider_spec.rb
+++ b/spec/services/applications/change_lead_provider_spec.rb
@@ -42,19 +42,6 @@ RSpec.describe Applications::ChangeLeadProvider, type: :model do
         expect(subject).to have_error(:base, :provider_must_be_different)
       end
     end
-
-    context "when application has previously been assigned to new provider" do
-      let(:application) do
-        create(:application, :pending,
-               :with_application_lead_provider,
-               old_lead_provider: new_provider,
-               lead_provider: old_provider)
-      end
-
-      it do
-        expect(subject).to have_error(:base, :previously_changed_to_provider)
-      end
-    end
   end
 
   describe "notification" do


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#516

Change provider does not allow you to choose a previous chosen provider

### Changes proposed in this pull request

Don't hide previous providers in change provider flow
