### PR TITLE
Admin enhancements for course / cohort / providers

### DIFF
--- a/app/components/cohorts_component.rb
+++ b/app/components/cohorts_component.rb
@@ -3,11 +3,12 @@ class CohortsComponent < BaseComponent
 
   attr_accessor :current_path, :current_section, :heading
 
-  def initialize(current_path, cohorts:, base_path:, resource: nil)
+  def initialize(current_path, cohorts:, base_path:, resource: nil, cohort_path: nil)
     @current_path = current_path
     @cohorts = cohorts
     @base_path = base_path
     @resource = resource
+    @cohort_path = cohort_path
     @heading = { text: "Cohorts", visible: true }
   end
 
@@ -71,7 +72,9 @@ class CohortsComponent < BaseComponent
 private
 
   def cohort_resource_path(cohort)
-    if @resource
+    if @cohort_path
+      @cohort_path.call(cohort)
+    elsif @resource
       public_send(:"cohort_#{@base_path}", @resource, cohort)
     else
       public_send(:"cohort_#{@base_path}", cohort)

--- a/app/controllers/admin/cohort_courses_controller.rb
+++ b/app/controllers/admin/cohort_courses_controller.rb
@@ -1,0 +1,51 @@
+class Admin::CohortCoursesController < AdminController
+  before_action :ensure_super_admin, except: :show
+  before_action :course_cohort, only: :show
+
+  def show; end
+
+  def new
+    @course_cohort = cohort.course_cohorts.new
+    load_form_options
+  end
+
+  def create
+    @course_cohort = cohort.course_cohorts.new(course_cohort_params)
+
+    if @course_cohort.save
+      flash[:success] = "Course added to cohort"
+      redirect_to admin_cohort_course_path(cohort, @course_cohort.course)
+    else
+      load_form_options
+      render :new, status: :unprocessable_content
+    end
+  end
+
+private
+
+  def course_cohort_params
+    params.require(:course_cohort).permit(:course_id, :schedule_id)
+  end
+
+  def course_cohort
+    @course_cohort ||= cohort.course_cohorts.includes(:course, :lead_providers).find_by!(course_id: params[:id]).tap do |course_cohort|
+      @course = course_cohort.course
+    end
+  end
+
+  def cohort
+    @cohort ||= Cohort.find(params[:cohort_id])
+  end
+
+  def load_form_options
+    @courses = Course.where.not(id: cohort.course_cohorts.select(:course_id)).order(:name)
+    @schedules = Schedule.where(cohort:).order(:name)
+  end
+
+  def ensure_super_admin
+    unless current_admin.super_admin?
+      flash[:error] = "You must be a super admin to change cohort courses"
+      redirect_to admin_cohort_path(cohort)
+    end
+  end
+end

--- a/app/controllers/admin/cohort_courses_controller.rb
+++ b/app/controllers/admin/cohort_courses_controller.rb
@@ -3,6 +3,7 @@ class Admin::CohortCoursesController < AdminController
   before_action :course_cohort, only: :show
 
   def show
+    @cohorts = Cohort.where(id: @course.course_cohorts.select(:cohort_id)).order_by_latest
     @delivery_partner_counts = DeliveryPartnership
       .where(cohort:, lead_provider_id: @course_cohort.lead_provider_ids)
       .group(:lead_provider_id)

--- a/app/controllers/admin/cohort_courses_controller.rb
+++ b/app/controllers/admin/cohort_courses_controller.rb
@@ -2,7 +2,12 @@ class Admin::CohortCoursesController < AdminController
   before_action :ensure_super_admin, except: :show
   before_action :course_cohort, only: :show
 
-  def show; end
+  def show
+    @delivery_partner_counts = DeliveryPartnership
+      .where(cohort:, lead_provider_id: @course_cohort.lead_provider_ids)
+      .group(:lead_provider_id)
+      .count
+  end
 
   def new
     @course_cohort = cohort.course_cohorts.new
@@ -39,7 +44,7 @@ private
 
   def load_form_options
     @courses = Course.where.not(id: cohort.course_cohorts.select(:course_id)).order(:name)
-    @schedules = Schedule.where(cohort:).order(:name)
+    @schedules = Schedule.order(training_starts_at: :desc)
   end
 
   def ensure_super_admin

--- a/app/controllers/admin/course_cohort_providers_controller.rb
+++ b/app/controllers/admin/course_cohort_providers_controller.rb
@@ -1,0 +1,44 @@
+module Admin
+  class CourseCohortProvidersController < AdminController
+    before_action :course
+    before_action :course_cohort
+    before_action :ensure_super_admin
+    before_action :lead_providers
+
+    def show; end
+
+    def update
+      if @course_cohort.update(course_cohort_params)
+        flash[:success] = "Course providers updated"
+        redirect_to admin_cohort_course_path(@course_cohort.cohort, @course)
+      else
+        render :show, status: :unprocessable_content
+      end
+    end
+
+  private
+
+    def course
+      @course ||= Course.find(params[:course_id])
+    end
+
+    def course_cohort
+      @course_cohort ||= @course.course_cohorts.find(params[:id])
+    end
+
+    def course_cohort_params
+      params.require(:course_cohort).permit(lead_provider_ids: [])
+    end
+
+    def lead_providers
+      @lead_providers ||= LeadProvider.order(:name)
+    end
+
+    def ensure_super_admin
+      return if current_admin.super_admin?
+
+      flash[:error] = "You must be a super admin to change course cohort providers"
+      redirect_to admin_cohort_course_path(@course_cohort.cohort, @course)
+    end
+  end
+end

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -32,7 +32,7 @@ module Admin
 
     def resources
       scope = Course
-                .includes(:course_cohorts, :applications)
+                .includes(:applications, course_cohorts: :cohort)
                 .order(name: :asc)
       scope.merge!(Course.where(course_cohorts: { cohort: @current_cohort })) if @current_cohort
       scope

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class CoursesController < AdminController
     include Cohortable
+
     before_action :set_course, only: %i[show edit update]
     before_action :require_super_admin, only: %i[edit update]
 
@@ -8,7 +9,9 @@ module Admin
       @pagy, @resources = pagy(resources)
     end
 
-    def show; end
+    def show
+      @cohorts = Cohort.where(id: @course.course_cohorts.select(:cohort_id)).order_by_latest
+    end
 
     def edit; end
 

--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -58,7 +58,7 @@ private
       :acceptance_window_start,
       :acceptance_window_end,
       allowed_declaration_types: [],
-    ).merge(cohort:)
+    )
   end
 
   def schedule

--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -58,7 +58,7 @@ private
       :acceptance_window_start,
       :acceptance_window_end,
       allowed_declaration_types: [],
-    )
+    ).merge(cohort:)
   end
 
   def schedule

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -22,7 +22,8 @@ class Cohort < ApplicationRecord
             length: { within: 5..50 }
 
   validates :registration_starts_at, presence: true
-  validates :identifier, presence: true, uniqueness: { case_sensitive: false }
+  validates :identifier, presence: true
+  validate :identifier_is_unique
   validate :registration_starts_at_matches_start_year
   validates :funding_cap, inclusion: { in: [true, false] }
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
@@ -71,6 +72,15 @@ private
     return if registration_starts_at.blank?
 
     self.identifier = registration_starts_at.strftime("%Y-%B")
