### PR TITLE
[547] Separate admin and user sign-out

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,17 +9,20 @@ class SessionsController < PublicPagesController
   end
 
   def destroy
-    admin = current_admin
-    user = current_user
     id_token = session[:id_token]
-
     sign_out_all_scopes
 
-    redirect_to("/admin") and return if admin
+    if id_token
+      redirect_to build_sign_out_uri(id_token), allow_other_host: true
+    else
+      redirect_to(root_path)
+    end
+  end
 
-    redirect_to(root_path) and return unless user
+  def destroy_admin
+    sign_out_all_scopes
 
-    redirect_to build_sign_out_uri(id_token), allow_other_host: true
+    redirect_to("/admin")
   end
 
 private
@@ -34,7 +37,7 @@ private
       path: "/oauth2/logout",
       query: URI.encode_www_form({
         "id_token_hint" => id_token,
-        "post_logout_redirect_uri" => post_logout_uri.to_s,
+        "post_logout_redirect_uri" => post_logout_uri,
       }),
     }).to_s
   end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -9,7 +9,7 @@ module AdminHelper
     [
       *admin_navigation_structure.service_navigation_items,
       {
-        href: sign_out_user_path,
+        href: admin_sign_out_path,
         text: "Sign out",
         classes: "ml-auto",
       },

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -1,5 +1,6 @@
 namespace :admin do
   get "/", to: "dashboards#index"
+  get "/sign-out", to: "/sessions#destroy_admin", as: "sign_out"
 
   concern :cohortable do |options|
     if options.key?(:index)

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe SessionsController do
+  include Devise::Test::ControllerHelpers
   include Helpers::JourneyHelper
 
   describe "#extend_session" do
@@ -29,47 +30,39 @@ RSpec.describe SessionsController do
     end
   end
 
-  context "when a user is signed in" do
-    before do
-      allow(controller).to receive(:current_user).and_return(create(:user))
+  describe "#destroy" do
+    it "signs out all scopes" do
+      expect(controller).to receive(:sign_out_all_scopes)
+      get :destroy
     end
 
-    it "redirects to the external OIDC provider's signout endpoint" do
-      expect(controller).to receive(:sign_out_all_scopes)
+    context "with an OIDC session" do
+      it "redirects to the OIDC provider's logout endpoint" do
+        session[:id_token] = "test-id-token"
 
-      id_token = "test-id-token"
-      session[:id_token] = id_token
+        get :destroy
 
-      post_logout_uri = "http://test.host/sign-out"
-      expected_redirect_url = "https://teacher-auth.example.com:443/oauth2/logout?id_token_hint=#{id_token}&post_logout_redirect_uri=#{CGI.escape(post_logout_uri)}"
+        expect(response.location).to include("/oauth2/logout")
+        expect(response.location).to include("id_token_hint=test-id-token")
+      end
+    end
 
-      get :destroy
+    context "without an OIDC session" do
+      it "redirects to root" do
+        get :destroy
 
-      expect(response).to redirect_to(expected_redirect_url)
+        expect(response).to redirect_to(root_path)
+      end
     end
   end
 
-  context "when an admin is signed in" do
-    before do
-      allow(controller).to receive(:current_admin).and_return(create(:admin))
-    end
-
-    it "redirects to admin path" do
+  describe "#destroy_admin" do
+    it "signs out all scopes and redirects to admin" do
       expect(controller).to receive(:sign_out_all_scopes)
 
-      get :destroy
+      get :destroy_admin
 
       expect(response).to redirect_to("/admin")
-    end
-  end
-
-  context "when no user is signed in (callback from provider)" do
-    it "redirects to root" do
-      expect(controller).to receive(:sign_out_all_scopes)
-
-      get :destroy
-
-      expect(response).to redirect_to(root_path)
     end
   end
 end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#547

An edge case:
If someone is logged in as both a user (Teacher Auth) and an admin, 
when they sign out, they are redirected to the admin sign in page.

### Changes proposed in this pull request
Add a new `admin/sign-out` path that logs out the admin from all scopes and redirects to the admin sign in page


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
