### PR TITLE
[518] Update course name

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -10,7 +10,25 @@ module Admin
       @course = Course.find(params[:id])
     end
 
+    def edit
+      @course = Course.find(params[:id])
+    end
+
+    def update
+      @course = Course.find(params[:id])
+
+      if @course.update(course_params)
+        redirect_to admin_course_path(@course), flash: { success: "Course updated" }
+      else
+        render :edit, status: :unprocessable_content
+      end
+    end
+
   private
+
+    def course_params
+      params.require(:course).permit(:name, :description)
+    end
 
     def resources
       scope = Course

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -1,23 +1,18 @@
 module Admin
   class CoursesController < AdminController
     include Cohortable
+    before_action :set_course, only: %i[show edit update]
     before_action :require_super_admin, only: %i[edit update]
 
     def index
       @pagy, @resources = pagy(resources)
     end
 
-    def show
-      @course = Course.find(params[:id])
-    end
+    def show; end
 
-    def edit
-      @course = Course.find(params[:id])
-    end
+    def edit; end
 
     def update
-      @course = Course.find(params[:id])
-
       if @course.update(course_params)
         redirect_to admin_course_path(@course), flash: { success: "Course updated" }
       else
@@ -26,6 +21,10 @@ module Admin
     end
 
   private
+
+    def set_course
+      @course = Course.find(params[:id])
+    end
 
     def course_params
       params.require(:course).permit(:name, :description)

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class CoursesController < AdminController
     include Cohortable
+    before_action :require_super_admin, only: %i[edit update]
 
     def index
       @pagy, @resources = pagy(resources)

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -1,0 +1,26 @@
+<%= form_with model: [:admin, course] do |form| %>
+  <%= form.govuk_error_summary %>
+
+  <%=
+    form.govuk_text_field :name,
+                          width: "two-thirds",
+                          label: {
+                            text: "Course name",
+                            size: "m",
+                          }
+  %>
+
+  <%=
+    form.govuk_text_area :description,
+                         rows: 5,
+                         label: {
+                           text: "Course description",
+                           size: "m",
+                         }
+  %>
+
+  <div class="govuk-button-group">
+    <%= form.govuk_submit "Save course details" %>
+    <%= govuk_link_to "Cancel", admin_course_path(course), class: "govuk-link--no-visited-state" %>
+  </div>
+<% end %>

--- a/app/views/admin/courses/edit.html.erb
+++ b/app/views/admin/courses/edit.html.erb
@@ -1,0 +1,5 @@
+<%= govuk_back_link href: admin_course_path(@course) %>
+
+<h1 class="govuk-heading-l">Edit course details</h1>
+
+<%= render "form", course: @course %>

--- a/app/views/admin/courses/show.html.erb
+++ b/app/views/admin/courses/show.html.erb
@@ -6,6 +6,12 @@
   govuk_summary_list do |sl|
 
     sl.with_row do |row|
+      row.with_key(text: "Name")
+      row.with_value(text: @course.name)
+      row.with_action(text: "Change", href: edit_admin_course_path(@course), visually_hidden_text: "name")
+    end
+
+    sl.with_row do |row|
       row.with_key(text: "Course ID")
       row.with_value(text: @course.ecf_id)
     end
@@ -23,6 +29,7 @@
     sl.with_row do |row|
       row.with_key(text: "Description")
       row.with_value(text: @course.description)
+      row.with_action(text: "Change", href: edit_admin_course_path(@course), visually_hidden_text: "description")
     end
 
     sl.with_row do |row|

--- a/app/views/admin/courses/show.html.erb
+++ b/app/views/admin/courses/show.html.erb
@@ -8,7 +8,7 @@
     sl.with_row do |row|
       row.with_key(text: "Name")
       row.with_value(text: @course.name)