+  end
+
+  def identifier_is_unique
+    return if identifier.blank?
+
+    duplicate = Cohort.where.not(id:).where("LOWER(identifier) = ?", identifier.downcase).exists?
+    return unless duplicate
+
+    errors.add(:identifier, :taken, cohort_start: registration_starts_at.strftime("%b %Y"))
   end
 
   def changing_funding_cap_with_dependent_applications

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -6,6 +6,7 @@ class Cohort < ApplicationRecord
   has_many :delivery_partnerships, dependent: :destroy
   has_many :delivery_partners, through: :delivery_partnerships
   has_many :course_cohorts, dependent: :destroy
+  has_many :courses, through: :course_cohorts
   has_many :schedules, through: :course_cohorts
 
   validates :start_year,

--- a/app/models/course_cohort.rb
+++ b/app/models/course_cohort.rb
@@ -9,6 +9,7 @@ class CourseCohort < ApplicationRecord
   has_many :applications
 
   validates :ecf_id, uniqueness: { case_sensitive: false }
+  validates :course_id, uniqueness: { scope: :cohort_id }
 
   delegate :name, to: :cohort
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -30,6 +30,10 @@ class Schedule < ApplicationRecord
     Declaration.declaration_types.keys
   end
 
+  def name_and_start_date
+    "#{name} / #{training_starts_at.to_date.to_fs(:govuk)}"
+  end
+
   def training_live?
     training_started? && training_ends_at > Time.zone.today
   end

--- a/app/views/admin/applications/api_tests/resume/_index.html.erb
+++ b/app/views/admin/applications/api_tests/resume/_index.html.erb
@@ -20,7 +20,7 @@
           next unless cc.schedule&.training_live?
           body.with_row do |row|
             row.with_cell do
-              link_to cc.course.name, admin_course_path(cc.course), target: "_blank"
+              link_to cc.course.name, admin_cohort_course_path(cc.cohort, cc.course), target: "_blank"
             end
             row.with_cell do
               link_to cc.cohort.description, admin_cohort_path(cc.cohort), target: "_blank"

--- a/app/views/admin/cohort_courses/new.html.erb
+++ b/app/views/admin/cohort_courses/new.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_back_link href: admin_cohort_path(@cohort) %>
 
-<h1 class="govuk-heading-l">Add course to <%= @cohort.description %></h1>
+<h1 class="govuk-heading-l">Add course to cohort <%= @cohort.description %></h1>
 
 <%= form_with model: @course_cohort, url: admin_cohort_courses_path(@cohort) do |f| %>
   <%= f.govuk_error_summary %>
@@ -22,7 +22,7 @@
           :schedule_id,
           @schedules,
           :id,
-          :name,
+          :name_and_start_date,
           options: { include_blank: true },
           label: { text: "Schedule" },
         )

--- a/app/views/admin/cohort_courses/new.html.erb
+++ b/app/views/admin/cohort_courses/new.html.erb
@@ -1,0 +1,42 @@
+<%= govuk_back_link href: admin_cohort_path(@cohort) %>
+
+<h1 class="govuk-heading-l">Add course to <%= @cohort.description %></h1>
+
+<%= form_with model: @course_cohort, url: admin_cohort_courses_path(@cohort) do |f| %>
+  <%= f.govuk_error_summary %>
+  <%=
+    f.govuk_collection_select(
+      :course_id,
+      @courses,
+      :id,
+      :name,
+      options: { include_blank: true },
+      label: { text: "Course" },
+    )
+  %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <%=
+        f.govuk_collection_select(
+          :schedule_id,
+          @schedules,
+          :id,
+          :name,
+          options: { include_blank: true },
+          label: { text: "Schedule" },
+        )
+      %>
+    </div>
+
+    <div class="govuk-grid-column-one-third govuk-!-padding-top-6">
+      <%= link_to "New schedule",
+                  new_admin_cohort_schedule_path(@cohort),
+                  class: "govuk-button",
+                  target: "_blank",
+                  rel: "noopener" %>
+    </div>
+  </div>
+
+  <%= f.govuk_submit "Add course" %>
+<% end %>

--- a/app/views/admin/cohort_courses/show.html.erb
+++ b/app/views/admin/cohort_courses/show.html.erb
@@ -1,63 +1,74 @@
-<%= govuk_back_link href: admin_cohorts_path %>
+<%= govuk_back_link href: request.referrer.presence || admin_courses_path %>
+
+<% content_for :side_navigation do %>
+  <%= render CohortsComponent.new(
+    request.path,
+    cohorts: @cohorts,
+    base_path: :admin_course_path,
+    resource: @course,
+    cohort_path: ->(cohort) { admin_cohort_course_path(cohort, @course) },
+  ) %>
+<% end %>
 
 <h1 class="govuk-heading-l"><%= @course.name %></h1>
 
 <%=
-  govuk_summary_list do |sl|
-
-    sl.with_row do |row|
+  govuk_summary_list do |summary_list|
+    summary_list.with_row do |row|
       row.with_key(text: "Cohort name")
       row.with_value(text: @cohort.name)
     end
 
-    sl.with_row do |row|
+    summary_list.with_row do |row|
       row.with_key(text: "Cohort registration open")
       row.with_value(text: @cohort.registration_starts_at.to_date.to_fs(:govuk))
     end
 
-sl.with_row do |row|
+    summary_list.with_row do |row|
       row.with_key(text: "Course ID")
       row.with_value(text: @course.ecf_id)
     end
 
-    sl.with_row do |row|
+    summary_list.with_row do |row|
       row.with_key(text: "Identifier")
       row.with_value(text: @course.identifier)
     end
 
-    sl.with_row do |row|
+    summary_list.with_row do |row|
       row.with_key(text: "Description")
       row.with_value(text: @course.description)
     end
   end
 %>
 
-<h2 class="govuk-heading-m">Schedules</h1>
+<h2 class="govuk-heading-m">Schedule</h2>
 
 <% if current_admin.super_admin? %>
   <%= govuk_button_link_to("New schedule", new_admin_cohort_schedule_path(@cohort)) %>
 <% end %>
 
 <%=
-  govuk_table do |table|
-    table.with_head do |head|
-      head.with_row do |row|
-        row.with_cell(text: "Name")
-        row.with_cell(text: "Training starts")
-        row.with_cell(text: "Training ends")
-        row.with_cell(text: "Declaration types")
-      end
+  govuk_summary_list do |summary_list|
+    schedule = @course_cohort.schedule
+
+    summary_list.with_row do |row|
+      row.with_key(text: "Name")
+      row.with_value(text: govuk_link_to(schedule.name, admin_cohort_schedule_path(@cohort, schedule)))
     end
 
-    table.with_body do |body|
-      @cohort.schedules.includes(:milestones).order(:name).each do |schedule|
-        body.with_row do |row|
-          row.with_cell(text: govuk_link_to(schedule.name, admin_cohort_schedule_path(@cohort, schedule)))
-          row.with_cell(text: schedule.training_starts_at.to_fs(:govuk_short))
-          row.with_cell(text: schedule.training_ends_at.to_fs(:govuk_short))
-          row.with_cell(text: schedule.allowed_declaration_types.join(', '))
-        end
-      end
+    summary_list.with_row do |row|
+      row.with_key(text: "Training starts")
+      row.with_value(text: schedule.training_starts_at.to_fs(:govuk_short))
+    end
+
+    summary_list.with_row do |row|
+      row.with_key(text: "Training ends")
+      row.with_value(text: schedule.training_ends_at.to_fs(:govuk_short))
+    end
+
+    summary_list.with_row do |row|
+      row.with_key(text: "Declaration types")
+      row.with_value(text: schedule.allowed_declaration_types.join(', '))
     end
   end
 %>
@@ -69,11 +80,20 @@ sl.with_row do |row|
 <% end %>
 
 <%=
