### PR TITLE
[527] Fix create_random_user to be idempotent

### DIFF
--- a/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
+++ b/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
@@ -219,6 +219,7 @@ module ValidTestDataGenerators
 
       email = "#{email_part}@#{to_dns_name(@lead_provider.name)}.com"
 
+      # temp commit to force seed rerun
       user = User.find_or_create_by!(email:) do |u|
         u.ecf_id = SecureRandom.uuid
         u.full_name = name

--- a/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
+++ b/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
@@ -217,12 +217,10 @@ module ValidTestDataGenerators
       name = Faker::Name.unique.name
       email_part = name.tr(" '.", "").downcase
 
-      # Create with temporary email first
-      temp_email = "#{email_part}@#{to_dns_name(@lead_provider.name)}.com"
-      ecf_id = SecureRandom.uuid
+      email = "#{email_part}@#{to_dns_name(@lead_provider.name)}.com"
 
-      user = User.find_or_create_by!(ecf_id: ecf_id) do |u|
-        u.email = temp_email
+      user = User.find_or_create_by!(email:) do |u|
+        u.ecf_id = SecureRandom.uuid
         u.full_name = name
         u.trn = generate_trn if with_trn
         u.date_of_birth = Faker::Date.birthday(min_age: 20)

--- a/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
+++ b/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
@@ -219,7 +219,6 @@ module ValidTestDataGenerators
 
       email = "#{email_part}@#{to_dns_name(@lead_provider.name)}.com"
 
-      # temp commit to force seed rerun
       user = User.find_or_create_by!(email:) do |u|
         u.ecf_id = SecureRandom.uuid
         u.full_name = name


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#527

Seeds are failing on review apps.

### Changes proposed in this pull request

Here we use email as the lookup key instead of
the randomly generated ecf_id

Tested by pushing three commits on this branch and checking that the review app seeded

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