-      row.with_action(text: "Change", href: edit_admin_course_path(@course), visually_hidden_text: "name")
+      row.with_action(text: "Change", href: edit_admin_course_path(@course), visually_hidden_text: "name") if current_admin.super_admin?
     end
 
     sl.with_row do |row|
@@ -29,7 +29,7 @@
     sl.with_row do |row|
       row.with_key(text: "Description")
       row.with_value(text: @course.description)
-      row.with_action(text: "Change", href: edit_admin_course_path(@course), visually_hidden_text: "description")
+      row.with_action(text: "Change", href: edit_admin_course_path(@course), visually_hidden_text: "description") if current_admin.super_admin?
     end
 
     sl.with_row do |row|

--- a/app/views/applications/applications/_course_details.html.erb
+++ b/app/views/applications/applications/_course_details.html.erb
@@ -2,7 +2,7 @@
   govuk_summary_list(card: { title: "Course details" }) do |sl|
     sl.with_row do |row|
       row.with_key(text: "Course")
-      row.with_value(text: application.course.name)
+      row.with_value(text: "#{application.course.name} registration")
     end
 
     sl.with_row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
             - come back to this service and you will be able to 'register with a different provider'
 
       start:
-        title: Register with a different provider for the %{course_name} course
+        title: "%{course_name} course: register with a different provider"
         text: 
           application_pending: You can only register with a different provider if you haven't started the course yet.
           application_rejected: ""

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -114,7 +114,7 @@ namespace :admin do
     end
   end
 
-  resources :courses, only: %i[index show] do
+  resources :courses, only: %i[index show edit update] do
     concerns :cohortable, index: "courses#index"
   end
 

--- a/db/seeds/base/add_courses.rb
+++ b/db/seeds/base/add_courses.rb
@@ -1,10 +1,10 @@
 course = Course.find_or_initialize_by(ecf_id: "7fbefdd4-dd2d-4a4f-8995-d59e525124b7")
 course.update!(
-  name: "Excellence in Reception Teaching",
+  name: "Excellence in reception teaching",
   ecf_id: "7fbefdd4-dd2d-4a4f-8995-d59e525124b7",
   # identifier: "npd-excellence-in-reception-teaching",
   identifier: "tte-early-years",
   course_group: "reception",
-  description: "The Excellence in Reception Teaching course is aimed at teachers who have completed their induction and are currently teaching reception age children, or plan to in the future.",
+  description: "The Excellence in reception teaching course is aimed at teachers who have completed their induction and are currently teaching reception age children, or plan to in the future.",
   short_code: "NPDEIRT",
 )

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     end
 
     trait :npd_eirt do
-      sequence(:name) { |n| "Excellence in Reception Teaching #{n}" }
+      sequence(:name) { |n| "Excellence in reception teaching #{n}" }
       # identifier { "npd-excellence-in-reception-teaching" }
       identifier { "tte-early-years" }
       course_group { "reception" }

--- a/spec/features/admin/courses_spec.rb
+++ b/spec/features/admin/courses_spec.rb
@@ -42,11 +42,39 @@ RSpec.feature "Listing and viewing courses", type: :feature do
     expect(page).to have_css("h1", text: course.name)
 
     within(".govuk-summary-list") do |summary_list|
+      expect(summary_list).to have_summary_item("Name", course.name)
       expect(summary_list).to have_summary_item("Course ID", course.ecf_id)
       expect(summary_list).to have_summary_item("Identifier", course.identifier)
       expect(summary_list).to have_summary_item("Position", course.position)
       expect(summary_list).to have_summary_item("Description", course.description)
       expect(summary_list).to have_summary_item("Display", "Yes")
     end
