### PR TITLE
Attempt to fix flaky spec

### DIFF
--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -110,6 +110,11 @@ FactoryBot.define do
         course = application.course.rebranded_alternative_courses.first
         previous_cohort = create(:cohort, :unique, :with_funding_cap)
 
+        if previous_cohort == application.cohort
+          previous_cohort = create(:cohort, :with_funding_cap,
+                                   registration_starts_at: application.cohort.registration_starts_at.prev_year)
+        end
+
         create(:application, :accepted, :eligible_for_funding, user: application.user, course:, cohort: previous_cohort)
       end
     end


### PR DESCRIPTION

### Context

If the previous cohort happens to have the same date, it returns the same cohort as the application's cohort, the validation kicks in - user can't have two applications for the same cohort - and the test fails
 
### Changes proposed in this pull request

[What has been changed?]

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
