### PR TITLE
Attempt to fix  flaky spec by using registration_starts_at for cohort lookup

### DIFF
--- a/spec/services/valid_test_data_generators/api_test_scenarios_seeder_spec.rb
+++ b/spec/services/valid_test_data_generators/api_test_scenarios_seeder_spec.rb
@@ -162,8 +162,8 @@ RSpec.describe ValidTestDataGenerators::APITestScenariosSeeder do
           seeder.call
 
           course = Course.find_by!(identifier: "tte-early-years")
-          primary_course_cohort = CourseCohort.find_by(course:, cohort: Cohort.find_by(start_year: cohort_year))
-          secondary_course_cohort = CourseCohort.find_by(course:, cohort: Cohort.find_by(start_year: cohort_year + 1))
+          primary_course_cohort = CourseCohort.find_by(course:, cohort: Cohort.find_by(registration_starts_at: Date.new(cohort_year, 7, 1)))
+          secondary_course_cohort = CourseCohort.find_by(course:, cohort: Cohort.find_by(registration_starts_at: Date.new(cohort_year + 1, 7, 1)))
 
           expect(lead_provider.updateable_applications.where(course_cohort: primary_course_cohort).count).to eq(11)
           expect(lead_provider.updateable_applications.where(course_cohort: secondary_course_cohort).count).to eq(1)


### PR DESCRIPTION
### Context

Attempt to fix flaky spec

### Changes proposed in this pull request

Use registration_starts_at for cohort lookup

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