+  end
+
+  scenario "editing a course name" do
+    course = Course.first
+
+    visit(admin_course_path(course))
+
+    click_link("Change name")
+
+    expect(page).to have_css("h1", text: "Edit course details")
+
+    fill_in("Course name", with: "Updated Course Name")
+    click_button("Save course details")
+
+    expect(page).to have_css("h1", text: "Updated Course Name")
+    expect(page).to have_summary_item("Name", "Updated Course Name")
+  end
+
+  scenario "editing a course with invalid input shows an error" do
+    course = Course.first
+
+    visit(edit_admin_course_path(course))
+
+    fill_in("Course name", with: "")
+    click_button("Save course details")
+
+    expect(page).to have_css(".govuk-error-summary", text: "can't be blank")
   end
 end

--- a/spec/features/admin/courses_spec.rb
+++ b/spec/features/admin/courses_spec.rb
@@ -7,74 +7,87 @@ RSpec.feature "Listing and viewing courses", type: :feature do
 
   before do
     create(:course, :npd_eirt)
-    sign_in_as(create(:admin))
   end
 
-  scenario "viewing the list of courses" do
-    visit(admin_courses_path)
-
-    expect(page).to have_css("h1", text: "Courses")
-
-    Course.order(name: :asc).limit(courses_per_page).each do |course|
-      expect(page).to have_link(course.name, href: admin_course_path(course))
+  context "when signed in as admin" do
+    before do
+      sign_in_as(create(:admin))
     end
 
-    # Not enough courses for pagination to kick in
-    # expect(page).to have_css(".govuk-pagination__item--current", text: 1)
-  end
+    scenario "viewing the list of courses" do
+      visit(admin_courses_path)
 
-  scenario "navigating to the second page of courses", :npq do
-    visit(admin_courses_path)
+      expect(page).to have_css("h1", text: "Courses")
 
-    click_on("Next")
+      Course.order(name: :asc).limit(courses_per_page).each do |course|
+        expect(page).to have_link(course.name, href: admin_course_path(course))
+      end
 
-    expect(page).to have_css("table.govuk-table tbody tr", count: 5)
-    expect(page).to have_css(".govuk-pagination__item--current", text: "2")
-  end
+      # Not enough courses for pagination to kick in
+      # expect(page).to have_css(".govuk-pagination__item--current", text: 1)
+    end
 
-  scenario "viewing course details" do
-    visit(admin_courses_path)
+    scenario "navigating to the second page of courses", :npq do
+      visit(admin_courses_path)
 
-    course = Course.order(name: :asc).first
+      click_on("Next")
 
-    click_link(course.name)
+      expect(page).to have_css("table.govuk-table tbody tr", count: 5)
+      expect(page).to have_css(".govuk-pagination__item--current", text: "2")
+    end
 
-    expect(page).to have_css("h1", text: course.name)
+    scenario "viewing course details" do
+      visit(admin_courses_path)
 
-    within(".govuk-summary-list") do |summary_list|
-      expect(summary_list).to have_summary_item("Name", course.name)
-      expect(summary_list).to have_summary_item("Course ID", course.ecf_id)
-      expect(summary_list).to have_summary_item("Identifier", course.identifier)
-      expect(summary_list).to have_summary_item("Position", course.position)
-      expect(summary_list).to have_summary_item("Description", course.description)
-      expect(summary_list).to have_summary_item("Display", "Yes")
+      course = Course.order(name: :asc).first
+
+      click_link(course.name)
+
+      expect(page).to have_css("h1", text: course.name)
+
+      within(".govuk-summary-list") do |summary_list|
+        expect(summary_list).to have_summary_item("Name", course.name)
+        expect(summary_list).to have_summary_item("Course ID", course.ecf_id)
+        expect(summary_list).to have_summary_item("Identifier", course.identifier)
+        expect(summary_list).to have_summary_item("Position", course.position)
+        expect(summary_list).to have_summary_item("Description", course.description)
+        expect(summary_list).to have_summary_item("Display", "Yes")
+      end
+
+      expect(page).not_to have_link("Change")
     end
   end
 
-  scenario "editing a course name" do
-    course = Course.first
+  context "when signed in as super admin" do
+    before do
+      sign_in_as(create(:super_admin))
+    end
 