-  govuk_summary_list do |summary_list|
-    @course_cohort.lead_providers.order(:name).each do |provider|
-      summary_list.with_row do |row|
-        row.with_key(text: govuk_link_to(provider.name, admin_lead_provider_path(provider)))
-        row.with_value(text: pluralize(@delivery_partner_counts.fetch(provider.id, 0), "delivery partner"))
+  govuk_table do |table|
+    table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(text: "Provider")
+        row.with_cell(text: "Delivery partners")
+      end
+    end
+
+    table.with_body do |body|
+      @course_cohort.lead_providers.order(:name).each do |provider|
+        body.with_row do |row|
+          row.with_cell(text: govuk_link_to(provider.name, admin_lead_provider_path(provider)))
+          row.with_cell(text: pluralize(@delivery_partner_counts.fetch(provider.id, 0), "delivery partner"))
+        end
       end
     end
   end

--- a/app/views/admin/cohort_courses/show.html.erb
+++ b/app/views/admin/cohort_courses/show.html.erb
@@ -1,0 +1,90 @@
+<%= govuk_back_link href: admin_cohort_path(@cohort) %>
+
+<h1 class="govuk-heading-l"><%= @course.name %></h1>
+
+<%=
+  govuk_summary_list do |sl|
+
+    sl.with_row do |row|
+      row.with_key(text: "Course ID")
+      row.with_value(text: @course.ecf_id)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Identifier")
+      row.with_value(text: @course.identifier)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Position")
+      row.with_value(text: @course.position)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Description")
+      row.with_value(text: @course.description)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Display")
+      row.with_value(text: boolean_red_green_tag(@course.display?))
+    end
+  end
+%>
+
+<h2 class="govuk-heading-m">Schedules</h1>
+
+<% if current_admin.super_admin? %>
+  <%= govuk_button_link_to("New schedule", new_admin_cohort_schedule_path(@cohort)) %>
+<% end %>
+
+<%=
+  govuk_table do |table|
+    table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(text: "Name")
+        row.with_cell(text: "Training starts")
+        row.with_cell(text: "Training ends")
+        row.with_cell(text: "Declaration types")
+        row.with_cell(text: "Milestones")
+      end
+    end
+
+    table.with_body do |body|
+      milestone_counts = @cohort.schedules.joins(:milestones).group("schedules.id").count
+      @cohort.schedules.includes(:milestones).order(:name).each do |schedule|
+        body.with_row do |row|
+          row.with_cell(text: govuk_link_to(schedule.name, admin_cohort_schedule_path(@cohort, schedule)))
+          row.with_cell(text: schedule.training_starts_at.to_fs(:govuk_short))
+          row.with_cell(text: schedule.training_ends_at.to_fs(:govuk_short))
+          row.with_cell(text: schedule.allowed_declaration_types.count)
+          row.with_cell(text: milestone_counts[schedule.id].to_i)
+        end
+      end
+    end
+  end
+%>
+
+<h2 class="govuk-heading-m">Providers</h2>
+
+<% if current_admin.super_admin? %>
+  <%= govuk_button_link_to("Add/Remove providers", admin_course_course_cohort_provider_path(@course, @course_cohort)) %>
+<% end %>
+
+<%=
+  govuk_table do |table|
+    table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(text: "Name")
+      end
+    end
+
+    table.with_body do |body|
+      @course_cohort.lead_providers.order(:name).each do |provider|
+        body.with_row do |row|
+          row.with_cell(text: govuk_link_to(provider.name, admin_lead_provider_path(provider)))
+        end
+      end
+    end
+  end
+%>

--- a/app/views/admin/cohort_courses/show.html.erb
+++ b/app/views/admin/cohort_courses/show.html.erb
@@ -91,7 +91,7 @@
     table.with_body do |body|
       @course_cohort.lead_providers.order(:name).each do |provider|
         body.with_row do |row|
-          row.with_cell(text: govuk_link_to(provider.name, admin_lead_provider_path(provider)))
+          row.with_cell(text: govuk_link_to(provider.name, cohort_admin_lead_provider_path(provider, @cohort)))
           row.with_cell(text: pluralize(@delivery_partner_counts.fetch(provider.id, 0), "delivery partner"))
         end
       end

--- a/app/views/admin/cohort_courses/show.html.erb
+++ b/app/views/admin/cohort_courses/show.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_back_link href: admin_cohort_path(@cohort) %>
+<%= govuk_back_link href: admin_cohorts_path %>
 
 <h1 class="govuk-heading-l"><%= @course.name %></h1>
 
@@ -6,6 +6,16 @@
   govuk_summary_list do |sl|
 
     sl.with_row do |row|
+      row.with_key(text: "Cohort name")
+      row.with_value(text: @cohort.name)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Cohort registration open")
+      row.with_value(text: @cohort.registration_starts_at.to_date.to_fs(:govuk))
+    end
+
+sl.with_row do |row|
       row.with_key(text: "Course ID")
       row.with_value(text: @course.ecf_id)
     end
@@ -16,18 +26,8 @@
     end
 
     sl.with_row do |row|
-      row.with_key(text: "Position")
-      row.with_value(text: @course.position)
-    end
-
-    sl.with_row do |row|
       row.with_key(text: "Description")
       row.with_value(text: @course.description)
-    end
-
-    sl.with_row do |row|
-      row.with_key(text: "Display")
-      row.with_value(text: boolean_red_green_tag(@course.display?))
     end
   end
 %>
@@ -46,19 +46,16 @@
         row.with_cell(text: "Training starts")
         row.with_cell(text: "Training ends")
         row.with_cell(text: "Declaration types")
-        row.with_cell(text: "Milestones")
       end
     end
 
     table.with_body do |body|
-      milestone_counts = @cohort.schedules.joins(:milestones).group("schedules.id").count
       @cohort.schedules.includes(:milestones).order(:name).each do |schedule|
         body.with_row do |row|
           row.with_cell(text: govuk_link_to(schedule.name, admin_cohort_schedule_path(@cohort, schedule)))
           row.with_cell(text: schedule.training_starts_at.to_fs(:govuk_short))
           row.with_cell(text: schedule.training_ends_at.to_fs(:govuk_short))
-          row.with_cell(text: schedule.allowed_declaration_types.count)
-          row.with_cell(text: milestone_counts[schedule.id].to_i)
+          row.with_cell(text: schedule.allowed_declaration_types.join(', '))
         end
       end
     end
@@ -72,18 +69,11 @@
 <% end %>
 
 <%=
-  govuk_table do |table|
-    table.with_head do |head|
-      head.with_row do |row|
-        row.with_cell(text: "Name")
-      end
-    end
-
-    table.with_body do |body|
-      @course_cohort.lead_providers.order(:name).each do |provider|
-        body.with_row do |row|
-          row.with_cell(text: govuk_link_to(provider.name, admin_lead_provider_path(provider)))
-        end
+  govuk_summary_list do |summary_list|
+    @course_cohort.lead_providers.order(:name).each do |provider|
+      summary_list.with_row do |row|
+        row.with_key(text: govuk_link_to(provider.name, admin_lead_provider_path(provider)))
+        row.with_value(text: pluralize(@delivery_partner_counts.fetch(provider.id, 0), "delivery partner"))
       end
     end
   end

--- a/app/views/admin/cohorts/form.html.erb
+++ b/app/views/admin/cohorts/form.html.erb
@@ -11,6 +11,7 @@
 </h1>
 
 <%= form_with model: [:admin, @cohort] do |f| %>
