### PR TITLE
Fix specs and factories around cohort setup

### DIFF
--- a/app/controllers/admin/cohorts_controller.rb
+++ b/app/controllers/admin/cohorts_controller.rb
@@ -56,7 +56,6 @@ private
 
   def cohort_params
     params.require(:cohort).permit(
-      :start_year,
       :registration_starts_at,
       :registration_ends_at,
       :funding_cap,

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -1,4 +1,5 @@
 class Cohort < ApplicationRecord
+  before_validation :set_start_year
   before_validation :set_identifier
 
   has_many :declarations, dependent: :restrict_with_exception
@@ -24,7 +25,6 @@ class Cohort < ApplicationRecord
   validates :registration_starts_at, presence: true
   validates :identifier, presence: true
   validate :identifier_is_unique
-  validate :registration_starts_at_matches_start_year
   validates :funding_cap, inclusion: { in: [true, false] }
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
   validate :changing_funding_cap_with_dependent_applications
@@ -55,10 +55,10 @@ class Cohort < ApplicationRecord
 
 private
 
-  def registration_starts_at_matches_start_year
+  def set_start_year
     return if registration_starts_at.blank?
 
-    errors.add(:registration_starts_at, "year must match the start year") if registration_starts_at.year != start_year
+    self.start_year = registration_starts_at.year
   end
 
   def set_identifier

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -6,6 +6,7 @@ class Course < ApplicationRecord
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
   has_many :course_cohorts, dependent: :destroy
   has_many :course_cohort_providers, through: :course_cohorts
+  has_many :cohorts, through: :course_cohorts
   has_many :lead_providers, through: :course_cohort_providers
   has_many :schedules, through: :course_cohorts
   has_many :applications, through: :course_cohorts

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -63,7 +63,7 @@ class Statement < ApplicationRecord
   end
 
   def use_targeted_delivery_funding?
-    Date.new(year, month) <= Date.new(2025, 10) && cohort.start_year >= 2022
+    Date.new(year, month) <= Date.new(2025, 10) && cohort.registration_starts_at.year >= 2022
   end
 
   def past?

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -63,7 +63,7 @@ class Statement < ApplicationRecord
   end
 
   def use_targeted_delivery_funding?
-    Date.new(year, month) <= Date.new(2025, 10) && cohort.registration_starts_at.year >= 2022
+    Date.new(year, month) <= Date.new(2025, 10) && cohort.start_year >= 2022
   end
 
   def past?

--- a/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
+++ b/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
@@ -248,15 +248,15 @@ module ValidTestDataGenerators
         ecf_id:,
       }
 
-      user = User.find_by(ecf_id: ecf_id)
+      email = user_email(app_data[:email])
+      user = User.find_by(ecf_id: ecf_id) || User.find_by(email:)
 
       if user
         # Update existing user
         user.update!(attrs)
       else
         # Create new user with temporary email
-        temp_email = user_email(app_data[:email])
-        user = User.create!(attrs.merge(email: temp_email))
+        user = User.create!(attrs.merge(email:))
       end
 
       # Update email if custom template exists for this lead provider
@@ -274,7 +274,7 @@ module ValidTestDataGenerators
         "4e87fadb",
         "f678",
         "4934",
-        sprintf("%04d", @lead_provider.id),
+        sprintf("%04x", @lead_provider.id % 0x10000),
         sprintf("%012d", index),
       ].join("-")
     end
@@ -295,7 +295,6 @@ module ValidTestDataGenerators
       current_cohort = Cohort.find_by(registration_starts_at:)
 
       attrs = {
-        start_year: cohort_year,
         description: "#{registration_starts_at.strftime('%B')} #{cohort_year}",
         registration_starts_at:,
         funding_cap: true,

--- a/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
+++ b/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
@@ -248,15 +248,15 @@ module ValidTestDataGenerators
         ecf_id:,
       }
 
-      email = user_email(app_data[:email])
-      user = User.find_by(ecf_id: ecf_id) || User.find_by(email:)
+      temp_email = user_email(app_data[:email])
+      user = User.find_by(ecf_id: ecf_id) || User.find_by(email: temp_email)
 
       if user
         # Update existing user
         user.update!(attrs)
       else
         # Create new user with temporary email
-        user = User.create!(attrs.merge(email:))
+        user = User.create!(attrs.merge(email: temp_email))
       end
 
       # Update email if custom template exists for this lead provider

--- a/app/views/admin/cohorts/form.html.erb
+++ b/app/views/admin/cohorts/form.html.erb
@@ -16,10 +16,6 @@
   <%= f.govuk_error_summary %>
   <%= f.govuk_text_field :description %>
 
-  <%= f.govuk_number_field :start_year,
-                           label: { text: "Start year" },
-                           width: 4 %>
-
   <%= f.govuk_check_box :funding_cap,
                         1,
                         0,

--- a/spec/components/admin/application_history_component_spec.rb
+++ b/spec/components/admin/application_history_component_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Admin::ApplicationHistoryComponent, :versioning, type: :component
   end
 
   context "when there is a change to the status field with a reason" do
-    let(:application) { create(:application, :with_declaration, :accepted) }
+    let(:application) { create(:application, :with_declaration, :accepted, :for_cohort_starting_on, registration_starts_at: Date.new(2021, 4, 1)) }
 
     before do
       ::Applications::Defer.new(application:, reason: "other", admin_user: create(:admin)).call

--- a/spec/components/admin/application_history_component_spec.rb
+++ b/spec/components/admin/application_history_component_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Admin::ApplicationHistoryComponent, :versioning, type: :component
   let(:time_2) { Time.zone.local(2025, 3, 1, 14, 0, 0) }
   let(:time_3) { Time.zone.local(2025, 3, 1, 15, 0, 0) }
   let(:time_4) { Time.zone.local(2025, 3, 1, 16, 0, 0) }
-  let(:cohort) { create(:cohort, start_year: 2024) }
-  let(:older_cohort) { create(:cohort, start_year: 2023) }
+  let(:cohort) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
+  let(:older_cohort) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
   let(:whodunnit) { "AdminUser 1" }
 
   before do

--- a/spec/controllers/registration_wizard_controller_spec.rb
+++ b/spec/controllers/registration_wizard_controller_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe RegistrationWizardController do
 
     context "when application already submitted for course" do
       let(:course) { Course.reception || create(:course) }
-      let!(:application) { create(:application, :accepted, course:, user: current_user) }
+      let(:course_cohort) { CourseCohort.next_open_for(course:) || create(:course_cohort, course:) }
+      let!(:application) { create(:application, :accepted, course:, cohort: course_cohort.cohort, user: current_user) }
       let(:step) { nil }
 
       before do

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -11,12 +11,20 @@ FactoryBot.define do
       lead_provider { nil }
       course { Course.find_by(identifier: Course::IDENTIFIERS.first) || create(Course::IDENTIFIERS.first.to_sym) }
       cohort do
-        existing = user.persisted? &&
-          user.applications.not_rejected
-            .joins(:course_cohort)
-            .merge(CourseCohort.where(course:))
-            .exists?
-        existing ? create(:cohort, :unique) : create(:cohort, :current)
+        existing_cohorts = if user.persisted?
+                             user.applications.not_rejected
+                               .joins(:course_cohort)
+                               .merge(CourseCohort.where(course:))
+                               .map(&:cohort)
+                           else
+                             []
+                           end
+
+        if existing_cohorts.any?
+          create(:cohort, registration_starts_at: existing_cohorts.map(&:registration_starts_at).max.next_month)
+        else
+          create(:cohort, :current)
+        end
       end
       schedule { CourseCohort.find_by(course:, cohort:)&.schedule || create(:schedule) }
     end
@@ -115,7 +123,6 @@ FactoryBot.define do
           create(
             :cohort,
             :with_funding_cap,
-            start_year: previous_registration_starts_at.year,
             registration_starts_at: previous_registration_starts_at,
           )
 

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -11,25 +11,12 @@ FactoryBot.define do
       lead_provider { nil }
       course { Course.find_by(identifier: Course::IDENTIFIERS.first) || create(Course::IDENTIFIERS.first.to_sym) }
       cohort do
-        existing_cohorts = if user.persisted?
-                             user.applications.not_rejected
-                               .joins(:course_cohort)
-                               .merge(CourseCohort.where(course:))
-                               .map(&:cohort)
-                           else
-                             []
-                           end
-
-        if existing_cohorts.any?
-          create(:cohort, registration_starts_at: existing_cohorts.map(&:registration_starts_at).max.next_month)
-        else
-          create(:cohort, :current)
-        end
+        course.cohorts.last
       end
-      schedule { CourseCohort.find_by(course:, cohort:)&.schedule || create(:schedule) }
+      schedule { course.course_cohorts.last&.schedule || create(:schedule, cohort: course.cohorts.last) }
     end
 
-    course_cohort { create(:course_cohort, course:, cohort:, schedule:) }
+    course_cohort { course.course_cohorts.last }
     teacher_catchment { course_cohort.cohort.start_year > 2023 ? "england" : nil }
     teacher_catchment_country { "United Kingdom of Great Britain and Northern Ireland" }
     teacher_catchment_iso_country_code { "GBR" }
@@ -54,6 +41,16 @@ FactoryBot.define do
       after(:create) do |application|
         application.state_changes << create(:state_change, :accepted, application:, lead_provider: application.lead_provider)
       end
+    end
+
+    trait :for_cohort_starting_on do
+      transient do
+        registration_starts_at { 1.week.ago.to_date.beginning_of_month }
+      end
+
+      cohort { create(:cohort, registration_starts_at:) }
+      schedule { create(:schedule, cohort:) }
+      course_cohort { create(:course_cohort, course:, cohort:, schedule:) }
     end
 
     trait :with_school do
@@ -131,7 +128,7 @@ FactoryBot.define do
                                    registration_starts_at: application.cohort.registration_starts_at.prev_year)
         end
 
