### PR TITLE
Don't show change course link on 'check answers' page

### DIFF
--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -91,7 +91,7 @@ class RegistrationWizard
     array = []
 
     array << Answer.new("Course start", store["course_start"], :course_start_date)
-    array << Answer.new("Course", course.name, :course_start_date)
+    array << Answer.new("Course", course.name)
     array << Answer.new("Provider", lead_provider&.name, :choose_your_provider)
     array << Answer.new("Workplace in England", teacher_catchment_humanized, :teacher_catchment)
 

--- a/spec/views/registration_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/registration_wizard/check_answers.html.erb_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "registration_wizard/check_answers.html.erb", type: :view do
+  subject(:rendered_page) { Capybara.string(render) }
+
+  let(:course) { create(:course, :npd_eirt) }
+  let(:lead_provider) { create(:lead_provider) }
+  let(:user) { create(:user) }
+  let(:store) do
+    {
+      "lead_provider_id" => lead_provider.id,
+      "course_start" => "April 2026",
+      "teacher_catchment" => "england",
+    }
+  end
+
+  let(:wizard) do
+    course
+
+    RegistrationWizard.new(
+      current_step: :check_answers,
+      store:,
+      request: controller.request,
+      current_user: user,
+    )
+  end
+
+  before do
+    assign(:wizard, wizard)
+    assign(:form, Questionnaires::CheckAnswers.new(wizard:))
+    controller.request.path_parameters[:step] = "check-answers"
+  end
+
+  it "does not render a change link for answers without a change step" do
+    expect(wizard.answers.find { _1.key == "Course" }.change_step).to be_nil
+
+    within_course_row = rendered_page
+      .all(".govuk-summary-list__row")
+      .find { _1.has_css?(".govuk-summary-list__key", text: "Course", exact_text: true) }
+    expect(within_course_row).not_to have_link("Change")
+  end
+
+  it "renders a change link for answers with a change step" do
+    within_provider_row = rendered_page
+      .all(".govuk-summary-list__row")
+      .find { _1.has_css?(".govuk-summary-list__key", text: "Provider", exact_text: true) }
+
+    expect(within_provider_row).to have_link("Change", href: "/registration/choose-your-provider/change")
+  end
+end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#545

Currently, on the Check Your Answers screen, there is the option to 'change' the course. However, as we only have one course, this takes users to course start question. We need to hide this link until such time where we have more than one course within the NPD suite.

### Changes proposed in this pull request

Alter the registration wizard to not show the link