+  <%= f.govuk_error_summary %>
   <%= f.govuk_text_field :description %>
 
   <%= f.govuk_number_field :start_year,

--- a/app/views/admin/cohorts/form.html.erb
+++ b/app/views/admin/cohorts/form.html.erb
@@ -1,5 +1,7 @@
 <% if @cohort.persisted? %>
   <%= govuk_back_link href: admin_cohort_path(@cohort) %>
+<% else %>
+  <%= govuk_back_link href: request.referrer.presence || admin_cohorts_path %>
 <% end %>
 
 <h1 class="govuk-heading-l">

--- a/app/views/admin/cohorts/show.html.erb
+++ b/app/views/admin/cohorts/show.html.erb
@@ -32,8 +32,6 @@
 <% if current_admin.super_admin? %>
   <%= govuk_button_link_to("Edit cohort details", edit_admin_cohort_path(@cohort)) %>
   <%= govuk_button_link_to("Delete cohort", admin_cohort_path(@cohort), method: :delete, warning: true) %>
-  <%= govuk_button_link_to("Create statements", new_admin_cohort_statement_path(@cohort), secondary: true) %>
-  <%= govuk_button_link_to("Download contracts CSV", download_contracts_admin_cohort_path(@cohort), secondary: true) %>
 <% end %>
 
 <hr class="govuk-section-break govuk-section-break--l">

--- a/app/views/admin/cohorts/show.html.erb
+++ b/app/views/admin/cohorts/show.html.erb
@@ -38,10 +38,10 @@
 
 <hr class="govuk-section-break govuk-section-break--l">
 
-<h2 class="govuk-heading-m">Schedules</h1>
+<h2 class="govuk-heading-m">Courses</h1>
 
 <% if current_admin.super_admin? %>
-  <%= govuk_button_link_to("New schedule", new_admin_cohort_schedule_path(@cohort)) %>
+  <%= govuk_button_link_to("Add course", new_admin_cohort_course_path(@cohort)) %>
 <% end %>
 
 <%=
@@ -49,22 +49,13 @@
     table.with_head do |head|
       head.with_row do |row|
         row.with_cell(text: "Name")
-        row.with_cell(text: "Training starts")
-        row.with_cell(text: "Training ends")
-        row.with_cell(text: "Declaration types")
-        row.with_cell(text: "Milestones")
       end
     end
 
     table.with_body do |body|
-      milestone_counts = @cohort.schedules.joins(:milestones).group("schedules.id").count
-      @cohort.schedules.includes(:milestones).order(:name).each do |schedule|
+      @cohort.courses.order(:name).each do |course|
         body.with_row do |row|
-          row.with_cell(text: govuk_link_to(schedule.name, admin_cohort_schedule_path(@cohort, schedule)))
-          row.with_cell(text: schedule.training_starts_at.to_fs(:govuk_short))
-          row.with_cell(text: schedule.training_ends_at.to_fs(:govuk_short))
-          row.with_cell(text: schedule.allowed_declaration_types.count)
-          row.with_cell(text: milestone_counts[schedule.id].to_i)
+          row.with_cell(text: govuk_link_to(course.name, admin_cohort_course_path(@cohort, course)))
         end
       end
     end

--- a/app/views/admin/course_cohort_providers/show.html.erb
+++ b/app/views/admin/course_cohort_providers/show.html.erb
@@ -1,0 +1,39 @@
+<%= govuk_back_link href: admin_cohort_course_path(@course_cohort.cohort_id, @course) %>
+
+<h1 class="govuk-heading-l">Add or remove providers</h1>
+
+<%=
+  govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "Course")
+      row.with_value(text: @course.name)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Cohort")
+      row.with_value(text: @course_cohort.cohort.name)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Schedule")
+      row.with_value(text: @course_cohort.schedule.name)
+    end
+  end
+%>
+
+<%= form_with model: @course_cohort, url: admin_course_course_cohort_provider_path(@course, @course_cohort), method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_check_boxes(
+    :lead_provider_ids,
+    @lead_providers,
+    :id,
+    :name,
+    legend: { text: "Providers", size: "m" },
+  ) %>
+
+  <div class="govuk-button-group">
+    <%= f.govuk_submit "Save providers" %>
+    <%= govuk_link_to("Cancel", admin_cohort_course_path(@course_cohort.cohort, @course), class: "govuk-link--no-visited-state") %>
+  </div>
+<% end %>

--- a/app/views/admin/courses/index.html.erb
+++ b/app/views/admin/courses/index.html.erb
@@ -18,15 +18,9 @@ govuk_table do |table|
 
     table.with_body do |body|
         @resources.each do |course|
-            latest_course_cohort = course.course_cohorts.max_by { |course_cohort| course_cohort.cohort.registration_starts_at }
-
             body.with_row do |row|
                 row.with_cell do
-                    if latest_course_cohort
-                        govuk_link_to(course.name, admin_cohort_course_path(latest_course_cohort.cohort, course))
-                    else
-                        course.name
-                    end
+                  govuk_link_to(course.name, admin_course_path(course))
                 end
                 row.with_cell(text: course.applications.size)
             end