-    visit(admin_course_path(course))
+    scenario "editing a course name" do
+      course = Course.first
 
-    click_link("Change name")
+      visit(admin_course_path(course))
 
-    expect(page).to have_css("h1", text: "Edit course details")
+      click_link("Change name")
 
-    fill_in("Course name", with: "Updated Course Name")
-    click_button("Save course details")
+      expect(page).to have_css("h1", text: "Edit course details")
 
-    expect(page).to have_css("h1", text: "Updated Course Name")
-    expect(page).to have_summary_item("Name", "Updated Course Name")
-  end
+      fill_in("Course name", with: "Updated Course Name")
+      click_button("Save course details")
 
-  scenario "editing a course with invalid input shows an error" do
-    course = Course.first
+      expect(page).to have_css("h1", text: "Updated Course Name")
+      expect(page).to have_summary_item("Name", "Updated Course Name")
+    end
 
-    visit(edit_admin_course_path(course))
+    scenario "editing a course with invalid input shows an error" do
+      course = Course.first
 
-    fill_in("Course name", with: "")
-    click_button("Save course details")
+      visit(edit_admin_course_path(course))
 
-    expect(page).to have_css(".govuk-error-summary", text: "can't be blank")
+      fill_in("Course name", with: "")
+      click_button("Save course details")
+
+      expect(page).to have_css(".govuk-error-summary", text: "can't be blank")
+    end
   end
 end

--- a/spec/features/applications/change_provider_spec.rb
+++ b/spec/features/applications/change_provider_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Change provider", type: :feature do
       #
       visit application_change_provider_start_index_path(application.ecf_id)
 
-      expect(page).to have_text("Register with a different provider for the #{application.course.name}")
+      expect(page).to have_text("#{application.course.name} course: register with a different provider")
 
       choose(I18n.t("applications.change_provider.start.application_#{application.status}.form.yes_option"), visible: :all)
 

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -84,12 +84,12 @@ RSpec.feature "Happy journeys", :with_default_lead_provider, :with_default_sched
     if User.last.applications.count == 1
       navigate_to_page(path: "/applications/#{User.last.applications.last.ecf_id}", submit_form: false) do
         expect(page).to have_text(LeadProvider.first.name)
-        expect(page).to have_text("Excellence in Reception Teaching")
+        expect(page).to have_text("Excellence in reception teaching")
       end
     else
       navigate_to_page(path: "/applications", submit_form: false) do
         expect(page).to have_text(LeadProvider.first.name)
-        expect(page).to have_text("Excellence in Reception Teaching")
+        expect(page).to have_text("Excellence in reception teaching")
       end
     end
 

--- a/spec/mailers/previews/generic_mailer_preview.rb
+++ b/spec/mailers/previews/generic_mailer_preview.rb
@@ -36,7 +36,7 @@ class GenericMailerPreview < ActionMailer::Preview
     GenericMailer.with(
       to: "test@example.com",
       full_name: "Jane Smith",
-      course_name: "Excellence in Reception Teaching",
+      course_name: "Excellence in reception teaching",
       deferral_date: 11.months.ago.to_fs(:govuk_date_only),
       ecf_id: "abc-123-def-456",
     ).deferral_expiring_notification
@@ -47,7 +47,7 @@ class GenericMailerPreview < ActionMailer::Preview
       to: "test@example.com",
       full_name: "Jane Smith",
       provider_name: "Ambition Institute",
-      course_name: "Excellence in Reception Teaching",
+      course_name: "Excellence in reception teaching",
       deferral_date: Date.current.to_fs(:govuk),
       ecf_id: "abc-123-def-456",
     ).deferral_notification
