### PR TITLE
Only send registration open emails for the course the application is for

### DIFF
--- a/app/jobs/crons/send_registration_open_notification_emails_job.rb
+++ b/app/jobs/crons/send_registration_open_notification_emails_job.rb
@@ -6,8 +6,8 @@ class Crons::SendRegistrationOpenNotificationEmailsJob < CronJob
   sentry_monitor_check_ins slug: "send-registration-open-notification-emails"
 
   def perform
-    Cohort.where(registration_starts_at: Date.yesterday).find_each do |cohort|
-      Application.deferred_status.find_each do |application|
+    Cohort.where(registration_starts_at: Time.zone.yesterday).find_each do |cohort|
+      eligible_applications(cohort).find_each do |application|
         next if already_notified?(application, cohort)
 
         GenericMailer.with(
@@ -18,6 +18,7 @@ class Crons::SendRegistrationOpenNotificationEmailsJob < CronJob
           deferral_date: application.deferred_at.to_fs(:govuk_date_only),
           ecf_id: application.ecf_id,
           cohort_id: cohort.id,
+          course_id: application.course.id,
         ).registration_open_notification.deliver_later
       end
     end
@@ -25,10 +26,19 @@ class Crons::SendRegistrationOpenNotificationEmailsJob < CronJob
 
 private
 
+  def eligible_applications(cohort)
+    Application
+      .deferred_status
+      .joins(:course_cohort)
+      .where(course_cohorts: { course_id: cohort.course_cohorts.select(:course_id) })
+      .includes(:user, course_cohort: :course)
+  end
+
   def already_notified?(application, cohort)
     application.notifications
                .where(event: "registration_open_notification")
                .where("metadata->>'cohort_id' = ?", cohort.id.to_s)
+               .where("metadata->>'course_id' = ?", application.course.id.to_s)
                .exists?
   end
 end

--- a/spec/jobs/crons/send_registration_open_notification_emails_job_spec.rb
+++ b/spec/jobs/crons/send_registration_open_notification_emails_job_spec.rb
@@ -2,29 +2,85 @@ require "rails_helper"
 
 RSpec.describe Crons::SendRegistrationOpenNotificationEmailsJob, type: :job do
   describe "#perform" do
-    let(:cohort) { create(:cohort, start_year: Date.yesterday.year, registration_starts_at: Date.yesterday) }
-    let(:application) { create(:application, :deferred) }
+    let(:cohort) { create(:cohort, start_year: Time.zone.yesterday.year, registration_starts_at: Time.zone.yesterday) }
+    let(:application_cohort) do
+      create(
+        :cohort,
+        start_year: Time.zone.yesterday.prev_year.year,
+        registration_starts_at: Time.zone.yesterday.prev_year,
+      )
+    end
+    let(:application) do
+      create(
+        :application,
+        :deferred,
+        cohort: application_cohort,
+        schedule: create(:schedule, cohort: application_cohort),
+      )
+    end
+    let!(:course_cohort) { create(:course_cohort, cohort:, course: application.course) }
 
-    it "enqueues email for deferred applications when registration opened yesterday" do
-      cohort
-      application
-
+    it "enqueues an email for a deferred application when its course is on a cohort that opened yesterday" do
       expect { described_class.perform_now }
         .to have_enqueued_mail(GenericMailer, :registration_open_notification)
+    end
+
+    it "records a notification event for the cohort and course" do
+      perform_enqueued_jobs { described_class.perform_now }
+
+      notification = application.notifications.find_by!(event: "registration_open_notification")
+
+      expect(notification.metadata).to include(
+        "cohort_id" => cohort.id,
+        "course_id" => application.course.id,
+      )
+    end
+
+    it "skips deferred applications whose course is not on the cohort" do
+      other_course = build(:course, identifier: "another-course")
+      other_course.save!
+      other_cohort = create(:cohort, :unique)
+
+      create(
+        :application,
+        :deferred,
+        course: other_course,
+        cohort: other_cohort,
+        schedule: create(:schedule, cohort: other_cohort),
+      )
+
+      expect { described_class.perform_now }
+        .to have_enqueued_mail(GenericMailer, :registration_open_notification).once
     end
 
     it "skips applications that have already been notified for this cohort" do
       application.notifications.create!(
         event: "registration_open_notification",
-        metadata: { "cohort_id" => cohort.id },
+        metadata: {
+          "cohort_id" => cohort.id,
+          "course_id" => application.course.id,
+        },
       )
 
       expect { described_class.perform_now }
         .not_to have_enqueued_mail(GenericMailer, :registration_open_notification)
     end
 
+    it "does not treat a notification for another course as already sent" do
+      application.notifications.create!(
+        event: "registration_open_notification",
+        metadata: {
+          "cohort_id" => cohort.id,
+          "course_id" => -1,
+        },
+      )
+
+      expect { described_class.perform_now }
+        .to have_enqueued_mail(GenericMailer, :registration_open_notification)
+    end
+
     it "skips cohorts where registration did not open yesterday" do
-      cohort.update!(registration_starts_at: Date.current)
+      cohort.update!(registration_starts_at: Time.zone.today)
 
       expect { described_class.perform_now }
         .not_to have_enqueued_mail(GenericMailer, :registration_open_notification)

--- a/spec/jobs/crons/send_registration_open_notification_emails_job_spec.rb
+++ b/spec/jobs/crons/send_registration_open_notification_emails_job_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Crons::SendRegistrationOpenNotificationEmailsJob, type: :job do
         schedule: create(:schedule, cohort: application_cohort),
       )
     end
-    let!(:course_cohort) { create(:course_cohort, cohort:, course: application.course) }
+
+    before { create(:course_cohort, cohort:, course: application.course) }
 
     it "enqueues an email for a deferred application when its course is on a cohort that opened yesterday" do
       expect { described_class.perform_now }


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#525
The current code will send a notification for each deferred application regardless of the course.
So if someone set up a cohort for "Course A" and linked "Course A" to it only, but the application was for "Course B" they would still get a notification.

### Changes proposed in this pull request

Fix the job query in order to limit the applications to the cohort only if the application course is also on the cohort
