### PR TITLE
[556] Make Privacy Policy links consistent

### DIFF
--- a/app/views/pages/closed_registration_exception.html.erb
+++ b/app/views/pages/closed_registration_exception.html.erb
@@ -35,7 +35,7 @@
     </p>
 
     <p class="govuk-body">
-      By continuing, you agree to our <%= govuk_link_to("privacy notice", PRIVACY_NOTICE) %>.
+      By continuing, you agree to our <%= govuk_link_to("privacy notice", privacy_policy_path) %>.
     </p>
 
     <% if Feature.registration_enabled? %>

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -57,7 +57,7 @@
     <p>You'll need a GOV One Login account (you'll be prompted to sign in or create one).</p>
 
     <p class="govuk-body">
-      By continuing, you agree to our <%= govuk_link_to("privacy notice", PRIVACY_NOTICE) %>.
+      By continuing, you agree to our <%= govuk_link_to("privacy notice", privacy_policy_path) %>.
     </p>
 
     <% if Feature.registration_enabled? %>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,3 +1,2 @@
 APRIL_2024_CUTOFF_DATE = Time.zone.local(2024, 4, 2)
 FEEDBACK_FORM_URL = "https://forms.cloud.microsoft/e/LfumWfMCY1".freeze
-PRIVACY_NOTICE = "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#NPQ".freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -974,7 +974,7 @@ en:
         - All the information you enter for your NPD registration will be shared with external organisations 
           including auditors, evaluators, relevant bodies and training providers — this allows your provider
           to register you onto their course.
-        - For more information about who we share your data with read our <a href="https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#NPQ"
+        - For more information about who we share your data with read our <a href="/privacy-policy"
           class="govuk-link">privacy notice</a>.
         - If you do not agree to share your information you will not be able to progress with your NPD course.
         choose_school_html: 


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#556
 

### Changes proposed in this pull request

Privacy 'policy' and Privacy 'notice' should go to the same page

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
