### PR TITLE
Remove back link from applications page after new registration

### DIFF
--- a/app/views/applications/applications/show.html.erb
+++ b/app/views/applications/applications/show.html.erb
@@ -5,11 +5,6 @@
       text: "Back to your registrations",
       href: applications_path
     ) %>
-  <% else %>
-    <%= render GovukComponent::BackLinkComponent.new(
-      text: "Back",
-      href: request.referrer.presence || root_path
-    ) %>
   <% end %>
 <% end %>
 <span class="govuk-caption-m">Submitted <%= application.created_at.to_date.to_fs(:govuk_short) %></span>


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#520

Currently, when an applicant views the application summary page, they will see a back button. This needs to be removed