@@ -75,7 +75,7 @@ class GenericMailerPreview < ActionMailer::Preview
     GenericMailer.with(
       to: "test@example.com",
       full_name: "Jane Smith",
-      course_name: "Excellence in Reception Teaching",
+      course_name: "Excellence in reception teaching",
       next_course_start_date: Date.current.to_fs(:govuk),
       deferral_date: 3.months.ago.to_fs(:govuk_date_only),
       ecf_id: "abc-123-def-456",
@@ -86,7 +86,7 @@ class GenericMailerPreview < ActionMailer::Preview
     GenericMailer.with(
       to: "test@example.com",
       full_name: "Jane Smith",
-      course_name: "Excellence in Reception Teaching",
+      course_name: "Excellence in reception teaching",
       provider_name: "Ambition Institute",
       cohort_date: "Autumn 2026",
       sign_in_link: "https://national-professional-development.education.gov.uk/",

--- a/spec/requests/admin/courses_controller_spec.rb
+++ b/spec/requests/admin/courses_controller_spec.rb
@@ -3,31 +3,86 @@ require "rails_helper"
 RSpec.describe Admin::CoursesController, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
-  before { sign_in_as_admin }
+  context "when signed in as admin" do
+    before { sign_in_as_admin }
 
-  describe "/admin/courses" do
-    subject do
-      get admin_courses_path
-      response
+    describe "GET /admin/courses" do
+      subject do
+        get admin_courses_path
+        response
+      end
+
+      it { is_expected.to have_http_status(:ok) }
     end
 
-    it { is_expected.to have_http_status(:ok) }
+    describe "GET /admin/courses/{id}" do
+      let(:course_id) { create(:course).id }
+
+      subject do
+        get admin_course_path(course_id)
+        response
+      end
+
+      it { is_expected.to have_http_status(:ok) }
+
+      context "when the course cannot be found", :exceptions_app do
+        let(:course_id) { -1 }
+
+        it { is_expected.to have_http_status(:not_found) }
+      end
+    end
+
+    describe "GET /admin/courses/{id}/edit" do
+      let(:course) { create(:course) }
+
+      subject do
+        get edit_admin_course_path(course)
+        response
+      end
+
+      it { is_expected.to redirect_to(sign_in_path) }
+    end
+
+    describe "PATCH /admin/courses/{id}" do
+      let(:course) { create(:course) }
+
+      subject do
+        patch admin_course_path(course), params: { course: { name: "Updated" } }
+        response
+      end
+
+      it { is_expected.to redirect_to(sign_in_path) }
+    end
   end
 
-  describe "/admin/courses/{id}" do
-    let(:course_id) { create(:course).id }
+  context "when signed in as super admin" do
+    before { sign_in_as_admin(super_admin: true) }
 
-    subject do
-      get admin_course_path(course_id)
-      response
+    describe "GET /admin/courses/{id}/edit" do
+      let(:course) { create(:course) }
+
+      subject do
+        get edit_admin_course_path(course)
+        response
+      end
+
+      it { is_expected.to have_http_status(:ok) }
     end
 
-    it { is_expected.to have_http_status(:ok) }
+    describe "PATCH /admin/courses/{id}" do
+      let(:course) { create(:course) }
 
-    context "when the course cannot be found", :exceptions_app do
-      let(:course_id) { -1 }
+      subject do
+        patch admin_course_path(course), params: { course: { name: "Updated" } }
+        response
+      end
 
-      it { is_expected.to have_http_status(:not_found) }
+      it { is_expected.to redirect_to(admin_course_path(course)) }
+
+      it "updates the course" do
+        subject
+        expect(course.reload.name).to eq("Updated")
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#518

As a Participant
I need the correct course name to be presented across the service
So that I know I am applying for the correct course:

"Excellence in reception teaching"
- Check course Name on Check and Submit screen
- Check course Name on Registration details screen - summary box
- Check course name in the course details summary will be 'Excellence in reception teaching registration'
- Check heaving on change provider screen will be ' 'Excellence in reception teaching course: register with a different provider'

### Changes proposed in this pull request

- Update course name in seeds and tests
- Add admin capability to edit course name and description


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
