### PR TITLE
Send registration of interest email

### DIFF
--- a/app/jobs/crons/send_registration_interest_emails_job.rb
+++ b/app/jobs/crons/send_registration_interest_emails_job.rb
@@ -1,6 +1,7 @@
 module Crons
   class SendRegistrationInterestEmailsJob < CronJob
     include Sentry::Cron::MonitorCheckIns
+    include Rails.application.routes.url_helpers
 
     self.cron_expression = "0 11 * * *"
 
@@ -11,11 +12,9 @@ module Crons
       return unless Cohort.where(registration_starts_at: Time.zone.today).exists?
 
       RegistrationInterest.not_yet_notified.find_each do |registration_interest|
-        next unless registration_interest.valid_email?
-
         GenericMailer.with(
           to: registration_interest.email,
-          registration_start_url: "#{Rails.configuration.service_base_url}/registration/start",
+          registration_start_url: registration_wizard_show_url(:start),
         ).registration_interest.deliver_later
 
         registration_interest.update!(notified: true)

--- a/app/jobs/crons/send_registration_interest_emails_job.rb
+++ b/app/jobs/crons/send_registration_interest_emails_job.rb
@@ -7,6 +7,7 @@ module Crons
     sentry_monitor_check_ins slug: "send-registration-interest-emails"
 
     def perform
+      return if Feature.registration_disabled?
       return unless Cohort.where(registration_starts_at: Time.zone.today).exists?
 
       RegistrationInterest.not_yet_notified.find_each do |registration_interest|

--- a/app/jobs/crons/send_registration_interest_emails_job.rb
+++ b/app/jobs/crons/send_registration_interest_emails_job.rb
@@ -1,0 +1,24 @@
+module Crons
+  class SendRegistrationInterestEmailsJob < CronJob
+    include Sentry::Cron::MonitorCheckIns
+
+    self.cron_expression = "0 11 * * *"
+
+    sentry_monitor_check_ins slug: "send-registration-interest-emails"
+
+    def perform
+      return unless Cohort.where(registration_starts_at: Time.zone.today).exists?
+
+      RegistrationInterest.not_yet_notified.find_each do |registration_interest|
+        next unless registration_interest.valid_email?
+
+        GenericMailer.with(
+          to: registration_interest.email,
+          registration_start_url: "#{Rails.configuration.service_base_url}/registration/start",
+        ).registration_interest.deliver_later
+
+        registration_interest.update!(notified: true)
+      end
+    end
+  end
+end

--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -31,6 +31,10 @@ class GenericMailer < ApplicationMailer
     generic_mail(subject: "mailers.registration_open_notification")
   end
 
+  def registration_interest
+    generic_mail(subject: "mailers.registration_interest")
+  end
+
   def deferral_expiring_notification
     generic_mail(subject: "mailers.deferral_expiring_notification")
   end

--- a/app/models/registration_interest.rb
+++ b/app/models/registration_interest.rb
@@ -10,6 +10,6 @@ class RegistrationInterest < ApplicationRecord
 
   # We did not originally valid email format so we need to check this before sending
   def valid_email?
-    NotifyEmailValidator.valid?(value)
+    NotifyEmailValidator.valid?(email)
   end
 end

--- a/app/models/registration_interest.rb
+++ b/app/models/registration_interest.rb
@@ -6,10 +6,4 @@ class RegistrationInterest < ApplicationRecord
             notify_email: true
 
   scope :not_yet_notified, -> { where(notified: false) }
-  scope :random_sample, ->(count) { order("RANDOM()").first(count) }
-
-  # We did not originally valid email format so we need to check this before sending
-  def valid_email?
-    NotifyEmailValidator.valid?(email)
-  end
 end

--- a/app/views/generic_mailer/registration_interest.text.erb
+++ b/app/views/generic_mailer/registration_interest.text.erb
@@ -1,10 +1,13 @@
-^Department for Education
+# You can now register for the excellence in teaching reception national professional development (NPD) course
 
-# Registration is now open
+Thank you for registering your interest in our training courses.
 
-You asked us to email you when registration opened for the next course.
+The excellence in teaching reception NPD course is now open for applications. This course will start in October 2026.
 
-Registration is now open. You can now [apply for a course](<%= params[:registration_start_url] %>).
+We'll let you know when future course dates open.
+
+To check your eligibility for funding and start your course registration, go to [<%= params[:registration_start_url] %>](<%= params[:registration_start_url] %>)
 
 Regards,
-The Teaching Continuing Professional Development Team
+
+The Teacher Continuing Professional Development Team

--- a/app/views/generic_mailer/registration_interest.text.erb
+++ b/app/views/generic_mailer/registration_interest.text.erb
@@ -1,0 +1,10 @@
+^Department for Education
+
+# Registration is now open
+
+You asked us to email you when registration opened for the next course.
+
+Registration is now open. You can now [apply for a course](<%= params[:registration_start_url] %>).
+
+Regards,
+The Teaching Continuing Professional Development Team

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
     change_provider: You've registered for %{course_name} - next steps
     deferral_notification: Notification of deferral - %{course_name}
     registration_open_notification: Registration open - %{course_name}