--- a/app/views/admin/courses/index.html.erb
+++ b/app/views/admin/courses/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :side_navigation do %>
-    <%= render CohortsComponent.new(
+  <%= render CohortsComponent.new(
         request.path,
         cohorts: @cohorts,
         base_path: :admin_courses_path,

--- a/app/views/admin/courses/index.html.erb
+++ b/app/views/admin/courses/index.html.erb
@@ -18,8 +18,16 @@ govuk_table do |table|
 
     table.with_body do |body|
         @resources.each do |course|
+            latest_course_cohort = course.course_cohorts.max_by { |course_cohort| course_cohort.cohort.registration_starts_at }
+
             body.with_row do |row|
-                row.with_cell(text: govuk_link_to(course.name, admin_course_path(course)))
+                row.with_cell do
+                    if latest_course_cohort
+                        govuk_link_to(course.name, admin_cohort_course_path(latest_course_cohort.cohort, course))
+                    else
+                        course.name
+                    end
+                end
                 row.with_cell(text: course.applications.size)
             end
         end

--- a/app/views/admin/courses/show.html.erb
+++ b/app/views/admin/courses/show.html.erb
@@ -1,38 +1,47 @@
-<%= govuk_back_link(href: url_for(:back)) %>
+<%= govuk_back_link href: request.referrer.presence || admin_courses_path %>
+
+<% content_for :side_navigation do %>
+  <%= render CohortsComponent.new(
+    request.path,
+    cohorts: @cohorts,
+    base_path: :admin_course_path,
+    resource: @course,
+    cohort_path: ->(cohort) { admin_cohort_course_path(cohort, @course) },
+  ) %>
+<% end %>
 
 <h1 class="govuk-heading-l"><%= @course.name %></h1>
 
 <%=
-  govuk_summary_list do |sl|
-
-    sl.with_row do |row|
+  govuk_summary_list do |summary_list|
+    summary_list.with_row do |row|
       row.with_key(text: "Name")
       row.with_value(text: @course.name)
       row.with_action(text: "Change", href: edit_admin_course_path(@course), visually_hidden_text: "name") if current_admin.super_admin?
     end
 
-    sl.with_row do |row|
+    summary_list.with_row do |row|
       row.with_key(text: "Course ID")
       row.with_value(text: @course.ecf_id)
     end
 
-    sl.with_row do |row|
+    summary_list.with_row do |row|
       row.with_key(text: "Identifier")
       row.with_value(text: @course.identifier)
     end
 
-    sl.with_row do |row|
+    summary_list.with_row do |row|
       row.with_key(text: "Position")
       row.with_value(text: @course.position)
     end
 
-    sl.with_row do |row|
+    summary_list.with_row do |row|
       row.with_key(text: "Description")
       row.with_value(text: @course.description)
       row.with_action(text: "Change", href: edit_admin_course_path(@course), visually_hidden_text: "description") if current_admin.super_admin?
     end
 
-    sl.with_row do |row|
+    summary_list.with_row do |row|
       row.with_key(text: "Display")
       row.with_value(text: boolean_red_green_tag(@course.display?))
     end

--- a/app/views/admin/courses/show.html.erb
+++ b/app/views/admin/courses/show.html.erb
@@ -12,12 +12,15 @@
 
 <h1 class="govuk-heading-l"><%= @course.name %></h1>
 
+<% if current_admin.super_admin? %>
+  <%= govuk_button_link_to("Edit course details", edit_admin_course_path(@course)) %>
+<% end %>
+
 <%=
   govuk_summary_list do |summary_list|
     summary_list.with_row do |row|
       row.with_key(text: "Name")
       row.with_value(text: @course.name)
-      row.with_action(text: "Change", href: edit_admin_course_path(@course), visually_hidden_text: "name") if current_admin.super_admin?
     end
 
     summary_list.with_row do |row|
@@ -31,19 +34,8 @@
     end
 
     summary_list.with_row do |row|
-      row.with_key(text: "Position")
-      row.with_value(text: @course.position)
-    end
-
-    summary_list.with_row do |row|
       row.with_key(text: "Description")
       row.with_value(text: @course.description)
-      row.with_action(text: "Change", href: edit_admin_course_path(@course), visually_hidden_text: "description") if current_admin.super_admin?
-    end
-
-    summary_list.with_row do |row|
-      row.with_key(text: "Display")
-      row.with_value(text: boolean_red_green_tag(@course.display?))
     end
   end
 %>

--- a/app/views/admin/lead_providers/_applications.html.erb
+++ b/app/views/admin/lead_providers/_applications.html.erb
@@ -17,7 +17,7 @@
                 link_to application.user.full_name, admin_application_path(application), class: "govuk-link"
               end
               row.with_cell(text: application.user.email)
-              row.with_cell(text: application.course.name)
+              row.with_cell(text: application.course&.name)
               row.with_cell do
                 if application.lead_provider == @lead_provider
                   application_status_badge(application.status)
@@ -26,7 +26,7 @@
                 end
               end
               row.with_cell do
-                if application.cohort.funding_cap?
+                if application.cohort&.funding_cap?
                   if application.funded_place
                     tag.strong("Funded", class: "govuk-tag govuk-tag--blue")
                   elsif application.funded_place == false

--- a/app/views/admin/schedules/form.html.erb
+++ b/app/views/admin/schedules/form.html.erb
@@ -9,6 +9,8 @@
 </h1>
 
 <%= form_with model: [:admin, @cohort, @schedule] do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_text_field :name, class: "govuk-input--width-20" %>
 
   <%= f.govuk_text_field :identifier, class: "govuk-input--width-20" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -271,6 +271,12 @@ en:
             ecf_id:
               blank: Enter an ECF ID
               taken: ECF ID must be unique
+        course_cohort:
+          attributes:
+            course:
+              required: A course is required
+            schedule:
+              required: A schedule is required
         declaration:
           attributes:
             declaration_date:
@@ -329,6 +335,20 @@ en:
               taken: ECF ID must be unique
         schedule:
           attributes:
+            name:
+              blank: Enter a name
+            identifier:
+              blank: Enter an identifier
+            policy_descriptor:
+              blank: Enter a policy descriptor
+            training_starts_at:
+              blank: Enter a training start date
+            training_ends_at:
+              blank: Enter a training end date
+            acceptance_window_start:
+              blank: Enter an acceptance window start date
+            acceptance_window_end:
+              blank: Enter an acceptance window end date
             ecf_id:
               blank: Enter an ECF ID
               taken: ECF ID must be unique

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -205,6 +205,9 @@ en:
               aken: Description is used by another cohort already
             start_year:
               blank: Enter the start year for the cohort
+            identifier:
+              blank: Enter a registration start date to generate the cohort identifier
+              taken: Cohort starting '%{cohort_start}' exists already
             funding_cap:
               inclusion: Choose true or false for funding cap
             ecf_id:

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -91,6 +91,7 @@ namespace :admin do
   end
 
   resources :cohorts do
+    resources :courses, controller: "cohort_courses", only: %i[show new create]
     resources :schedules, except: :index do
       resources :milestones, except: :show
     end
@@ -116,6 +117,7 @@ namespace :admin do
 
   resources :courses, only: %i[index show edit update] do
     concerns :cohortable, index: "courses#index"
+    resources :course_cohort_providers, path: "course-providers", only: %i[show update]
   end
 
   resources :users, only: %i[index show]

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -91,7 +91,7 @@ namespace :admin do
   end
 
   resources :cohorts do
-    resources :courses, controller: "cohort_courses", only: %i[show new create]
+    resources :courses, controller: "cohort_courses", only: %i[index show new create]
     resources :schedules, except: :index do
       resources :milestones, except: :show
     end

--- a/spec/features/admin/cohorts_spec.rb
+++ b/spec/features/admin/cohorts_spec.rb
@@ -122,8 +122,7 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
         end
       end
 
-      navigate_to_cohort
-      click_on download_contracts_button_text
+      visit download_contracts_admin_cohort_path(cohort)
       csv_file = "#{Capybara.save_path}/#{cohort.start_year}_cohort_contracts.csv"
       wait_for_file_to_be_created(csv_file)
       csv = CSV.read(csv_file)

--- a/spec/features/admin/cohorts_spec.rb
+++ b/spec/features/admin/cohorts_spec.rb
@@ -55,6 +55,8 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
       visit_index
       click_on new_button_text
 
+      expect(page).to have_css("a.govuk-back-link[href$='#{admin_cohorts_path}']", text: "Back")
+
       fill_in "Description", with: "2029 to 2030"
       fill_in "Start year", with: "2029"
       check "Funding cap", visible: :all

--- a/spec/features/admin/courses_spec.rb
+++ b/spec/features/admin/courses_spec.rb
@@ -16,12 +16,11 @@ RSpec.feature "Listing and viewing courses", type: :feature do
 
     scenario "viewing the list of courses" do
       course = create(:course, name: "Course with multiple cohorts", identifier: "course-with-multiple-cohorts")
-      latest_course_cohort = course.course_cohorts.max_by { |course_cohort| course_cohort.cohort.registration_starts_at }
 
       visit(admin_courses_path)
 
       expect(page).to have_css("h1", text: "Courses")
-      expect(page).to have_link(course.name, href: admin_cohort_course_path(latest_course_cohort.cohort, course))
+      expect(page).to have_link(course.name, href: admin_course_path(course))
       expect(page).to have_css(".x-govuk-sub-navigation")
 
       # Not enough courses for pagination to kick in
@@ -48,6 +47,23 @@ RSpec.feature "Listing and viewing courses", type: :feature do
       expect(page).to have_css("h1", text: course.name)
 
       within(".govuk-summary-list", match: :first) do |summary_list|
+        expect(summary_list).to have_summary_item("Name", course.name)
+        expect(summary_list).to have_summary_item("Course ID", course.ecf_id)
+        expect(summary_list).to have_summary_item("Identifier", course.identifier)
+        expect(summary_list).to have_summary_item("Description", course.description)
+        expect(summary_list).not_to have_text("Cohort name")
+      end
+
+      expect(page).not_to have_css("h2", text: "Schedule")
+      expect(page).not_to have_css("h2", text: "Providers")
+      expect(page).to have_link("All", href: admin_course_path(course))
+      expect(page).to have_link(course_cohort.cohort.description, href: admin_cohort_course_path(course_cohort.cohort, course))
+      expect(page).to have_current_path(admin_course_path(course))
+      expect(page).not_to have_link("Change")
+
+      click_on course_cohort.cohort.description
+
+      within(".govuk-summary-list", match: :first) do |summary_list|
         expect(summary_list).to have_summary_item("Cohort name", course_cohort.cohort.name)
         expect(summary_list).to have_summary_item("Cohort registration open", course_cohort.cohort.registration_starts_at.to_date.to_fs(:govuk))
         expect(summary_list).to have_summary_item("Course ID", course.ecf_id)
@@ -57,26 +73,7 @@ RSpec.feature "Listing and viewing courses", type: :feature do
 
       expect(page).to have_css("h2", text: "Schedule")
       expect(page).to have_css("h2", text: "Providers")
-      expect(page).to have_link("All", href: admin_course_path(course))
-      expect(page).to have_link(course_cohort.cohort.description, href: admin_cohort_course_path(course_cohort.cohort, course))
       expect(page).to have_current_path(admin_cohort_course_path(course_cohort.cohort, course))
-
-      click_on "All"
-
-      within(".govuk-summary-list", match: :first) do |summary_list|
-        expect(summary_list).to have_summary_item("Name", course.name)
-        expect(summary_list).to have_summary_item("Course ID", course.ecf_id)
-        expect(summary_list).to have_summary_item("Identifier", course.identifier)
-        expect(summary_list).to have_summary_item("Position", course.position)
-        expect(summary_list).to have_summary_item("Description", course.description)
-        expect(summary_list).to have_summary_item("Display", "Yes")
-        expect(summary_list).not_to have_text("Cohort name")
-      end
-
-      expect(page).not_to have_css("h2", text: "Schedule")
-      expect(page).not_to have_css("h2", text: "Providers")
-      expect(page).to have_current_path(admin_course_path(course))
-      expect(page).not_to have_link("Change")
     end
   end
 
@@ -90,7 +87,7 @@ RSpec.feature "Listing and viewing courses", type: :feature do
 
       visit(admin_course_path(course))
 
-      click_link("Change name")
+      click_link("Edit course details")
 
       expect(page).to have_css("h1", text: "Edit course details")
 

--- a/spec/features/admin/courses_spec.rb
+++ b/spec/features/admin/courses_spec.rb
@@ -15,17 +15,13 @@ RSpec.feature "Listing and viewing courses", type: :feature do
     end
 
     scenario "viewing the list of courses" do
-      latest_cohort = create(:cohort, :unique, registration_starts_at: Date.new(2028, 1, 1))
-      older_cohort = create(:cohort, :unique, registration_starts_at: Date.new(2027, 1, 1))
       course = create(:course, name: "Course with multiple cohorts", identifier: "course-with-multiple-cohorts")
-
-      create(:course_cohort, course:, cohort: older_cohort)
-      create(:course_cohort, course:, cohort: latest_cohort)
+      latest_course_cohort = course.course_cohorts.max_by { |course_cohort| course_cohort.cohort.registration_starts_at }
 
       visit(admin_courses_path)
 
       expect(page).to have_css("h1", text: "Courses")
-      expect(page).to have_link(course.name, href: admin_cohort_course_path(latest_cohort, course))
+      expect(page).to have_link(course.name, href: admin_cohort_course_path(latest_course_cohort.cohort, course))
       expect(page).to have_css(".x-govuk-sub-navigation")
 
       # Not enough courses for pagination to kick in
@@ -41,7 +37,7 @@ RSpec.feature "Listing and viewing courses", type: :feature do
       expect(page).to have_css(".govuk-pagination__item--current", text: "2")
     end
 
-    scenario "viewing course details for the latest cohort" do
+    scenario "viewing course details for all cohorts and a selected cohort" do
       visit(admin_courses_path)
 
       course = Course.order(name: :asc).first
@@ -50,7 +46,6 @@ RSpec.feature "Listing and viewing courses", type: :feature do
       click_link(course.name)
 
       expect(page).to have_css("h1", text: course.name)
-      expect(page).to have_current_path(admin_cohort_course_path(course_cohort.cohort, course))
 
       within(".govuk-summary-list", match: :first) do |summary_list|
         expect(summary_list).to have_summary_item("Cohort name", course_cohort.cohort.name)
@@ -62,28 +57,26 @@ RSpec.feature "Listing and viewing courses", type: :feature do
 
       expect(page).to have_css("h2", text: "Schedule")
       expect(page).to have_css("h2", text: "Providers")
-    end
+      expect(page).to have_link("All", href: admin_course_path(course))
+      expect(page).to have_link(course_cohort.cohort.description, href: admin_cohort_course_path(course_cohort.cohort, course))
+      expect(page).to have_current_path(admin_cohort_course_path(course_cohort.cohort, course))
 
-    scenario "viewing course details for all cohorts" do
-      course = Course.first
+      click_on "All"
 
-      visit(admin_course_path(course))
-
-      expect(page).to have_css("h1", text: course.name)
-      expect(page).to have_css(".x-govuk-sub-navigation")
-
-      within(".govuk-summary-list") do |summary_list|
+      within(".govuk-summary-list", match: :first) do |summary_list|
         expect(summary_list).to have_summary_item("Name", course.name)
         expect(summary_list).to have_summary_item("Course ID", course.ecf_id)
         expect(summary_list).to have_summary_item("Identifier", course.identifier)
         expect(summary_list).to have_summary_item("Position", course.position)
         expect(summary_list).to have_summary_item("Description", course.description)
         expect(summary_list).to have_summary_item("Display", "Yes")
+        expect(summary_list).not_to have_text("Cohort name")
       end
 
-      expect(page).not_to have_link("Change")
       expect(page).not_to have_css("h2", text: "Schedule")
       expect(page).not_to have_css("h2", text: "Providers")
+      expect(page).to have_current_path(admin_course_path(course))
+      expect(page).not_to have_link("Change")
     end
   end
 

--- a/spec/features/admin/courses_spec.rb
+++ b/spec/features/admin/courses_spec.rb
@@ -70,6 +70,7 @@ RSpec.feature "Listing and viewing courses", type: :feature do
       visit(admin_course_path(course))
 
       expect(page).to have_css("h1", text: course.name)
+      expect(page).to have_css(".x-govuk-sub-navigation")
 
       within(".govuk-summary-list") do |summary_list|
         expect(summary_list).to have_summary_item("Name", course.name)
@@ -81,6 +82,8 @@ RSpec.feature "Listing and viewing courses", type: :feature do
       end
 
       expect(page).not_to have_link("Change")
+      expect(page).not_to have_css("h2", text: "Schedule")
+      expect(page).not_to have_css("h2", text: "Providers")
     end
   end
 

--- a/spec/features/admin/courses_spec.rb
+++ b/spec/features/admin/courses_spec.rb
@@ -15,13 +15,18 @@ RSpec.feature "Listing and viewing courses", type: :feature do
     end
 
     scenario "viewing the list of courses" do
+      latest_cohort = create(:cohort, :unique, registration_starts_at: Date.new(2028, 1, 1))
+      older_cohort = create(:cohort, :unique, registration_starts_at: Date.new(2027, 1, 1))
+      course = create(:course, name: "Course with multiple cohorts", identifier: "course-with-multiple-cohorts")
+
+      create(:course_cohort, course:, cohort: older_cohort)
+      create(:course_cohort, course:, cohort: latest_cohort)
+
       visit(admin_courses_path)
 
       expect(page).to have_css("h1", text: "Courses")
-
-      Course.order(name: :asc).limit(courses_per_page).each do |course|
-        expect(page).to have_link(course.name, href: admin_course_path(course))
-      end
+      expect(page).to have_link(course.name, href: admin_cohort_course_path(latest_cohort, course))
+      expect(page).to have_css(".x-govuk-sub-navigation")
 
       # Not enough courses for pagination to kick in
       # expect(page).to have_css(".govuk-pagination__item--current", text: 1)
@@ -36,12 +41,33 @@ RSpec.feature "Listing and viewing courses", type: :feature do
       expect(page).to have_css(".govuk-pagination__item--current", text: "2")
     end
 
-    scenario "viewing course details" do
+    scenario "viewing course details for the latest cohort" do
       visit(admin_courses_path)
 
       course = Course.order(name: :asc).first
+      course_cohort = course.course_cohorts.max_by { |cc| cc.cohort.registration_starts_at }
 
       click_link(course.name)
+
+      expect(page).to have_css("h1", text: course.name)
+      expect(page).to have_current_path(admin_cohort_course_path(course_cohort.cohort, course))
+
+      within(".govuk-summary-list", match: :first) do |summary_list|
+        expect(summary_list).to have_summary_item("Cohort name", course_cohort.cohort.name)
+        expect(summary_list).to have_summary_item("Cohort registration open", course_cohort.cohort.registration_starts_at.to_date.to_fs(:govuk))
+        expect(summary_list).to have_summary_item("Course ID", course.ecf_id)
+        expect(summary_list).to have_summary_item("Identifier", course.identifier)
+        expect(summary_list).to have_summary_item("Description", course.description)
+      end
+
+      expect(page).to have_css("h2", text: "Schedule")
+      expect(page).to have_css("h2", text: "Providers")
+    end
+
+    scenario "viewing course details for all cohorts" do
+      course = Course.first
+
+      visit(admin_course_path(course))
 
       expect(page).to have_css("h1", text: course.name)
 

--- a/spec/features/admin/creating_statements_spec.rb
+++ b/spec/features/admin/creating_statements_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Creating statements", type: :feature do
     let(:admin) { create(:super_admin) }
 
     scenario "is possible" do
-      click_on "Create statements"
+      visit new_admin_cohort_statement_path(cohort)
 
       attach_file "statements_bulk_creator[statements_csv_file]", statements_csv.path, make_visible: true
       attach_file "statements_bulk_creator[contracts_csv_file]", contracts_csv.path, make_visible: true
@@ -67,7 +67,7 @@ RSpec.feature "Creating statements", type: :feature do
     end
 
     scenario "downloading examples" do
-      click_on "Create statements"
+      visit new_admin_cohort_statement_path(cohort)
 
       find("summary", text: "Example statements CSV").click
       click_on "Download empty statements template"
@@ -85,8 +85,7 @@ RSpec.feature "Creating statements", type: :feature do
       csv = CSV.read(csv_file)
       expect(csv.count).to eq(1)
 
-      visit admin_cohort_path(cohort)
-      click_on "Download contracts CSV"
+      visit download_contracts_admin_cohort_path(cohort)
       csv_file = "#{Capybara.save_path}/contracts.csv"
       wait_for_file_to_be_created(csv_file)
     end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe Cohort, type: :model do
     it { is_expected.not_to allow_value(nil).for(:funding_cap).with_message("Choose true or false for funding cap") }
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
 
+    it "shows the conflicting cohort start month when the identifier already exists" do
+      create(:cohort, start_year: 2026, registration_starts_at: Date.new(2026, 1, 3))
+      duplicate = Cohort.new(
+        start_year: 2026,
+        registration_starts_at: Date.new(2026, 1, 20),
+        description: "Another January 2026 cohort",
+        funding_cap: true,
+      )
+
+      expect(duplicate).to have_error(:identifier, :taken, "Cohort starting 'Jan 2026' exists already")
+    end
+
     describe "registration_starts_at year should match start_year" do
       it "adds an error when the registration_starts_at year does not match the start_year" do
         cohort = Cohort.new(start_year: 2022, registration_starts_at: Date.new(2023, 4, 10))

--- a/spec/requests/admin/cohort_courses_controller_spec.rb
+++ b/spec/requests/admin/cohort_courses_controller_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe Admin::CohortCoursesController, :ecf_api_disabled, type: :request do
+  include Helpers::NPQSeparationAdminLogin
+
+  subject { response }
+
+  let(:cohort) { create(:cohort, :unique) }
+  let!(:schedule) { create(:schedule, cohort:) }
+  let!(:course) { create(:course, name: "Course to add", identifier: "course-to-add") }
+  let(:lead_provider) { create(:lead_provider, name: "Provider One") }
+  let(:course_cohort) { create(:course_cohort, cohort:, course:, schedule:, lead_provider:) }
+  let(:valid_params) { { course_cohort: { course_id: course.id, schedule_id: schedule.id } } }
+  let(:invalid_params) { { course_cohort: { course_id: "", schedule_id: "" } } }
+
+  context "when logged in as super admin" do
+    before { sign_in_as_admin(super_admin: true) }
+
+    describe "#show" do
+      before { get admin_cohort_course_path(cohort, course_cohort.course) }
+
+      it { is_expected.to have_http_status :success }
+
+      it "links to providers on the course cohort" do
+        expect(response.body).to include(admin_lead_provider_path(lead_provider))
+      end
+
+      it "links to add or remove providers" do
+        expect(response.body).to include(admin_course_course_cohort_provider_path(course, course_cohort))
+      end
+    end
+
+    describe "#new" do
+      before { get new_admin_cohort_course_path(cohort) }
+
+      it { is_expected.to have_http_status :success }
+
+      it "shows schedules for the cohort" do
+        expect(response.body).to include(schedule.name)
+      end
+
+      it "links to create a schedule in a new tab" do
+        expect(response.body).to include(new_admin_cohort_schedule_path(cohort))
+        expect(response.body).to include('target="_blank"')
+      end
+    end
+
+    describe "#create" do
+      before { post admin_cohort_courses_path(cohort), params: valid_params }
+
+      it { is_expected.to redirect_to admin_cohort_course_path(cohort, course) }
+
+      it "creates the course cohort" do
+        expect(cohort.course_cohorts.find_by(course:, schedule:)).to be_present
+      end
+
+      it "flashes success" do
+        expect(flash[:success]).to match(/Course added/i)
+      end
+    end
+
+    describe "#create with invalid params" do
+      before { post admin_cohort_courses_path(cohort), params: invalid_params }
+
+      it { is_expected.to have_http_status :unprocessable_content }
+    end
+  end
+
+  context "when logged in as normal admin" do
+    before { sign_in_as_admin }
+
+    shared_examples "inaccessible to normal admins" do
+      it { is_expected.to redirect_to admin_cohort_path(cohort) }
+
+      it "flashes the correct error" do
+        expect(flash[:error]).to match(/You must be a super admin to change cohort courses/i)
+      end
+    end
+
+    describe "#show" do
+      before { get admin_cohort_course_path(cohort, course_cohort.course) }
+
+      it { is_expected.to have_http_status :success }
+    end
+
+    describe "#new" do
+      before { get new_admin_cohort_course_path(cohort) }
+
+      it_behaves_like "inaccessible to normal admins"
+    end
+
+    describe "#create" do
+      before { post admin_cohort_courses_path(cohort), params: valid_params }
+
+      it_behaves_like "inaccessible to normal admins"
+    end
+  end
+
+  context "when not logged in" do
+    describe "#show" do
+      before { get admin_cohort_course_path(cohort, course_cohort.course) }
+
+      it { is_expected.to redirect_to sign_in_path }
+    end
+
+    describe "#new" do
+      before { get new_admin_cohort_course_path(cohort) }
+
+      it { is_expected.to redirect_to sign_in_path }
+    end
+
+    describe "#create" do
+      before { post admin_cohort_courses_path(cohort), params: valid_params }
+
+      it { is_expected.to redirect_to sign_in_path }
+    end
+  end
+end

--- a/spec/requests/admin/cohort_courses_controller_spec.rb
+++ b/spec/requests/admin/cohort_courses_controller_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe Admin::CohortCoursesController, :ecf_api_disabled, type: :request
   let!(:course) { create(:course, name: "Course to add", identifier: "course-to-add") }
   let(:lead_provider) { create(:lead_provider, name: "Provider One") }
   let(:course_cohort) { create(:course_cohort, cohort:, course:, schedule:, lead_provider:) }
-  let!(:delivery_partnerships) { create_list(:delivery_partnership, 2, cohort:, lead_provider:) }
+
   let(:valid_params) { { course_cohort: { course_id: course.id, schedule_id: schedule.id } } }
   let(:invalid_params) { { course_cohort: { course_id: "", schedule_id: "" } } }
+
+  before { create_list(:delivery_partnership, 2, cohort:, lead_provider:) }
 
   context "when logged in as super admin" do
     before { sign_in_as_admin(super_admin: true) }

--- a/spec/requests/admin/cohort_courses_controller_spec.rb
+++ b/spec/requests/admin/cohort_courses_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Admin::CohortCoursesController, :ecf_api_disabled, type: :request
   let!(:course) { create(:course, name: "Course to add", identifier: "course-to-add") }
   let(:lead_provider) { create(:lead_provider, name: "Provider One") }
   let(:course_cohort) { create(:course_cohort, cohort:, course:, schedule:, lead_provider:) }
+  let!(:delivery_partnerships) { create_list(:delivery_partnership, 2, cohort:, lead_provider:) }
   let(:valid_params) { { course_cohort: { course_id: course.id, schedule_id: schedule.id } } }
   let(:invalid_params) { { course_cohort: { course_id: "", schedule_id: "" } } }
 
@@ -21,8 +22,16 @@ RSpec.describe Admin::CohortCoursesController, :ecf_api_disabled, type: :request
 
       it { is_expected.to have_http_status :success }
 
+      it "shows the cohort name" do
+        expect(response.body).to include(cohort.name)
+      end
+
       it "links to providers on the course cohort" do
         expect(response.body).to include(admin_lead_provider_path(lead_provider))
+      end
+
+      it "shows the number of delivery partners for the provider and cohort" do
+        expect(response.body).to include("2 delivery partners")
       end
 
       it "links to add or remove providers" do

--- a/spec/requests/admin/cohort_courses_controller_spec.rb
+++ b/spec/requests/admin/cohort_courses_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Admin::CohortCoursesController, :ecf_api_disabled, type: :request
       end
 
       it "links to providers on the course cohort" do
-        expect(response.body).to include(admin_lead_provider_path(lead_provider))
+        expect(response.body).to include(cohort_admin_lead_provider_path(lead_provider, cohort))
       end
 
       it "shows the number of delivery partners for the provider and cohort" do

--- a/spec/requests/admin/cohort_courses_controller_spec.rb
+++ b/spec/requests/admin/cohort_courses_controller_spec.rb
@@ -24,8 +24,27 @@ RSpec.describe Admin::CohortCoursesController, :ecf_api_disabled, type: :request
 
       it { is_expected.to have_http_status :success }
 
+      it "links back to courses when there is no referrer" do
+        expect(response.body).to include(%(href="#{admin_courses_path}"))
+      end
+
+      it "links back to the referrer when present" do
+        referrer = admin_cohort_path(cohort)
+
+        get admin_cohort_course_path(cohort, course_cohort.course), headers: { "HTTP_REFERER" => referrer }
+
+        expect(response.body).to include(%(href="#{referrer}"))
+      end
+
       it "shows the cohort name" do
         expect(response.body).to include(cohort.name)
+      end
+
+      it "shows the course cohort schedule" do
+        expect(response.body).to include(schedule.name)
+        expect(response.body).to include(schedule.training_starts_at.to_fs(:govuk_short))
+        expect(response.body).to include(schedule.training_ends_at.to_fs(:govuk_short))
+        expect(response.body).to include(schedule.allowed_declaration_types.join(", "))
       end
 
       it "links to providers on the course cohort" do

--- a/spec/requests/admin/course_cohort_providers_controller_spec.rb
+++ b/spec/requests/admin/course_cohort_providers_controller_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Admin::CourseCohortProvidersController, type: :request do
+  include Helpers::NPQSeparationAdminLogin
+
+  let(:course) { create(:course) }
+  let(:lead_provider) { create(:lead_provider) }
+  let!(:course_cohort) { create(:course_cohort, course:, lead_provider:) }
+
+  before { sign_in_as_admin(super_admin:) }
+
+  context "when logged in as super admin" do
+    let(:super_admin) { true }
+
+    describe "#show" do
+      before { get admin_course_course_cohort_provider_path(course, course_cohort) }
+
+      it { expect(response).to have_http_status(:success) }
+    end
+
+    describe "#update" do
+      let!(:new_lead_provider) { create(:lead_provider) }
+
+      it "updates the providers for the course cohort" do
+        patch admin_course_course_cohort_provider_path(course, course_cohort),
+              params: {
+                course_cohort: { lead_provider_ids: [new_lead_provider.id] },
+              }
+
+        expect(response).to redirect_to(admin_cohort_course_path(course_cohort.cohort, course))
+        expect(course_cohort.lead_providers.reload).to contain_exactly(new_lead_provider)
+      end
+    end
+  end
+
+  context "when logged in as normal admin" do
+    let(:super_admin) { false }
+
+    describe "#show" do
+      before { get admin_course_course_cohort_provider_path(course, course_cohort) }
+
+      it "redirects to the course page" do
+        expect(response).to redirect_to(admin_cohort_course_path(course_cohort.cohort, course))
+        expect(flash[:error]).to match(/You must be a super admin to change course cohort providers/i)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/courses_controller_spec.rb
+++ b/spec/requests/admin/courses_controller_spec.rb
@@ -85,13 +85,4 @@ RSpec.describe Admin::CoursesController, type: :request do
       end
     end
   end
-
-  describe "/admin/courses/:id" do
-    subject do
-      get admin_course_path(create(:course))
-      response
-    end
-
-    it { is_expected.to have_http_status(:ok) }
-  end
 end

--- a/spec/requests/admin/courses_controller_spec.rb
+++ b/spec/requests/admin/courses_controller_spec.rb
@@ -85,4 +85,13 @@ RSpec.describe Admin::CoursesController, type: :request do
       end
     end
   end
+
+  describe "/admin/courses/:id" do
+    subject do
+      get admin_course_path(create(:course))
+      response
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+  end
 end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#505

There is no way to add/remove a provider from a course cohort unless you're on a rails console.

### Changes proposed in this pull request

Add admin screens to manage providers across course cohorts
