### PR TITLE
Update admin console login email

### DIFF
--- a/app/controllers/email_updates_controller.rb
+++ b/app/controllers/email_updates_controller.rb
@@ -32,6 +32,6 @@ class EmailUpdatesController < PublicPagesController
 private
 
   def unsubscribe_link
-    "#{Rails.configuration.service_base_url}#{unsubscribe_email_updates_path(unsubscribe_key: current_user.email_updates_unsubscribe_key)}"
+    unsubscribe_email_updates_url(unsubscribe_key: current_user.email_updates_unsubscribe_key)
   end
 end

--- a/app/views/generic_mailer/confirmation_code.text.erb
+++ b/app/views/generic_mailer/confirmation_code.text.erb
@@ -1,2 +1,11 @@
-Your confirmation code is <%= params[:code].upcase %>.
-It will expire in 10 minutes.
+Your confirmation code is: <%= params[:code].upcase %>
+
+This code will expire in 10 minutes.
+
+---
+
+[Go to NPD service admin console](<%= Rails.application.routes.url_helpers.admin_url %>)
+
+---
+
+If you did not request this code, you can safely ignore this email.

--- a/config/initializers/default_url_options.rb
+++ b/config/initializers/default_url_options.rb
@@ -1,0 +1,7 @@
+uri = URI(ENV.fetch("HOSTING_DOMAIN"))
+
+Rails.application.routes.default_url_options = {
+  host: uri.host,
+  port: uri.port,
+  protocol: uri.scheme,
+}


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#555

Email was lacking the service name and link to admin console

### Changes proposed in this pull request


- add link to admin console in confirmation email
- add NPD name

<img width="649" height="404" alt="image" src="https://github.com/user-attachments/assets/e0cd4012-0937-483f-ab74-f9e4b34dca2a" />