+    registration_interest: Registration is now open
     deferral_expiring_notification: Registration about to expire - %{course_name}
     provider_rejected: Registration status updated for %{course_name} – next steps
     previous_provider: Change provider notification

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
     change_provider: You've registered for %{course_name} - next steps
     deferral_notification: Notification of deferral - %{course_name}
     registration_open_notification: Registration open - %{course_name}
-    registration_interest: Registration is now open
+    registration_interest: Registration open for Excellence in reception teaching course 
     deferral_expiring_notification: Registration about to expire - %{course_name}
     provider_rejected: Registration status updated for %{course_name} – next steps
     previous_provider: Change provider notification

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -124,8 +124,10 @@ FactoryBot.define do
           )
 
         if previous_cohort == application.cohort
+          registration_starts_at = application.cohort.registration_starts_at.prev_year
           previous_cohort = create(:cohort, :with_funding_cap,
-                                   registration_starts_at: application.cohort.registration_starts_at.prev_year)
+                                   start_year: registration_starts_at.year,
+                                   registration_starts_at:)
         end
 
         create(:application, :accepted, :eligible_for_funding, :for_cohort_starting_on, user: application.user, course:, registration_starts_at: previous_cohort.registration_starts_at)

--- a/spec/factories/registration_interests.rb
+++ b/spec/factories/registration_interests.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :registration_interest do
     email { "johndoe@example.com" }
+
+    trait :notified do
+      notified { true }
+    end
   end
 end

--- a/spec/jobs/crons/send_registration_interest_emails_job_spec.rb
+++ b/spec/jobs/crons/send_registration_interest_emails_job_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe Crons::SendRegistrationInterestEmailsJob, type: :job do
+  describe "#perform" do
+    context "when registration opens today" do
+      before { create(:cohort, start_year: Time.zone.today.year, registration_starts_at: Time.zone.today) }
+
+      it "enqueues registration interest emails" do
+        create(:registration_interest)
+
+        expect { described_class.perform_now }
+          .to have_enqueued_mail(GenericMailer, :registration_interest)
+      end
+
+      it "includes the full registration start URL" do
+        create(:registration_interest)
+
+        described_class.perform_now
+
+        expect(enqueued_jobs.last[:args].last["params"]["registration_start_url"])
+          .to eq("#{Rails.configuration.service_base_url}/registration/start")
+      end
+
+      it "marks the registration interest as notified" do
+        registration_interest = create(:registration_interest)
+
+        expect { described_class.perform_now }
+          .to change { registration_interest.reload.notified }
+          .from(false)
+          .to(true)
+      end
+
+      it "does not email registration interests already notified" do
+        create(:registration_interest, :notified)
+
+        expect { described_class.perform_now }
+          .not_to have_enqueued_mail(GenericMailer, :registration_interest)
+      end
+
+      it "skips invalid stored email addresses" do
+        build(:registration_interest, email: "plainaddress").save!(validate: false)
+
+        expect { described_class.perform_now }
+          .not_to have_enqueued_mail(GenericMailer, :registration_interest)
+      end
+    end
+
+    context "when registration does not open today" do
+      before { create(:cohort, start_year: Time.zone.yesterday.year, registration_starts_at: Time.zone.yesterday) }
+
+      it "does not enqueue registration interest emails" do
+        create(:registration_interest)
+
+        expect { described_class.perform_now }
+          .not_to have_enqueued_mail(GenericMailer, :registration_interest)
+      end
+
+      it "leaves the registration interest as not notified" do
+        registration_interest = create(:registration_interest)
+
+        expect { described_class.perform_now }
+          .not_to(change { registration_interest.reload.notified })
+      end
+    end
+
+    it "runs at 11am each day" do
+      expect(described_class.cron_expression).to eq("0 11 * * *")
+    end
+  end
+end

--- a/spec/jobs/crons/send_registration_interest_emails_job_spec.rb
+++ b/spec/jobs/crons/send_registration_interest_emails_job_spec.rb
@@ -5,6 +5,24 @@ RSpec.describe Crons::SendRegistrationInterestEmailsJob, type: :job do
     context "when registration opens today" do
       before { create(:cohort, start_year: Time.zone.today.year, registration_starts_at: Time.zone.today) }
 
+      context "when registration is disabled" do
+        before { Feature.disable_registration! }
+
+        it "does not enqueue registration interest emails" do
+          create(:registration_interest)
+
+          expect { described_class.perform_now }
+            .not_to have_enqueued_mail(GenericMailer, :registration_interest)
+        end
+
+        it "leaves the registration interest as not notified" do
+          registration_interest = create(:registration_interest)
+
+          expect { described_class.perform_now }
+            .not_to(change { registration_interest.reload.notified })
+        end
+      end
+
       it "enqueues registration interest emails" do
         create(:registration_interest)
 

