### PR TITLE
During registration go to ineligible step when not in England

### DIFF
--- a/app/forms/questionnaires/ineligible_for_funding.rb
+++ b/app/forms/questionnaires/ineligible_for_funding.rb
@@ -13,6 +13,8 @@ module Questionnaires
     end
 
     def previous_step
+      return :teacher_catchment unless wizard.query_store.inside_catchment?
+
       if wizard.query_store.work_setting == Institution::STATE_FUNDED_INSTITUTION
         :choose_school
       else

--- a/app/forms/questionnaires/teacher_catchment.rb
+++ b/app/forms/questionnaires/teacher_catchment.rb
@@ -2,7 +2,10 @@ module Questionnaires
   class TeacherCatchment < Base
     attr_accessor :teacher_catchment, :teacher_catchment_country
 
-    OPTIONS = %w[england another].freeze
+    OPTIONS = [
+      ENGLAND = "england".freeze,
+      NOT_ENGLAND = "another".freeze,
+    ].freeze
 
     validates :teacher_catchment, presence: true, inclusion: { in: OPTIONS }
 
@@ -22,6 +25,8 @@ module Questionnaires
     end
 
     def next_step
+      return :ineligible_for_funding if teacher_catchment == NOT_ENGLAND
+
       :work_setting
     end
 
@@ -40,8 +45,8 @@ module Questionnaires
 
     def options
       [
-        build_option_struct(value: "england", label: "Yes", link_errors: true),
-        build_option_struct(value: "another", label: "No"),
+        build_option_struct(value: ENGLAND, label: "Yes", link_errors: true),
+        build_option_struct(value: NOT_ENGLAND, label: "No"),
       ]
     end
   end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -94,11 +94,15 @@ class RegistrationWizard
     array << Answer.new("Course", course.name, :course_start_date)
     array << Answer.new("Provider", lead_provider&.name, :choose_your_provider)
     array << Answer.new("Workplace in England", teacher_catchment_humanized, :teacher_catchment)
-    array << Answer.new("Work setting", t("work_setting"), :work_setting)
-    if kind_of_nursery_public?
-      array << Answer.new("Nursery", t("kind_of_nursery"), :kind_of_nursery)
+
+    if store["work_setting"].present?
+      array << Answer.new("Work setting", t("work_setting"), :work_setting)
     end
-    array << Answer.new("Workplace", institution_from_store.try(:name_with_address), :choose_school)
+
+    if institution_from_store
+      array << Answer.new("Workplace", institution_from_store.name_with_address, :choose_school)
+    end
+
     if store["funding"].present?
       array << Answer.new("Course funding", I18n.t(store["funding"], scope: "helpers.label.registration_wizard.funding_options"), :funding_your_course)
     end

--- a/spec/controllers/registration_wizard_controller_spec.rb
+++ b/spec/controllers/registration_wizard_controller_spec.rb
@@ -113,6 +113,24 @@ RSpec.describe RegistrationWizardController do
       end
     end
 
+    context "when teacher catchment is outside England" do
+      let(:wizard_params) { { teacher_catchment: "another" } }
+      let(:make_request) { patch :update, params: { step: "teacher-catchment", registration_wizard: wizard_params } }
+
+      before do
+        session["registration_store"] = {
+          "course_identifier" => create(:course).identifier,
+          "provider_id" => create(:lead_provider).id,
+        }
+      end
+
+      it "redirects to ineligible for funding" do
+        make_request
+
+        expect(response).to redirect_to registration_wizard_show_path("ineligible-for-funding")
+      end
+    end
+
     context "when step is being skipped" do
       before do
         allow(RegistrationWizard).to receive(:new).and_return(wizard)

--- a/spec/features/journeys/reception_registration/other_setting_not_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/other_setting_not_in_england_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
     choose_current_course_start_date
     choose_provider(lead_provider)
     choose_teacher_catchment("No")
-    choose_work_setting("Other")
     continue_past_ineligible_funding
     choose_course_funding("My course is being paid for in another way")
     agree_to_share_provider_information
@@ -39,7 +38,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
         teacher_catchment_iso_country_code: nil,
         targeted_support_funding_eligibility: false,
         ukprn: nil,
-        work_setting: Institution::OTHER,
+        work_setting: nil,
       )
 
       expect(application.raw_application_data).to match(
@@ -52,7 +51,6 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
         "submitted" => true,
         "teacher_catchment" => "another",
         "teacher_catchment_country" => nil,
-        "work_setting" => Institution::OTHER,
       )
     end
   end