-        create(:application, :accepted, :eligible_for_funding, user: application.user, course:, cohort: previous_cohort)
+        create(:application, :accepted, :eligible_for_funding, :for_cohort_starting_on, user: application.user, course:, registration_starts_at: previous_cohort.registration_starts_at)
       end
     end
 
@@ -165,7 +162,21 @@ FactoryBot.define do
 
     trait :with_declaration do
       after(:create) do |application|
-        application.declarations << create(:declaration, :started, application:, cohort: application.cohort)
+        if application.schedule.training_starts_at.future?
+          application.schedule.update!(
+            training_starts_at: 1.month.ago.beginning_of_day,
+            training_ends_at: 1.month.from_now.beginning_of_day,
+          )
+        end
+
+        application.declarations << create(
+          :declaration,
+          :started,
+          application:,
+          course_cohort: application.course_cohort,
+          cohort: application.cohort,
+          declaration_date: application.schedule.reload.training_starts_at + 1.day,
+        )
       end
     end
 

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -1,36 +1,27 @@
 FactoryBot.define do
   factory :cohort do
-    sequence(:start_year, 0) { |n| 2021 + n % 9 }
-    registration_starts_at { Date.new(start_year, Date.current.month - 1, 3) }
+    registration_starts_at { 1.week.ago.to_date.beginning_of_month }
     registration_ends_at { registration_starts_at.advance(months: 2) }
     funding_cap { true }
     description { registration_starts_at.strftime("%B %Y") }
     identifier { registration_starts_at.strftime("%Y-%B") }
 
     initialize_with do
-      Cohort.find_or_create_by(registration_starts_at:)
+      Cohort.find_or_initialize_by(identifier:) do |cohort|
+        cohort.assign_attributes(attributes)
+      end
     end
 
     trait :current do
-      start_year { Date.current.year }
+      registration_starts_at { 1.week.ago.to_date.beginning_of_month }
     end
 
     trait :next do
-      start_year { Date.current.year.succ }
+      registration_starts_at { 1.week.ago.to_date.beginning_of_month.next_year }
     end
 
     trait :previous do
-      start_year { Date.current.year.pred }
-    end
-
-    trait :unique do
-      sequence(:registration_starts_at, 0) do |n|
-        year = 2021 + (n / 12) % 9
-        month = (n % 12) + 1
-
-        Date.new(year, month, 3)
-      end
-      start_year { registration_starts_at.year }
+      registration_starts_at { 1.week.ago.to_date.beginning_of_month.prev_year }
     end
 
     trait :with_funding_cap do
@@ -42,7 +33,7 @@ FactoryBot.define do
     end
 
     trait :has_targeted_delivery_funding do