--- a/spec/jobs/crons/send_registration_interest_emails_job_spec.rb
+++ b/spec/jobs/crons/send_registration_interest_emails_job_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Crons::SendRegistrationInterestEmailsJob, type: :job do
         described_class.perform_now
 
         expect(enqueued_jobs.last[:args].last["params"]["registration_start_url"])
-          .to eq("#{Rails.configuration.service_base_url}/registration/start")
+          .to eq(Rails.application.routes.url_helpers.registration_wizard_show_url(:start))
       end
 
       it "marks the registration interest as notified" do
@@ -50,13 +50,6 @@ RSpec.describe Crons::SendRegistrationInterestEmailsJob, type: :job do
 
       it "does not email registration interests already notified" do
         create(:registration_interest, :notified)
-
-        expect { described_class.perform_now }
-          .not_to have_enqueued_mail(GenericMailer, :registration_interest)
-      end
-
-      it "skips invalid stored email addresses" do
-        build(:registration_interest, email: "plainaddress").save!(validate: false)
 
         expect { described_class.perform_now }
           .not_to have_enqueued_mail(GenericMailer, :registration_interest)

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe GenericMailer, type: :mailer do
 
   describe "#registration_interest" do
     let(:to) { "recipient@example.com" }
-    let(:registration_start_url) { "http://test.npd.education.gov.uk/registration/start" }
+    let(:registration_start_url) { Rails.application.routes.url_helpers.registration_wizard_show_url(:start) }
 
     subject(:mail) { described_class.with(to:, registration_start_url:).registration_interest }
 

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -286,6 +286,28 @@ RSpec.describe GenericMailer, type: :mailer do
     it_behaves_like "a mailer with redacted logs"
   end
 
+  describe "#registration_interest" do
+    let(:to) { "recipient@example.com" }
+    let(:registration_start_url) { "http://test.npd.education.gov.uk/registration/start" }
+
+    subject(:mail) { described_class.with(to:, registration_start_url:).registration_interest }
+
+    it do
+      aggregate_failures do
+        expect(subject).to use_template(GenericMailer::TEMPLATE_ID)
+        expect(mail.to).to eq([to])
+        expect(mail.personalisation[:subject]).to eq("Registration is now open")
+
+        body = mail.personalisation[:body]
+        expect(body).to include("Registration is now open")
+        expect(body).to include("You asked us to email you when registration opened")
+        expect(body).to include("[apply for a course](#{registration_start_url})")
+      end
+    end
+
+    it_behaves_like "a mailer with redacted logs"
+  end
+
   describe "#deferral_expiring_notification" do
     let(:to) { "recipient@example.com" }
     let(:full_name) { "Example User" }

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -296,12 +296,11 @@ RSpec.describe GenericMailer, type: :mailer do
       aggregate_failures do
         expect(subject).to use_template(GenericMailer::TEMPLATE_ID)
         expect(mail.to).to eq([to])
-        expect(mail.personalisation[:subject]).to eq("Registration is now open")
+        expect(mail.personalisation[:subject]).to eq("Registration open for Excellence in reception teaching course")
 
         body = mail.personalisation[:body]
-        expect(body).to include("Registration is now open")
-        expect(body).to include("You asked us to email you when registration opened")
-        expect(body).to include("[apply for a course](#{registration_start_url})")
+        expect(body).to include("The excellence in teaching reception NPD course is now open for applications.")
+        expect(body).to include("[#{registration_start_url}](#{registration_start_url})")
       end
     end
 

--- a/spec/mailers/previews/generic_mailer_preview.rb
+++ b/spec/mailers/previews/generic_mailer_preview.rb
@@ -82,6 +82,13 @@ class GenericMailerPreview < ActionMailer::Preview
     ).registration_open_notification
   end
 
+  def registration_interest
+    GenericMailer.with(
+      to: "test@example.com",
+      registration_start_url: "#{Rails.configuration.service_base_url}/registration/start",
+    ).registration_interest
+  end
+
   def provider_rejected
     GenericMailer.with(
       to: "test@example.com",

--- a/spec/mailers/previews/generic_mailer_preview.rb
+++ b/spec/mailers/previews/generic_mailer_preview.rb
@@ -85,7 +85,7 @@ class GenericMailerPreview < ActionMailer::Preview
   def registration_interest
     GenericMailer.with(
       to: "test@example.com",
-      registration_start_url: "#{Rails.configuration.service_base_url}/registration/start",
+      registration_start_url: Rails.application.routes.url_helpers.registration_wizard_show_url(:start),
     ).registration_interest
   end
 


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#528

We are capturing the registration of interest email
but we do not have any job to actually send these emails

### Changes proposed in this pull request

Create job to send emails when a cohort opens