--- a/spec/features/journeys/reception_registration/private_setting_not_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/private_setting_not_in_england_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
     choose_current_course_start_date
     choose_provider(lead_provider)
     choose_teacher_catchment("No")
-    choose_work_setting("Private nursery, pre-school or school")
     continue_past_ineligible_funding
     choose_course_funding("I am paying")
     agree_to_share_provider_information
@@ -39,7 +38,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
         teacher_catchment_iso_country_code: nil,
         targeted_support_funding_eligibility: false,
         ukprn: nil,
-        work_setting: Institution::PRIVATE_INSTITUTION,
+        work_setting: nil,
       )
 
       expect(application.raw_application_data).to match(
@@ -52,7 +51,6 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
         "submitted" => true,
         "teacher_catchment" => "another",
         "teacher_catchment_country" => nil,
-        "work_setting" => Institution::PRIVATE_INSTITUTION,
       )
     end
   end

--- a/spec/features/journeys/reception_registration/state_funded_school_not_in_england_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_not_in_england_spec.rb
@@ -10,14 +10,11 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
 
   scenario "state-funded school not in England without funded place" do
     lead_provider = LeadProvider.first
-    institution = Institution.find_by!(institution_reference_number: "100000")
 
     start_registration
     choose_current_course_start_date
     choose_provider(lead_provider)
     choose_teacher_catchment("No")
-    choose_work_setting("State-funded nursery, pre-school, school or academy trust")
-    choose_a_school(js: false, name: "open")
     continue_past_ineligible_funding
     choose_course_funding("My trust is paying")
     agree_to_share_provider_information
@@ -42,7 +39,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
         teacher_catchment_iso_country_code: nil,
         targeted_support_funding_eligibility: false,
         ukprn: nil,
-        work_setting: Institution::STATE_FUNDED_INSTITUTION,
+        work_setting: nil,
       )
 
       expect(application.raw_application_data).to match(
@@ -51,13 +48,10 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
         "course_start_date" => "yes",
         "funding" => "trust",
         "funding_amount" => nil,
-        "institution_id" => institution.id.to_s,
-        "institution_name" => "open",
         "lead_provider_id" => lead_provider.id.to_s,
         "submitted" => true,
         "teacher_catchment" => "another",
         "teacher_catchment_country" => nil,
-        "work_setting" => Institution::STATE_FUNDED_INSTITUTION,
       )
     end
   end

--- a/spec/features/journeys/sad_paths/teacher_catchment_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/teacher_catchment_not_in_england_spec.rb
@@ -34,10 +34,6 @@ RSpec.feature "Sad journey", :with_default_lead_provider, :with_default_schedule
       page.choose("No", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
-      page.choose("Other", visible: :all)
-    end
-
     expect_page_to_have(path: "/registration/ineligible-for-funding")
   end
 end

--- a/spec/forms/questionnaires/ineligible_for_funding_spec.rb
+++ b/spec/forms/questionnaires/ineligible_for_funding_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Questionnaires::IneligibleForFunding, type: :model do
     context "when user is not in England" do
       let(:store) { { "teacher_catchment" => "another" } }
 
-      it { is_expected.to eq(:work_setting) }
+      it { is_expected.to eq(:teacher_catchment) }
     end
   end
 end

--- a/spec/forms/questionnaires/teacher_catchment_spec.rb
+++ b/spec/forms/questionnaires/teacher_catchment_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Questionnaires::TeacherCatchment, type: :model do
 
       let(:instance) { described_class.new(teacher_catchment: "another") }
 
-      it { is_expected.to eq :work_setting }
+      it { is_expected.to eq :ineligible_for_funding }
     end
   end
 end

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe RegistrationWizard do
   describe "#answers" do
     let(:school) { create(:school, establishment_type_code: "1") }
 
+    context "when work setting has not been answered" do
+      let(:lead_provider) { create(:lead_provider) }
+      let(:store) do
+        {
+          "course_identifier" => "tte-early-years",
+          "lead_provider_id" => lead_provider.id,
+          "teacher_catchment" => "another",
+          "funding" => "self",
+        }
+      end
+
+      it "does not show work setting answers" do
+        expect(subject.answers.map(&:key)).not_to include("Work setting", "Workplace")
+      end
+    end
+
     context "when working in Local authority maintained nursery" do
       let(:store) do
         {


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#517

When selecting "Not in England" during registration flow, the next step should be the ineligibility step, but it is instead taking the applicant to the work setting step.

### Changes proposed in this pull request

Fix the TeacherCatchment step so that the ineligibility step is shown after selecting "Not in England" during registration flow