-      start_year { 2022 }
+      registration_starts_at { Date.new(2022, 4, 1) }
     end
   end
 end

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
 
     delivery_partner { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
     started
-    declaration_date { Date.current }
+    declaration_date { application.schedule.training_starts_at + 1.day }
     submitted
     ecf_id { SecureRandom.uuid }
 

--- a/spec/features/admin/applications/application_history_spec.rb
+++ b/spec/features/admin/applications/application_history_spec.rb
@@ -26,8 +26,8 @@ RSpec.feature "viewing application history", :revisit, :versioning, type: :featu
 
   context "when there are changes to the application" do
     let(:application) { create(:application, :accepted, cohort:, lead_provider: LeadProvider.first) }
-    let(:cohort) { create(:cohort, start_year: 2024) }
-    let(:older_cohort) { create(:cohort, start_year: 2023) }
+    let(:cohort) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
+    let(:older_cohort) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
     let(:new_lead_provider) { create(:lead_provider, :with_courses) }
 
     before do

--- a/spec/features/admin/applications/applications_in_review_spec.rb
+++ b/spec/features/admin/applications/applications_in_review_spec.rb
@@ -13,8 +13,8 @@ RSpec.feature "Applications in review", :npq, type: :feature do
   let(:serialized_application) { { application: 1 } }
 
   before do
-    create(:cohort, :without_funding_cap, start_year: 2021)
-    create(:cohort, :without_funding_cap, start_year: 2022)
+    create(:cohort, :without_funding_cap, registration_starts_at: Date.new(2021, 4, 1))
+    create(:cohort, :without_funding_cap, registration_starts_at: Date.new(2022, 4, 1))
     sign_in_as create(:admin)
     visit admin_applications_path
     click_on "In review"

--- a/spec/features/admin/applications/applications_spec.rb
+++ b/spec/features/admin/applications/applications_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
   end
 
   scenario "filtering applications by year of application" do
-    cohort = create(:cohort, start_year: 2022)
+    cohort = create(:cohort, registration_starts_at: Date.new(2022, 4, 1))
     course_cohort = create(:course_cohort, cohort:)
     application = applications_in_order.last
     application.update!(course_cohort:)
@@ -326,10 +326,10 @@ RSpec.feature "Listing and viewing applications", type: :feature do
   end
 
   scenario "changing schedule cohort" do
-    future_cohort = create(:cohort, start_year: 3.years.from_now.year)
+    future_cohort = create(:cohort, registration_starts_at: 3.years.from_now.to_date.beginning_of_month)
     course_cohort = create(:course_cohort, cohort: Cohort.first)
     create(:course_cohort, course: course_cohort.course, cohort: future_cohort)
-    create(:cohort, start_year: 2.years.from_now.year)
+    create(:cohort, registration_starts_at: 2.years.from_now.to_date.beginning_of_month)
     application = create(:application, course_cohort:)
 
     visit admin_application_path(application)

--- a/spec/features/admin/bulk_operations/backfill_declaration_delivery_partners_spec.rb
+++ b/spec/features/admin/bulk_operations/backfill_declaration_delivery_partners_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Backfill declaration delivery partners", :no_js, type: :feature d
   let(:admin) { create(:admin) }
   let(:filename) { File.basename(file.path) }
   let(:lead_provider) { LeadProvider.first }
-  let(:cohort) { create(:cohort, start_year: 2023) }
+  let(:cohort) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
   let(:bulk_operation) { create(:backfill_declaration_delivery_partners_bulk_operation, admin: create(:admin)) }
   let(:instance) { described_class.new(bulk_operation:) }
   let(:declaration) { create(:declaration, lead_provider:, cohort:, delivery_partner: nil) }

--- a/spec/features/admin/cohorts_spec.rb
+++ b/spec/features/admin/cohorts_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
   include Helpers::FileHelper
 
   let(:admin) { create :admin }
-  let!(:cohort) { Cohort.find_by(identifier: "2026-April") || create(:cohort, start_year: 2026, registration_starts_at: Date.new(2026, 4, 1)) }
+  let!(:cohort) { Cohort.find_by(identifier: "2026-April") || create(:cohort, registration_starts_at: Date.new(2026, 4, 1)) }
 
   let(:new_button_text)    { "New cohort" }
   let(:edit_button_text)   { "Edit cohort details" }
@@ -13,7 +13,7 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
   let(:download_contracts_button_text) { "Download contracts CSV" }
 
   before do
-    (2026..2028).each { create :cohort, start_year: _1 }
+    (2026..2028).each { create :cohort, registration_starts_at: Date.new(_1, 4, 1) }
 
     sign_in_as admin
   end
@@ -52,7 +52,6 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
       expect(page).to have_css("a.govuk-back-link[href$='#{admin_cohorts_path}']", text: "Back")
 
       fill_in "Description", with: "2029 to 2030"
-      fill_in "Start year", with: "2029"
       check "Funding cap", visible: :all
       within(".starts_at") do
         fill_in "Day", with: "2"
@@ -82,7 +81,6 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
 
       new_description = "2025 to 2026 #{rand(100)}"
       fill_in "Description", with: new_description
-      fill_in "Start year", with: "2025"
       check "Funding cap", visible: :all
       within(".starts_at") do
         fill_in "Day", with: "6"

--- a/spec/features/admin/dashboards/courses_dashboard_spec.rb
+++ b/spec/features/admin/dashboards/courses_dashboard_spec.rb
@@ -7,8 +7,7 @@ RSpec.feature "Viewing the courses dashboard", type: :feature do
   let(:current_cohort) { create(:cohort, :current) }
 
   let :previous_cohort do
-    create(:cohort, start_year: current_cohort.start_year - 1,
-                    registration_starts_at: (current_cohort.registration_starts_at - 1.year))
+    create(:cohort, registration_starts_at: (current_cohort.registration_starts_at - 1.year))
   end
 
   before do

--- a/spec/features/admin/dashboards/courses_dashboard_spec.rb
+++ b/spec/features/admin/dashboards/courses_dashboard_spec.rb
@@ -13,8 +13,8 @@ RSpec.feature "Viewing the courses dashboard", type: :feature do
   before do
     sign_in_as(create(:admin))
 
-    create_list(:application, 2, course: test_course, cohort: current_cohort)
-    create(:application, course: test_course, cohort: previous_cohort)
+    create_list(:application, 2, :for_cohort_starting_on, course: test_course, registration_starts_at: current_cohort.registration_starts_at)
+    create(:application, :for_cohort_starting_on, course: test_course, registration_starts_at: previous_cohort.registration_starts_at)
   end
 
   scenario "viewing the courses dashboard table" do

--- a/spec/features/admin/dashboards/providers_dashboard_spec.rb
+++ b/spec/features/admin/dashboards/providers_dashboard_spec.rb
@@ -13,8 +13,8 @@ RSpec.feature "Viewing the providers dashboard", type: :feature do
   before do
     sign_in_as(create(:admin))
 
-    create_list(:application, 2, cohort: current_cohort, lead_provider: test_provider)
-    create(:application, cohort: previous_cohort, lead_provider: test_provider)
+    create_list(:application, 2, :for_cohort_starting_on, registration_starts_at: current_cohort.registration_starts_at, lead_provider: test_provider)
+    create(:application, :for_cohort_starting_on, registration_starts_at: previous_cohort.registration_starts_at, lead_provider: test_provider)
   end
 
   scenario "viewing the providers dashboard table" do

--- a/spec/features/admin/dashboards/providers_dashboard_spec.rb
+++ b/spec/features/admin/dashboards/providers_dashboard_spec.rb
@@ -7,8 +7,7 @@ RSpec.feature "Viewing the providers dashboard", type: :feature do
   let(:current_cohort) { create(:cohort, :current) }
 
   let :previous_cohort do
-    create(:cohort, start_year: current_cohort.start_year - 1,
-                    registration_starts_at: (current_cohort.registration_starts_at - 1.year))
+    create(:cohort, registration_starts_at: (current_cohort.registration_starts_at - 1.year))
   end
 
   before do

--- a/spec/features/admin/lead_providers_spec.rb
+++ b/spec/features/admin/lead_providers_spec.rb
@@ -19,9 +19,9 @@ RSpec.feature "Listing and viewing course providers", type: :feature do
   end
 
   scenario "viewing course provider details" do
-    cohort_2025 = create(:cohort, start_year: 2025)
-    cohort_2024 = create(:cohort, start_year: 2024)
-    cohort_2023 = create(:cohort, start_year: 2023)
+    cohort_2025 = create(:cohort, registration_starts_at: Date.new(2025, 4, 1))
+    cohort_2024 = create(:cohort, registration_starts_at: Date.new(2024, 4, 1))
+    cohort_2023 = create(:cohort, registration_starts_at: Date.new(2023, 4, 1))
     lead_provider = LeadProvider.order(:name).first
     lead_provider.update!(url: "https://example.com/provider")
     delivery_partner_25 = create(:delivery_partner, lead_providers: { cohort_2025 => lead_provider })

--- a/spec/features/admin/schedules_spec.rb
+++ b/spec/features/admin/schedules_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Managing schedules", :ecf_api_disabled, :no_js, :revisit, type: :
   include Helpers::AdminLogin
 
   let(:admin)  { create :admin }
-  let(:cohort) { create :cohort, start_year: 2026 }
+  let(:cohort) { create :cohort, registration_starts_at: Date.new(2026, 4, 1) }
 
   let(:new_button_text) { "New schedule" }
   let(:edit_button_text) { "Edit schedule details" }

--- a/spec/features/applications/change_provider_spec.rb
+++ b/spec/features/applications/change_provider_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "Change provider", type: :feature do
   end
 
   context "when application is started" do
-    let(:application) { create(:application, :started) }
+    let(:application) { create(:application, :started, :for_cohort_starting_on, registration_starts_at: Date.new(2021, 4, 1)) }
 
     it "redirects you back to application#show" do
       visit application_change_provider_start_index_path(application.ecf_id)

--- a/spec/features/applications_spec.rb
+++ b/spec/features/applications_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Applications", type: :feature do
 
   describe "withdrawn application" do
     let(:user) { create(:user) }
-    let!(:application) { create(:application, :withdrawn, user:) }
+    let!(:application) { create(:application, :withdrawn, :for_cohort_starting_on, user:, registration_starts_at: Date.new(2021, 4, 1)) }
 
     before do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
@@ -57,7 +57,7 @@ RSpec.feature "Applications", type: :feature do
     end
 
     context "when user also has a newer active application" do
-      let!(:active_application) { create(:application, :accepted, user:, created_at: 1.day.from_now) }
+      let!(:active_application) { create(:application, :accepted, :for_cohort_starting_on, user:, registration_starts_at: Date.new(2021, 5, 1), created_at: 1.day.from_now) }
 
       scenario "redirects to the most recent application" do
         visit applications_path

--- a/spec/features/journeys/reception_registration/state_funded_school_in_england_previously_funded_spec.rb
+++ b/spec/features/journeys/reception_registration/state_funded_school_in_england_previously_funded_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Registration wizard paths", :no_js, :with_default_lead_provider, 
     lead_provider = LeadProvider.first
     institution = Institution.find_by!(institution_reference_number: "100000")
     previously_funded_user = create(:user, trn: user_trn)
-    create(:application, :accepted, :eligible_for_funding, user: previously_funded_user, course: Course.reception, cohort: create(:cohort, :unique))
+    create(:application, :accepted, :eligible_for_funding, user: previously_funded_user, course: Course.reception, cohort: create(:cohort, registration_starts_at: Date.new(2024, 5, 1)))
     previously_funded_user.update!(archived_at: Time.current, archived_email: previously_funded_user.email, email: "archived@example.com")
 
     start_registration

--- a/spec/forms/admin/applications/change_cohort_form_spec.rb
+++ b/spec/forms/admin/applications/change_cohort_form_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Admin::Applications::ChangeCohortForm, type: :model do
   subject(:service) { described_class.new(application:, course_cohort_id:) }
 
   let(:application) { create(:application, course_cohort:) }
-  let(:course_cohort) { create(:course_cohort, cohort: create(:cohort, start_year: 2021)) }
+  let(:course_cohort) { create(:course_cohort, cohort: create(:cohort, registration_starts_at: Date.new(2021, 4, 1))) }
   let(:course) { course_cohort.course }
-  let(:new_cohort) { create(:cohort, start_year: 2025) }
+  let(:new_cohort) { create(:cohort, registration_starts_at: Date.new(2025, 4, 1)) }
   let(:new_course_cohort) { create(:course_cohort, course:, cohort: new_cohort) }
   let(:course_cohort_id) { new_course_cohort.id }
 
@@ -17,9 +17,9 @@ RSpec.describe Admin::Applications::ChangeCohortForm, type: :model do
   end
 
   describe "#cohort_options" do
-    let(:cohort_2022) { create(:cohort, start_year: 2022) }
-    let(:cohort_2023) { create(:cohort, start_year: 2023) }
-    let(:cohort_2024) { create(:cohort, start_year: 2024) }
+    let(:cohort_2022) { create(:cohort, registration_starts_at: Date.new(2022, 4, 1)) }
+    let(:cohort_2023) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
+    let(:cohort_2024) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
 
     before do
       create(:course_cohort, course:, cohort: cohort_2022)

--- a/spec/forms/questionnaires/choose_your_provider_spec.rb
+++ b/spec/forms/questionnaires/choose_your_provider_spec.rb
@@ -4,14 +4,13 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
   let!(:cohort) { create(:cohort, :current) }
   let!(:lead_provider) { create(:lead_provider) }
   let!(:course) { create(:course, :npd_eirt, lead_provider:) }
-
-  before { create(:course_cohort, course:, cohort:, lead_provider:) }
+  let!(:course_cohort) { create(:course_cohort, course:, cohort:, lead_provider:) }
 
   describe "validations" do
     let(:current_step) { "choose_your_provider" }
     let(:request) { nil }
     let(:school) { bulid_stubbed(:school) }
-    let(:store) { {} }
+    let(:store) { { "course_cohort_id" => course_cohort.id } }
     let(:wizard) do
       RegistrationWizard.new(
         current_step:,
@@ -59,13 +58,12 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
     subject { form.options }
 
     let(:form) { described_class.new }
-    let(:course_cohort) { CourseCohort.next_open_for(course:) }
     let(:expected_providers) { course_cohort.lead_providers.alphabetical }
 
     before do
       form.wizard = RegistrationWizard.new(
         current_step: :choose_your_provider,
-        store: {},
+        store: { "course_cohort_id" => course_cohort.id },
         request: nil,
         current_user: create(:user),
       )

--- a/spec/jobs/crons/send_registration_open_notification_emails_job_spec.rb
+++ b/spec/jobs/crons/send_registration_open_notification_emails_job_spec.rb
@@ -45,8 +45,9 @@ RSpec.describe Crons::SendRegistrationOpenNotificationEmailsJob, type: :job do
       create(
         :application,
         :deferred,
+        :for_cohort_starting_on,
         course: other_course,
-        cohort: other_cohort,
+        registration_starts_at: other_cohort.registration_starts_at,
         schedule: create(:schedule, cohort: other_cohort),
       )
 

--- a/spec/jobs/crons/send_registration_open_notification_emails_job_spec.rb
+++ b/spec/jobs/crons/send_registration_open_notification_emails_job_spec.rb
@@ -2,11 +2,10 @@ require "rails_helper"
 
 RSpec.describe Crons::SendRegistrationOpenNotificationEmailsJob, type: :job do
   describe "#perform" do
-    let(:cohort) { create(:cohort, start_year: Time.zone.yesterday.year, registration_starts_at: Time.zone.yesterday) }
+    let(:cohort) { create(:cohort, registration_starts_at: Time.zone.yesterday) }
     let(:application_cohort) do
       create(
         :cohort,
-        start_year: Time.zone.yesterday.prev_year.year,
         registration_starts_at: Time.zone.yesterday.prev_year,
       )
     end
@@ -41,7 +40,7 @@ RSpec.describe Crons::SendRegistrationOpenNotificationEmailsJob, type: :job do
     it "skips deferred applications whose course is not on the cohort" do
       other_course = build(:course, identifier: "another-course")
       other_course.save!
-      other_cohort = create(:cohort, :unique)
+      other_cohort = create(:cohort, registration_starts_at: Date.new(2024, 5, 1))
 
       create(
         :application,

--- a/spec/lib/tasks/update_application_spec.rb
+++ b/spec/lib/tasks/update_application_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe "update_application", :revisit do
   include_context "with default schedules"
 
   let(:cohort) do
-    create(:cohort, :without_funding_cap, start_year: 1.year.ago.year,
-                                          registration_starts_at: 1.year.ago)
+    create(:cohort, :without_funding_cap, registration_starts_at: 1.year.ago)
   end
 
   shared_examples "outputting an error" do |message: "Application not found: "|
@@ -104,7 +103,7 @@ RSpec.describe "update_application", :revisit do
       end
 
       context "when the target schedule does not exist" do
-        let(:new_cohort) { create(:cohort, start_year: 2029) }
+        let(:new_cohort) { create(:cohort, registration_starts_at: Date.new(2029, 4, 1)) }
 
         it "raises an error" do
           expect { run_task }.to raise_error(

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -103,8 +103,9 @@ RSpec.describe Application do
 
     context "when the cohort does not have a funding cap" do
       let(:cohort) { create(:cohort, :without_funding_cap, registration_starts_at: Date.new(2024, 5, 1)) }
+      let(:course_cohort) { create(:course_cohort, cohort:) }
 
-      subject { build(:application, :accepted, cohort:) }
+      subject { build(:application, :accepted, course_cohort:) }
 
       it "validates funded_place is nil" do
         subject.funded_place = false
@@ -247,11 +248,12 @@ RSpec.describe Application do
 
     let(:application) do
       if school
-        create(:application, cohort:, school_record: school, teacher_catchment:)
+        create(:application, course_cohort:, school_record: school, teacher_catchment:)
       else
-        create(:application, cohort:, institution: nil, teacher_catchment:, works_in_school: false)
+        create(:application, course_cohort:, institution: nil, teacher_catchment:, works_in_school: false)
       end
     end
+    let(:course_cohort) { create(:course_cohort, cohort:) }
 
     context "when the application is in the 2023 cohort or earlier" do
       let(:cohort) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Application do
     end
 
     context "when the cohort does not have a funding cap" do
-      let(:cohort) { create(:cohort, :unique, :without_funding_cap) }
+      let(:cohort) { create(:cohort, :without_funding_cap, registration_starts_at: Date.new(2024, 5, 1)) }
 
       subject { build(:application, :accepted, cohort:) }
 
@@ -254,7 +254,7 @@ RSpec.describe Application do
     end
 
     context "when the application is in the 2023 cohort or earlier" do
-      let(:cohort) { create(:cohort, start_year: 2023) }
+      let(:cohort) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
 
       context "when the teacher_catchment is not set" do
         let(:teacher_catchment) { nil }
@@ -286,7 +286,7 @@ RSpec.describe Application do
     end
 
     context "when the application is in the 2024 cohort or later" do
-      let(:cohort) { create(:cohort, start_year: 2024) }
+      let(:cohort) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
       let(:school) { nil }
 
       context "when the teacher_catchment is not set" do
@@ -407,8 +407,8 @@ RSpec.describe Application do
     let(:course) { create(:course) }
     let(:course_cohort) { create(:course_cohort, course:, cohort: cohort_with_funding_cap) }
     let(:application) { create(:application, :previously_funded, user:, course_cohort:) }
-    let(:cohort_with_funding_cap) { create(:cohort, :unique, :with_funding_cap) }
-    let(:cohort_without_funding_cap) { create(:cohort, :unique, :without_funding_cap) }
+    let(:cohort_with_funding_cap) { create(:cohort, :with_funding_cap, registration_starts_at: Date.new(2024, 5, 1)) }
+    let(:cohort_without_funding_cap) { create(:cohort, :without_funding_cap, registration_starts_at: Date.new(2024, 6, 1)) }
     let(:previous_application) { user.applications.where.not(id: application.id).first! }
     let(:course_cohort_no_cap) { create(:course_cohort, course:, cohort: cohort_without_funding_cap) }
 

--- a/spec/models/bulk_operation/backfill_declaration_delivery_partners_spec.rb
+++ b/spec/models/bulk_operation/backfill_declaration_delivery_partners_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe BulkOperation::BackfillDeclarationDeliveryPartners, type: :model 
 
   describe "#run!" do
     let(:lead_provider) { LeadProvider.first }
-    let(:cohort) { create(:cohort, start_year: 2023) }
+    let(:cohort) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
     let(:bulk_operation) { create(:backfill_declaration_delivery_partners_bulk_operation, admin: create(:admin)) }
     let(:instance) { described_class.new(bulk_operation:) }
     let(:declaration_1) { create(:declaration, lead_provider:, cohort:, delivery_partner: nil) }

--- a/spec/models/bulk_operation/submit_declarations_spec.rb
+++ b/spec/models/bulk_operation/submit_declarations_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe BulkOperation::SubmitDeclarations do
   let(:admin) { create(:admin) }
   let(:bulk_operation) { create(:submit_declarations_bulk_operation, admin: admin) }
 
-  let(:cohort) { create(:cohort, start_year: 2023) }
+  let(:cohort) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
   let(:course) { create(:course, identifier: "leadership-development") }
   let(:lead_provider) { create(:lead_provider) }
   let(:delivery_partner) { create(:delivery_partner) }

--- a/spec/models/bulk_operation/submit_declarations_spec.rb
+++ b/spec/models/bulk_operation/submit_declarations_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BulkOperation::SubmitDeclarations do
   let(:statement) { create(:statement, cohort:, lead_provider:) }
   let(:participant) { create(:user) }
 
-  let!(:application) { create(:application, :accepted, user: participant, cohort:, course:, lead_provider:, schedule:) }
+  let!(:application) { create(:application, :accepted, :for_cohort_starting_on, user: participant, course:, lead_provider:, schedule:, registration_starts_at: cohort.registration_starts_at) }
 
   describe "validations" do
     context "with valid CSV file" do
@@ -83,7 +83,7 @@ RSpec.describe BulkOperation::SubmitDeclarations do
 
     context "when the entire CSV is valid" do
       let(:participant2) { create(:user) }
-      let!(:application2) { create(:application, :accepted, user: participant2, cohort:, course:, lead_provider:, schedule:) }
+      let!(:application2) { create(:application, :accepted, :for_cohort_starting_on, user: participant2, course:, lead_provider:, schedule:, registration_starts_at: cohort.registration_starts_at) }
 
       let(:csv) do
         <<~CSV

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Cohort, type: :model do
       [5, 8].shuffle.map do |month|
         registration_starts_at = Date.new(start_year, month, 10)
         exist = Cohort.find_by(identifier: registration_starts_at.strftime("%Y-%B"))
-        exist || create(:cohort, start_year:, registration_starts_at:)
+        exist || create(:cohort, registration_starts_at:)
       end
     end
   end
@@ -28,44 +28,14 @@ RSpec.describe Cohort, type: :model do
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
 
     it "shows the conflicting cohort start month when the identifier already exists" do
-      create(:cohort, start_year: 2026, registration_starts_at: Date.new(2026, 1, 3))
+      create(:cohort, registration_starts_at: Date.new(2026, 1, 3))
       duplicate = Cohort.new(
-        start_year: 2026,
         registration_starts_at: Date.new(2026, 1, 20),
         description: "Another January 2026 cohort",
         funding_cap: true,
       )
 
       expect(duplicate).to have_error(:identifier, :taken, "Cohort starting 'Jan 2026' exists already")
-    end
-
-    describe "registration_starts_at year should match start_year" do
-      it "adds an error when the registration_starts_at year does not match the start_year" do
-        cohort = Cohort.new(start_year: 2022, registration_starts_at: Date.new(2023, 4, 10))
-
-        cohort.valid?
-        expect(cohort.errors[:registration_starts_at]).to include("year must match the start year")
-      end
-
-      it "does not add an error when the registration_starts_at year matches the start_year" do
-        cohort = Cohort.new(start_year: 2022, registration_starts_at: Date.new(2022, 4, 10))
-
-        cohort.valid?
-        expect(cohort.errors[:registration_starts_at]).not_to include("year must match the start year")
-      end
-    end
-
-    describe "start_year" do
-      it { is_expected.to validate_presence_of(:start_year) }
-
-      it {
-        expect(subject)
-          .to(
-            validate_numericality_of(:start_year)
-              .is_greater_than_or_equal_to(2021)
-              .is_less_than(2030),
-          )
-      }
     end
 
     describe "#description" do
@@ -125,17 +95,17 @@ RSpec.describe Cohort, type: :model do
 
   describe ".current" do
     it "returns the closest cohort in the past" do
-      current_cohort = create(:cohort, start_year: 2022, registration_starts_at: Date.new(2022, 4, 10))
-      _older_cohort = create(:cohort, start_year: 2021, registration_starts_at: Date.new(2021, 4, 10))
-      _future_cohort = create(:cohort, start_year: 2023, registration_starts_at: Date.new(2023, 4, 10))
+      current_cohort = create(:cohort, registration_starts_at: Date.new(2022, 4, 10))
+      _older_cohort = create(:cohort, registration_starts_at: Date.new(2021, 4, 10))
+      _future_cohort = create(:cohort, registration_starts_at: Date.new(2023, 4, 10))
 
       expect(Cohort.current(Date.new(2022, 4, 11))).to eq(current_cohort)
     end
 
     it "includes the Cohort starting exactly on the current date" do
-      current_cohort = create(:cohort, start_year: 2022, registration_starts_at: Date.new(2022, 4, 10))
-      _older_cohort = create(:cohort, start_year: 2021, registration_starts_at: Date.new(2021, 4, 10))
-      _future_cohort = create(:cohort, start_year: 2023, registration_starts_at: Date.new(2023, 4, 10))
+      current_cohort = create(:cohort, registration_starts_at: Date.new(2022, 4, 10))
+      _older_cohort = create(:cohort, registration_starts_at: Date.new(2021, 4, 10))
+      _future_cohort = create(:cohort, registration_starts_at: Date.new(2023, 4, 10))
 
       expect(Cohort.current(Date.new(2022, 4, 10))).to eq(current_cohort)
     end
@@ -155,9 +125,9 @@ RSpec.describe Cohort, type: :model do
 
       let :multiple_cohorts do
         {
-          current: create(:cohort, start_year: 2022, registration_starts_at: Date.new(2022, 4, 10), description: "2022 April"),
-          older: create(:cohort, start_year: 2022, registration_starts_at: Date.new(2022, 1, 10), description: "2022 January"),
-          future: create(:cohort, start_year: 2023, registration_starts_at: Date.new(2023, 4, 10)),
+          current: create(:cohort, registration_starts_at: Date.new(2022, 4, 10), description: "2022 April"),
+          older: create(:cohort, registration_starts_at: Date.new(2022, 1, 10), description: "2022 January"),
+          future: create(:cohort, registration_starts_at: Date.new(2023, 4, 10)),
         }
       end
 

--- a/spec/models/course_cohort_spec.rb
+++ b/spec/models/course_cohort_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe CourseCohort do
     end
 
     def create_cohort(registration_starts_at, registration_ends_at: registration_starts_at.advance(months: 2))
-      Cohort.create!(
-        start_year: registration_starts_at.year,
+      create(
+        :cohort,
         registration_starts_at:,
         registration_ends_at:,
         funding_cap: true,

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Declaration, type: :model do
 
       let :old_cohort_partner do
         create :delivery_partner, lead_providers: {
-          create(:cohort, start_year: 2023) => declaration.lead_provider,
+          create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) => declaration.lead_provider,
         }
       end
 
@@ -76,7 +76,7 @@ RSpec.describe Declaration, type: :model do
 
       describe "skipping validation for certain cases" do
         let(:declaration) { build(:declaration, cohort:, delivery_partner: nil) }
-        let(:cohort) { create(:cohort, start_year: cohort_start_year) }
+        let(:cohort) { create(:cohort, registration_starts_at: Date.new(cohort_start_year, 4, 1)) }
         let(:cohort_start_year) { described_class::DELIVER_PARTNER_REQUIRED_FROM }
 
         context "with earlier cohort" do
@@ -143,7 +143,7 @@ RSpec.describe Declaration, type: :model do
 
       context "with existing declarations" do
         let(:cohort_start_year) { described_class::DELIVER_PARTNER_REQUIRED_FROM }
-        let(:cohort) { create(:cohort, start_year: cohort_start_year) }
+        let(:cohort) { create(:cohort, registration_starts_at: Date.new(cohort_start_year, 4, 1)) }
 
         subject(:declaration) { create(:declaration, cohort:) }
 
@@ -828,12 +828,12 @@ RSpec.describe Declaration, type: :model do
     let :lead_provider do
       create :lead_provider, delivery_partners: {
         twenty_three => twenty_three_partner,
-        create(:cohort, start_year: 2024) => twenty_four_partner,
+        create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) => twenty_four_partner,
       }
     end
 
     let(:declaration) { build(:declaration, lead_provider:, cohort: twenty_three) }
-    let(:twenty_three) { create(:cohort, start_year: 2023) }
+    let(:twenty_three) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
     let(:twenty_three_partner) { create(:delivery_partner) }
     let(:twenty_four_partner) { create(:delivery_partner) }
 

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -115,11 +115,7 @@ RSpec.describe DeliveryPartner, type: :model do
     let(:lead_provider) { create :lead_provider }
     let(:other_lead_provider) { create :lead_provider }
     let(:cohort) { create :cohort }
-    let(:other_cohort) { create :cohort }
-
-    before do
-      create :delivery_partner, lead_providers: { cohort => lead_provider, other_cohort => other_lead_provider }
-    end
+    let(:other_cohort) { create :cohort, registration_starts_at: Date.new(2024, 5, 1) }
 
     it { is_expected.to eq [cohort] }
   end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe LeadProvider do
       # Deadline is later
       create(:statement, output_fee: true, cohort:, lead_provider:, deadline_date: 2.days.from_now)
       # Wrong cohort
-      create(:statement, output_fee: true, cohort: create(:cohort, start_year: cohort.start_year + 1), lead_provider:, deadline_date: 1.hour.from_now)
+      create(:statement, output_fee: true, cohort: create(:cohort, registration_starts_at: Date.new(cohort.start_year + 1, 4, 1)), lead_provider:, deadline_date: 1.hour.from_now)
       # In the past
       create(:statement, output_fee: true, cohort:, lead_provider:, deadline_date: 1.day.ago)
     end
@@ -44,11 +44,11 @@ RSpec.describe LeadProvider do
     let :lead_provider do
       create_list(:lead_provider, 2, delivery_partners: {
         twenty_three => twenty_three_partner,
-        create(:cohort, start_year: 2024) => twenty_four_partner,
+        create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) => twenty_four_partner,
       }).first
     end
 
-    let(:twenty_three) { create(:cohort, start_year: 2023) }
+    let(:twenty_three) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
     let(:twenty_three_partner) { create(:delivery_partner) }
     let(:twenty_four_partner) { create(:delivery_partner) }
     let(:unrelated_partner) { create(:delivery_partner) }

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Statement, type: :model do
     subject { statement.use_targeted_delivery_funding? }
 
     let(:statement) { build(:statement, cohort:) }
-    let(:cohort) { build(:cohort, start_year: cohort_start_year) }
+    let(:cohort) { create(:cohort, registration_starts_at: Date.new(cohort_start_year, 4, 1)) }
 
     context "when the statement date is before November 2025" do
       let(:statement) { build(:statement, month: 10, year: 2025, cohort:) }

--- a/spec/requests/admin/cohort_courses_controller_spec.rb
+++ b/spec/requests/admin/cohort_courses_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Admin::CohortCoursesController, :ecf_api_disabled, type: :request
 
   subject { response }
 
-  let(:cohort) { create(:cohort, :unique) }
+  let(:cohort) { create(:cohort, registration_starts_at: Date.new(2024, 5, 1)) }
   let!(:schedule) { create(:schedule, cohort:) }
   let!(:course) { create(:course, name: "Course to add", identifier: "course-to-add") }
   let(:lead_provider) { create(:lead_provider, name: "Provider One") }

--- a/spec/requests/admin/cohorts_controller_spec.rb
+++ b/spec/requests/admin/cohorts_controller_spec.rb
@@ -6,12 +6,11 @@ RSpec.describe Admin::CohortsController, :ecf_api_disabled, :revisit, type: :req
   subject { response }
 
   let(:cohort)         { create(:cohort) }
-  let(:invalid_params) { valid_params.deep_merge(cohort: { start_year: 1066 }) }
+  let(:invalid_params) { valid_params.deep_merge(cohort: { registration_starts_at: "1066-04-01" }) }
 
   let :valid_params do
     {
       cohort: {
-        start_year: 2029,
         funding_cap: true,
         registration_starts_at: "2029-03-02",
         name: "2029",

--- a/spec/requests/admin/finance/statements_controller_spec.rb
+++ b/spec/requests/admin/finance/statements_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Admin::Finance::StatementsController, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
-  let(:cohort) { create(:cohort, start_year: 2024) }
+  let(:cohort) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
   let(:lead_provider) { create(:lead_provider) }
   let(:statement) { statements.first }
 

--- a/spec/requests/api/docs/v1/participants_spec.rb
+++ b/spec/requests/api/docs/v1/participants_spec.rb
@@ -12,14 +12,15 @@ RSpec.describe "Participants endpoint", openapi_spec: "v1/swagger.yaml", type: :
   let(:application) do
     create(:application,
            application_status_trait,
+           :for_cohort_starting_on,
            :with_declaration,
            :with_accepted_event,
            :eligible_for_funded_place,
            :with_participant_id_change,
            lead_provider:,
            course:,
-           cohort:,
            schedule:,
+           registration_starts_at: cohort.registration_starts_at,
            user:,
            funded_place: true)
   end

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -43,7 +43,13 @@ RSpec.describe "Application endpoints", type: :request do
     let(:resource_id_key) { :ecf_id }
 
     def create_resource(**attrs)
-      create(:application, **attrs).application_lead_providers.first
+      cohort = attrs.delete(:cohort)
+
+      if cohort
+        create(:application, :for_cohort_starting_on, **attrs, registration_starts_at: cohort.registration_starts_at).application_lead_providers.first
+      else
+        create(:application, **attrs).application_lead_providers.first
+      end
     end
 
     it_behaves_like "an API index endpoint"

--- a/spec/requests/api/v1/delivery_partners_spec.rb
+++ b/spec/requests/api/v1/delivery_partners_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "Delivery Partner endpoints", type: :request do
     it_behaves_like "an API index endpoint with sorting", %w[name]
 
     context "when filtering by cohort" do
-      let(:cohort_2023) { create(:cohort, start_year: 2023) }
-      let(:cohort_2024) { create(:cohort, start_year: 2024) }
+      let(:cohort_2023) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
+      let(:cohort_2024) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
       let!(:delivery_partner_2023) { create(:delivery_partner, lead_providers: { cohort_2023 => current_lead_provider }) }
 
       before { create(:delivery_partner, lead_providers: { cohort_2024 => current_lead_provider }) }

--- a/spec/requests/applications/applications_spec.rb
+++ b/spec/requests/applications/applications_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Applications::ApplicationsController", type: :request do
 
   describe "GET /applications" do
     context "when the user has multiple applications" do
-      let!(:completed_application) { create(:application, :completed, user: pending_application.user) }
+      let!(:completed_application) { create(:application, :completed, :for_cohort_starting_on, user: pending_application.user, registration_starts_at: Date.new(2021, 4, 1)) }
 
       it do
         get "/applications"

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
            secondary_delivery_partner:)
   end
 
-  let(:application) { create(:application, :accepted) }
+  let(:application) { create(:application, :accepted, :for_cohort_starting_on, registration_starts_at: Date.new(2021, 4, 1)) }
   let(:cohort) { application.cohort }
   let(:lead_provider) { application.lead_provider }
   let(:delivery_partner) do

--- a/spec/serializers/api/delivery_partner_serializer_spec.rb
+++ b/spec/serializers/api/delivery_partner_serializer_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe API::DeliveryPartnerSerializer, type: :serializer do
              cohort_23 => other_lead_provider,
            })
   end
-  let(:cohort_21) { create :cohort, start_year: 2021 }
-  let(:cohort_22) { create :cohort, start_year: 2022 }
-  let(:cohort_23) { create :cohort, start_year: 2023 }
+  let(:cohort_21) { create :cohort, registration_starts_at: Date.new(2021, 4, 1) }
+  let(:cohort_22) { create :cohort, registration_starts_at: Date.new(2022, 4, 1) }
+  let(:cohort_23) { create :cohort, registration_starts_at: Date.new(2023, 4, 1) }
 
   subject(:response) { JSON.parse(described_class.render(delivery_partner)) }
 

--- a/spec/serializers/api/participant_serializer_spec.rb
+++ b/spec/serializers/api/participant_serializer_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
       end
 
       context "when there're multiple application with different lead provider approval states" do
-        before { create(:application, lead_provider:, user: participant) }
+        before { create(:application, :for_cohort_starting_on, lead_provider:, user: participant, registration_starts_at: Date.new(2021, 4, 1)) }
 
         it "serializes only accepted `enrolments`" do
           expect(attributes["enrolments"].size).to eq(1)

--- a/spec/services/admin_service/users_search_spec.rb
+++ b/spec/services/admin_service/users_search_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe AdminService::UsersSearch do
       let(:q) { user.full_name }
 
       before do
-        create(:application, user:)
+        create(:application, :for_cohort_starting_on, user:, registration_starts_at: Date.new(2021, 4, 1))
       end
 
       it "returns one result" do

--- a/spec/services/applications/change_cohort_spec.rb
+++ b/spec/services/applications/change_cohort_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Applications::ChangeCohort, type: :service do
   let(:override_declarations_check) { false }
   let(:error_message_path) { "activemodel.errors.models.applications/change_cohort.attributes.base" }
-  let(:current_cohort) { create(:cohort, start_year: 2025) }
+  let(:current_cohort) { create(:cohort, registration_starts_at: Date.new(2025, 4, 1)) }
   let(:new_cohort) { current_cohort }
   let(:course_cohort) { create(:course_cohort, cohort: current_cohort) }
   let(:application) { create(:application, course_cohort:) }
@@ -19,7 +19,7 @@ RSpec.describe Applications::ChangeCohort, type: :service do
 
   describe "validation" do
     context "when the new cohort start_year is the same" do
-      let(:new_cohort) { create(:cohort, start_year: 2025) }
+      let(:new_cohort) { create(:cohort, registration_starts_at: Date.new(2025, 4, 1)) }
 
       it do
         expect(subject).not_to be_valid
@@ -28,7 +28,7 @@ RSpec.describe Applications::ChangeCohort, type: :service do
     end
 
     context "when the new cohort start_year is different" do
-      let(:new_cohort) { create(:cohort, start_year: 2026) }
+      let(:new_cohort) { create(:cohort, registration_starts_at: Date.new(2026, 4, 1)) }
 
       it do
         expect(subject.errors).to be_blank
@@ -36,7 +36,7 @@ RSpec.describe Applications::ChangeCohort, type: :service do
     end
 
     context "when the application has declarations" do
-      let(:new_cohort) { create(:cohort, start_year: 2026) }
+      let(:new_cohort) { create(:cohort, registration_starts_at: Date.new(2026, 4, 1)) }
       let(:application) { create(:application, :with_declaration, course_cohort:) }
 
       it do

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Applications::Query do
           let(:cohort_start_years) { "2024" }
 
           it "filters by cohort" do
-            create(:application, cohort: cohort_2023)
-            application = create(:application, lead_provider:, cohort: cohort_2024)
+            create(:application, :for_cohort_starting_on, registration_starts_at: cohort_2023.registration_starts_at)
+            application = create(:application, :for_cohort_starting_on, lead_provider:, registration_starts_at: cohort_2024.registration_starts_at)
             expect(query.applications).to contain_exactly(application)
           end
         end
@@ -70,9 +70,9 @@ RSpec.describe Applications::Query do
           let(:cohort_start_years) { "2023,2024" }
 
           it "filters by multiple cohorts" do
-            application1 = create(:application, lead_provider:, cohort: cohort_2023)
-            application2 = create(:application, lead_provider:, cohort: cohort_2024)
-            create(:application, cohort: cohort_2025)
+            application1 = create(:application, :for_cohort_starting_on, lead_provider:, registration_starts_at: cohort_2023.registration_starts_at)
+            application2 = create(:application, :for_cohort_starting_on, lead_provider:, registration_starts_at: cohort_2024.registration_starts_at)
+            create(:application, :for_cohort_starting_on, registration_starts_at: cohort_2025.registration_starts_at)
 
             expect(query.applications).to contain_exactly(application1, application2)
           end
@@ -159,22 +159,27 @@ RSpec.describe Applications::Query do
         let(:user) { create(:user) }
 
         context "with valid id" do
-          let(:application) { create(:application, lead_provider:, user:) }
+          let(:application) { create(:application, :for_cohort_starting_on, lead_provider:, user:, registration_starts_at: Date.new(2021, 5, 1)) }
           let(:participant_ids) { application.user.ecf_id }
 
           it "filters by participant_id" do
-            create(:application, user:)
+            create(:application, :for_cohort_starting_on, user:, registration_starts_at: Date.new(2021, 4, 1))
 
             expect(query.applications).to contain_exactly(application)
           end
         end
 
         context "with multiple values" do
-          let(:applications) { create_list(:application, 2, lead_provider:, user:) }
+          let(:applications) do
+            [
+              create(:application, :for_cohort_starting_on, lead_provider:, user:, registration_starts_at: Date.new(2021, 4, 1)),
+              create(:application, :for_cohort_starting_on, lead_provider:, user:, registration_starts_at: Date.new(2021, 5, 1)),
+            ]
+          end
           let(:participant_ids) { applications.map { _1.user.ecf_id } }
 
           it "filters by multiple participant_ids" do
-            create(:application, user:)
+            create(:application, :for_cohort_starting_on, user:, registration_starts_at: Date.new(2021, 6, 1))
 
             expect(query.applications).to match_array(applications)
           end

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe Applications::Query do
       end
 
       context "when filtering by cohort" do
-        let(:cohort_2023) { create(:cohort, start_year: 2023) }
-        let(:cohort_2024) { create(:cohort, start_year: 2024) }
-        let(:cohort_2025) { create(:cohort, start_year: 2025) }
+        let(:cohort_2023) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
+        let(:cohort_2024) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
+        let(:cohort_2025) { create(:cohort, registration_starts_at: Date.new(2025, 4, 1)) }
 
         context "when 2024" do
           let(:cohort_start_years) { "2024" }

--- a/spec/services/applications/reject_spec.rb
+++ b/spec/services/applications/reject_spec.rb
@@ -76,9 +76,9 @@ RSpec.describe Applications::Reject, type: :model do
 
     context "when user has other pending applications" do
       let(:user) { create(:user, trn: nil, refresh_token: "token", refresh_token_updated_at: Time.current) }
-      let(:application) { create(:application, :pending, user:) }
+      let(:application) { create(:application, :pending, :for_cohort_starting_on, user:, registration_starts_at: Date.new(2021, 5, 1)) }
 
-      before { create(:application, :pending, user:) }
+      before { create(:application, :pending, :for_cohort_starting_on, user:, registration_starts_at: Date.new(2021, 4, 1)) }
 
       it "does not clear the refresh token" do
         service.call

--- a/spec/services/cohorts/copy_delivery_partners_spec.rb
+++ b/spec/services/cohorts/copy_delivery_partners_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe Cohorts::CopyDeliveryPartners do
   describe "#copy" do
     let!(:previous_cohort) do
-      create(:cohort, start_year: 2029, registration_starts_at: Date.new(2029, 1, 1))
+      create(:cohort, registration_starts_at: Date.new(2029, 1, 1))
     end
     let(:cohort) do
-      create(:cohort, start_year: 2029, registration_starts_at: Date.new(2029, 2, 1))
+      create(:cohort, registration_starts_at: Date.new(2029, 2, 1))
     end
     let(:service) { described_class.new(cohort) }
 

--- a/spec/services/declarations/query_spec.rb
+++ b/spec/services/declarations/query_spec.rb
@@ -124,9 +124,9 @@ RSpec.describe Declarations::Query do
       end
 
       context "when filtering by cohort" do
-        let(:cohort_2023) { create(:cohort, start_year: 2023) }
-        let(:cohort_2024) { create(:cohort, start_year: 2024) }
-        let(:cohort_2025) { create(:cohort, start_year: 2025) }
+        let(:cohort_2023) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
+        let(:cohort_2024) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
+        let(:cohort_2025) { create(:cohort, registration_starts_at: Date.new(2025, 4, 1)) }
 
         it "filters by cohort" do
           create(:declaration, cohort: cohort_2023)

--- a/spec/services/delivery_partners/query_spec.rb
+++ b/spec/services/delivery_partners/query_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe DeliveryPartners::Query do
   let(:lead_provider_1) { create(:lead_provider) }
   let(:lead_provider_2) { create(:lead_provider) }
-  let(:cohort_21) { create :cohort, start_year: 2021, registration_starts_at: Date.new(2021, 4, 1) }
-  let(:cohort_22) { create :cohort, start_year: 2022, registration_starts_at: Date.new(2022, 4, 1) }
-  let(:cohort_23) { create :cohort, start_year: 2023, registration_starts_at: Date.new(2023, 4, 1) }
-  let(:cohort_21_2) { create :cohort, start_year: 2021, registration_starts_at: Date.new(2021, 10, 1) }
+  let(:cohort_21) { create :cohort, registration_starts_at: Date.new(2021, 4, 1) }
+  let(:cohort_22) { create :cohort, registration_starts_at: Date.new(2022, 4, 1) }
+  let(:cohort_23) { create :cohort, registration_starts_at: Date.new(2023, 4, 1) }
+  let(:cohort_21_2) { create :cohort, registration_starts_at: Date.new(2021, 10, 1) }
   let(:sort) { nil }
 
   subject(:query) { described_class.new(lead_provider: lead_provider_1, sort: sort) }

--- a/spec/services/exporters/contracts_spec.rb
+++ b/spec/services/exporters/contracts_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Exporters::Contracts do
   context "when there are statements that have different values for the same cohort, lead provider and course" do
     subject { described_class.new(cohort: older_cohort).call }
 
-    let(:older_cohort) { create(:cohort, start_year: 2022) }
+    let(:older_cohort) { create(:cohort, registration_starts_at: Date.new(2022, 4, 1)) }
     let(:older_statement_output_fee_true) { create(:statement, cohort: older_cohort, lead_provider:, output_fee: true, for_date: Date.new(2022, 1, 1)) }
     let(:older_statement_output_fee_false) { create(:statement, cohort: older_cohort, lead_provider:, output_fee: false, for_date: Date.new(2022, 2, 1)) }
     let(:latest_statement_output_fee_true) { create(:statement, cohort: older_cohort, lead_provider:, output_fee: true, for_date: Date.new(2022, 6, 1)) }

--- a/spec/services/exporters/tad_data_request_spec.rb
+++ b/spec/services/exporters/tad_data_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Exporters::TadDataRequest do
   let(:file) { Tempfile.new }
   let(:course) { create(:course, name: "Some course") }
-  let(:cohort) { create(:cohort, start_year: 2023) }
+  let(:cohort) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
   let(:schedule) { create(:schedule, cohort: cohort, course_group: course.course_group, name: "Schedule Autumn 2023") }
   let(:course_cohort) { create(:course_cohort, cohort:, course:, schedule:) }
   let(:user) { create(:user, full_name: "John Doe", email: "john@example.com") }

--- a/spec/services/handle_submission_for_store_spec.rb
+++ b/spec/services/handle_submission_for_store_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe HandleSubmissionForStore do
     {
       "current_user_id" => user.id,
       "course_identifier" => course.identifier,
+      "course_cohort_id" => course_cohort.id,
       "institution_id" => private_childcare_provider.institution.id,
       "lead_provider_id" => lead_provider.id,
       "works_in_childcare" => "yes",
@@ -79,6 +80,7 @@ RSpec.describe HandleSubmissionForStore do
         {
           "current_user_id" => user.id,
           "course_identifier" => course.identifier,
+          "course_cohort_id" => course_cohort.id,
           "institution_id" => school.institution.id,
           "lead_provider_id" => lead_provider.id,
           "works_in_school" => "yes",
@@ -167,6 +169,7 @@ RSpec.describe HandleSubmissionForStore do
         {
           "current_user_id" => user.id,
           "course_identifier" => course.identifier,
+          "course_cohort_id" => course_cohort.id,
           "institution_id" => private_childcare_provider.institution.id,
           "lead_provider_id" => lead_provider.id,
           "works_in_childcare" => "yes",
@@ -220,6 +223,7 @@ RSpec.describe HandleSubmissionForStore do
         {
           "current_user_id" => user.id,
           "course_identifier" => course.identifier,
+          "course_cohort_id" => course_cohort.id,
           "institution_id" => private_childcare_provider.institution.id,
           "lead_provider_id" => lead_provider.id,
           "works_in_childcare" => "yes",
@@ -278,6 +282,7 @@ RSpec.describe HandleSubmissionForStore do
         {
           "current_user_id" => user.id,
           "course_identifier" => course.identifier,
+          "course_cohort_id" => course_cohort.id,
           "institution_id" => private_childcare_provider.institution.id,
           "lead_provider_id" => lead_provider.id,
           "works_in_childcare" => "yes",

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Participants::Query do
       before do
         create(:participant_id_change, user: participant1, to_participant_id: participant1.ecf_id)
         create(:participant_id_change, user: participant1, to_participant_id: participant1.ecf_id)
-        create(:application, :accepted, user: participant1, lead_provider:)
-        create(:application, :accepted, user: participant1, lead_provider:)
+        create(:application, :accepted, :for_cohort_starting_on, user: participant1, lead_provider:, registration_starts_at: Date.new(2021, 4, 1))
+        create(:application, :accepted, :for_cohort_starting_on, user: participant1, lead_provider:, registration_starts_at: Date.new(2021, 5, 1))
       end
 
       it "does not return duplicate participants" do
@@ -118,8 +118,8 @@ RSpec.describe Participants::Query do
 
         context "when a participant was not updated within the time-frame and they have applications that have been updated both inside and outside the time-frame" do
           let(:participant1) { create(:user) }
-          let!(:application_outside_time_frame) { travel_to(4.days.ago) { create(:application, :accepted, lead_provider:, user: participant1) } }
-          let!(:application_inside_time_frame) { travel_to(2.days.ago) { create(:application, :accepted, lead_provider:, user: participant1) } }
+          let!(:application_outside_time_frame) { travel_to(4.days.ago) { create(:application, :accepted, :for_cohort_starting_on, lead_provider:, user: participant1, registration_starts_at: Date.new(2021, 4, 1)) } }
+          let!(:application_inside_time_frame) { travel_to(2.days.ago) { create(:application, :accepted, :for_cohort_starting_on, lead_provider:, user: participant1, registration_starts_at: Date.new(2021, 5, 1)) } }
           let(:participant2) { travel_to(10.days.ago) { create(:user) } }
 
           let(:params) { { updated_since: 3.days.ago } }
@@ -198,7 +198,7 @@ RSpec.describe Participants::Query do
 
           before do
             participant1.applications.first.update_columns(status: Application::WITHDRAWN)
-            create(:application, :accepted, user: participant1, lead_provider:)
+            create(:application, :accepted, :for_cohort_starting_on, user: participant1, lead_provider:, registration_starts_at: Date.new(2021, 4, 1))
           end
 
           it "filters the users by status and only returns applications with the matching status" do

--- a/spec/services/schedules/query_spec.rb
+++ b/spec/services/schedules/query_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Schedules::Query do
   let(:sort) { nil }
 
   let(:course_cohort1) { create(:course_cohort, course: create(:course, identifier: "other")) }
-  let(:course_cohort2) { create(:course_cohort, cohort: create(:cohort, start_year: 2021, registration_starts_at: Date.new(2021, 9, 1))) }
+  let(:course_cohort2) { create(:course_cohort, cohort: create(:cohort, registration_starts_at: Date.new(2021, 9, 1))) }
 
   describe "#course_cohorts" do
     before do

--- a/spec/services/statements/query_spec.rb
+++ b/spec/services/statements/query_spec.rb
@@ -72,9 +72,9 @@ RSpec.describe Statements::Query do
       end
 
       describe "by cohort" do
-        let!(:cohort_2023) { create(:cohort, start_year: 2023) }
-        let!(:cohort_2024) { create(:cohort, start_year: 2024) }
-        let!(:cohort_2025) { create(:cohort, start_year: 2025) }
+        let!(:cohort_2023) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
+        let!(:cohort_2024) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
+        let!(:cohort_2025) { create(:cohort, registration_starts_at: Date.new(2025, 4, 1)) }
 
         context "when cohort param omitted" do
           it "returns all statements" do

--- a/spec/services/users/merge_and_archive_spec.rb
+++ b/spec/services/users/merge_and_archive_spec.rb
@@ -3,14 +3,15 @@ require "rails_helper"
 RSpec.describe Users::MergeAndArchive do
   let(:user_to_merge) { create(:user, :with_one_login_id) }
   let(:user_to_keep) { create(:user) }
+  let(:course) { create(Course::IDENTIFIERS.first.to_sym) }
 
-  let!(:user_to_keep_rejected_application) { create(:application, :rejected, user: user_to_keep, cohort: create(:cohort, registration_starts_at: Date.new(2021, 4, 1))) }
-  let!(:user_to_keep_pending_application) { create(:application, :pending, user: user_to_keep, cohort: create(:cohort, registration_starts_at: Date.new(2021, 5, 1))) }
-  let!(:user_to_keep_accepted_application) { create(:application, :accepted, user: user_to_keep, cohort: create(:cohort, registration_starts_at: Date.new(2021, 6, 1))) }
+  let!(:user_to_keep_rejected_application) { create(:application, :rejected, :for_cohort_starting_on, user: user_to_keep, course:, registration_starts_at: Date.new(2021, 4, 1)) }
+  let!(:user_to_keep_pending_application) { create(:application, :pending, :for_cohort_starting_on, user: user_to_keep, course:, registration_starts_at: Date.new(2021, 5, 1)) }
+  let!(:user_to_keep_accepted_application) { create(:application, :accepted, :for_cohort_starting_on, user: user_to_keep, course:, registration_starts_at: Date.new(2021, 6, 1)) }
 
-  let!(:user_to_merge_rejected_application) { create(:application, :rejected, user: user_to_merge, cohort: create(:cohort, registration_starts_at: Date.new(2021, 7, 1))) }
-  let!(:user_to_merge_pending_application) { create(:application, :pending, user: user_to_merge, cohort: create(:cohort, registration_starts_at: Date.new(2021, 8, 1))) }
-  let!(:user_to_merge_accepted_application) { create(:application, :accepted, user: user_to_merge, cohort: create(:cohort, registration_starts_at: Date.new(2021, 9, 1))) }
+  let!(:user_to_merge_rejected_application) { create(:application, :rejected, :for_cohort_starting_on, user: user_to_merge, course:, registration_starts_at: Date.new(2021, 7, 1)) }
+  let!(:user_to_merge_pending_application) { create(:application, :pending, :for_cohort_starting_on, user: user_to_merge, course:, registration_starts_at: Date.new(2021, 8, 1)) }
+  let!(:user_to_merge_accepted_application) { create(:application, :accepted, :for_cohort_starting_on, user: user_to_merge, course:, registration_starts_at: Date.new(2021, 9, 1)) }
 
   let!(:existing_participant_id_change) { create(:participant_id_change, user: user_to_merge) }
 

--- a/spec/services/users/merge_and_archive_spec.rb
+++ b/spec/services/users/merge_and_archive_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe Users::MergeAndArchive do
   let(:user_to_merge) { create(:user, :with_one_login_id) }
   let(:user_to_keep) { create(:user) }
 
-  let!(:user_to_keep_rejected_application) { create(:application, :rejected, user: user_to_keep, cohort: create(:cohort, :unique)) }
-  let!(:user_to_keep_pending_application) { create(:application, :pending, user: user_to_keep, cohort: create(:cohort, :unique)) }
-  let!(:user_to_keep_accepted_application) { create(:application, :accepted, user: user_to_keep, cohort: create(:cohort, :unique)) }
+  let!(:user_to_keep_rejected_application) { create(:application, :rejected, user: user_to_keep, cohort: create(:cohort, registration_starts_at: Date.new(2021, 4, 1))) }
+  let!(:user_to_keep_pending_application) { create(:application, :pending, user: user_to_keep, cohort: create(:cohort, registration_starts_at: Date.new(2021, 5, 1))) }
+  let!(:user_to_keep_accepted_application) { create(:application, :accepted, user: user_to_keep, cohort: create(:cohort, registration_starts_at: Date.new(2021, 6, 1))) }
 
-  let!(:user_to_merge_rejected_application) { create(:application, :rejected, user: user_to_merge, cohort: create(:cohort, :unique)) }
-  let!(:user_to_merge_pending_application) { create(:application, :pending, user: user_to_merge, cohort: create(:cohort, :unique)) }
-  let!(:user_to_merge_accepted_application) { create(:application, :accepted, user: user_to_merge, cohort: create(:cohort, :unique)) }
+  let!(:user_to_merge_rejected_application) { create(:application, :rejected, user: user_to_merge, cohort: create(:cohort, registration_starts_at: Date.new(2021, 7, 1))) }
+  let!(:user_to_merge_pending_application) { create(:application, :pending, user: user_to_merge, cohort: create(:cohort, registration_starts_at: Date.new(2021, 8, 1))) }
+  let!(:user_to_merge_accepted_application) { create(:application, :accepted, user: user_to_merge, cohort: create(:cohort, registration_starts_at: Date.new(2021, 9, 1))) }
 
   let!(:existing_participant_id_change) { create(:participant_id_change, user: user_to_merge) }
 

--- a/spec/services/valid_test_data_generators/api_test_scenarios_seeder_spec.rb
+++ b/spec/services/valid_test_data_generators/api_test_scenarios_seeder_spec.rb
@@ -143,16 +143,18 @@ RSpec.describe ValidTestDataGenerators::APITestScenariosSeeder do
         it "creates 2 cohorts" do
           expect { seeder.call }.to change(Cohort, :count).by_at_least(2)
 
-          expect(Cohort.find_by(start_year: cohort_year)).to be_present
-          expect(Cohort.find_by(start_year: cohort_year + 1)).to be_present
+          cohort_start_dates = seeder.cohort_start_dates.take(4)
+          expect(Cohort.find_by(registration_starts_at: cohort_start_dates[0])).to be_present
+          expect(Cohort.find_by(registration_starts_at: cohort_start_dates[2])).to be_present
         end
 
         it "creates 2 course_cohorts" do
           seeder.call
 
           course = Course.find_by!(identifier: "tte-early-years")
-          primary_cohort = Cohort.find_by(start_year: cohort_year)
-          secondary_cohort = Cohort.find_by(start_year: cohort_year + 1)
+          cohort_start_dates = seeder.cohort_start_dates.take(4)
+          primary_cohort = Cohort.find_by(registration_starts_at: cohort_start_dates[0])
+          secondary_cohort = Cohort.find_by(registration_starts_at: cohort_start_dates[2])
 
           expect(CourseCohort.find_by(course:, cohort: primary_cohort)).to be_present
           expect(CourseCohort.find_by(course:, cohort: secondary_cohort)).to be_present
@@ -255,8 +257,9 @@ RSpec.describe ValidTestDataGenerators::APITestScenariosSeeder do
         it "creates cohorts for the specified year" do
           seeder.call
 
-          expect(Cohort.find_by(start_year: 2027)).to be_present
-          expect(Cohort.find_by(start_year: 2028)).to be_present
+          cohort_start_dates = seeder.cohort_start_dates.take(4)
+          expect(Cohort.find_by(registration_starts_at: cohort_start_dates[0])).to be_present
+          expect(Cohort.find_by(registration_starts_at: cohort_start_dates[2])).to be_present
         end
 
         it "creates statements for the specified year" do

--- a/spec/services/valid_test_data_generators/statements_populater_spec.rb
+++ b/spec/services/valid_test_data_generators/statements_populater_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe ValidTestDataGenerators::StatementsPopulater do
   let(:lead_provider) { create(:lead_provider) }
-  let(:cohort) { create(:cohort, start_year: 2021) }
+  let(:cohort) { create(:cohort, registration_starts_at: Date.new(2021, 4, 1)) }
 
   before { allow(Rails).to receive(:env) { environment.inquiry } }
 

--- a/spec/support/shared_examples/api_index_csv_endpoint_support.rb
+++ b/spec/support/shared_examples/api_index_csv_endpoint_support.rb
@@ -64,9 +64,9 @@ end
 
 RSpec.shared_examples "an API index Csv endpoint with filter by cohort" do
   context "when fitlering by cohort" do
-    let(:cohort_2023) { create(:cohort, start_year: 2023) }
-    let(:cohort_2024) { create(:cohort, start_year: 2024) }
-    let(:cohort_2025) { create(:cohort, start_year: 2025) }
+    let(:cohort_2023) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
+    let(:cohort_2024) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
+    let(:cohort_2025) { create(:cohort, registration_starts_at: Date.new(2025, 4, 1)) }
 
     it "returns resources for the specified cohorts" do
       create_resource(lead_provider: current_lead_provider, cohort: cohort_2023)

--- a/spec/support/shared_examples/api_index_endpoint_support.rb
+++ b/spec/support/shared_examples/api_index_endpoint_support.rb
@@ -129,9 +129,9 @@ end
 
 RSpec.shared_examples "an API index endpoint with filter by cohort" do
   context "when fitlering by cohort" do
-    let(:cohort_2023) { create(:cohort, start_year: 2023) }
-    let(:cohort_2024) { create(:cohort, start_year: 2024) }
-    let(:cohort_2025) { create(:cohort, start_year: 2025) }
+    let(:cohort_2023) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
+    let(:cohort_2024) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
+    let(:cohort_2025) { create(:cohort, registration_starts_at: Date.new(2025, 4, 1)) }
 
     it "returns resources for the specified cohorts" do
       create_resource(lead_provider: current_lead_provider, cohort: cohort_2023)

--- a/spec/support/shared_examples/course_group_schedule_support.rb
+++ b/spec/support/shared_examples/course_group_schedule_support.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples "leadership and specialist #schedule" do
 
   context "when the course is in the autumn schedule for the 2025 cohort" do
     let!(:autumn_schedule) { create(:schedule, autumn_schedule_identifier, cohort:) }
-    let(:cohort) { create(:cohort, start_year: 2025) }
+    let(:cohort) { create(:cohort, registration_starts_at: Date.new(2025, 4, 1)) }
 
     context "when at the start of the autumn registration window" do
       let(:date) { Date.new(2025, 9, 8) }
@@ -28,14 +28,14 @@ RSpec.shared_examples "leadership and specialist #schedule" do
 
   context "when the course is in the spring schedule for the 2025 cohort" do
     let!(:spring_schedule) { create(:schedule, spring_schedule_identifier, cohort:) }
-    let(:cohort) { create(:cohort, start_year: 2025) }
+    let(:cohort) { create(:cohort, registration_starts_at: Date.new(2025, 4, 1)) }
 
     it { is_expected.to eq(spring_schedule) }
   end
 
   context "when the course is only in the autumn schedule (like the 2024 cohort)" do
     let!(:autumn_schedule) { create(:schedule, autumn_schedule_identifier, cohort:) }
-    let(:cohort) { create(:cohort, start_year: 2024) }
+    let(:cohort) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
 
     it { is_expected.to eq(autumn_schedule) }
   end
@@ -43,7 +43,7 @@ RSpec.shared_examples "leadership and specialist #schedule" do
   context "when course is in both autumn and spring schedules (like 2021-2023 cohorts)" do
     let!(:spring_schedule) { create(:schedule, spring_schedule_identifier, cohort:) }
     let!(:autumn_schedule) { create(:schedule, autumn_schedule_identifier, cohort:) }
-    let(:cohort) { create(:cohort, start_year: 2023) }
+    let(:cohort) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
 
     context "when date is between 1st January and 2nd April" do
       before { travel_to(Date.new(2025, 4, 2)) }

--- a/spec/support/with_default_schedules.rb
+++ b/spec/support/with_default_schedules.rb
@@ -6,7 +6,7 @@ RSpec.shared_context "with default schedules", shared_context: :metadata do
     end_year = Date.current.month < 9 ? Date.current.year : Date.current.year.succ
     course = Course.first
     (2021..end_year).each do |start_year|
-      cohort = FactoryBot.create(:cohort, start_year:)
+      cohort = FactoryBot.create(:cohort, registration_starts_at: Date.new(start_year, 4, 1))
       Schedule::IDENTIFIERS.each do |schedule_identifier|
         FactoryBot.create(:schedule, schedule_identifier.tr("-", "_"), cohort:, change_training_dates: false)
         create(:course_cohort, cohort:, course:)


### PR DESCRIPTION
### Context

The cohort factory and related specs are somewhat flaky, this simplifies the setup

### Changes proposed in this pull request

Drive cohort creation in the specs/factories from ```registration_starts_at``` instead of ```start_year``` derive ```start_year``` from ```registration_starts_at```