### PR TITLE
EOI form access control

### DIFF
--- a/app/controllers/interest_notification_sign_up_controller.rb
+++ b/app/controllers/interest_notification_sign_up_controller.rb
@@ -1,4 +1,5 @@
 class InterestNotificationSignUpController < PublicPagesController
+  before_action :ensure_registration_closed
   before_action :set_notification_form, only: %i[new]
 
   def new; end
@@ -26,5 +27,9 @@ private
 
   def set_notification_form
     @notification_form = Questionnaires::RegistrationInterestNotification.new
+  end
+
+  def ensure_registration_closed
+    redirect_to root_path unless Feature.registration_closed?(current_user)
   end
 end

--- a/spec/accessibility/expression_of_interest_spec.rb
+++ b/spec/accessibility/expression_of_interest_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Expression of interest accessibility", :axe, type: :feature do
+  before do
+    Flipper.disable(Feature::REGISTRATION_OPEN)
+  end
+
   it "sign up page is accessible" do
     visit registration_interest_sign_up_path
     expect(page).to be_axe_clean

--- a/spec/features/registration_interest_spec.rb
+++ b/spec/features/registration_interest_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.feature "Register interest", type: :feature do
   include_context "Stub Teacher Auth Responses"
 
+  before do
+    Flipper.disable(Feature::REGISTRATION_OPEN)
+  end
+
   scenario "Sign up to notification with direct link" do
     visit "/registration-interest/sign-up"
 

--- a/spec/requests/interest_notification_sign_up_controller_spec.rb
+++ b/spec/requests/interest_notification_sign_up_controller_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe InterestNotificationSignUpController, type: :request do
+  describe "#new" do
+    context "when registration is closed" do
+      before { Flipper.disable(Feature::REGISTRATION_OPEN) }
+
+      it "displays the email sign up form" do
+        get registration_interest_sign_up_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("email")
+      end
+    end
+
+    context "when registration is open" do
+      before { Flipper.enable(Feature::REGISTRATION_OPEN) }
+
+      it "redirects to the service homepage" do
+        get registration_interest_sign_up_path
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "#create" do
+    let(:params) do
+      { questionnaires_registration_interest_notification: { email: "jane@example.com" } }
+    end
+
+    context "when registration is closed" do
+      before { Flipper.disable(Feature::REGISTRATION_OPEN) }
+
+      it "redirects to the confirmation page" do
+        post registration_interest_sign_up_path, params: params
+
+        expect(response).to redirect_to(registration_interest_sign_up_confirm_path(email: "jane@example.com"))
+      end
+    end
+
+    context "when registration is open" do
+      before { Flipper.enable(Feature::REGISTRATION_OPEN) }
+
+      it "redirects to the service homepage instead of processing the sign up" do
+        expect {
+          post registration_interest_sign_up_path, params: params
+        }.not_to change(RegistrationInterest, :count)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "#confirm" do
+    context "when registration is closed" do
+      before { Flipper.disable(Feature::REGISTRATION_OPEN) }
+
+      it "displays the confirmation page" do
+        get registration_interest_sign_up_confirm_path(email: "jane@example.com")
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "when registration is open" do
+      before { Flipper.enable(Feature::REGISTRATION_OPEN) }
+
+      it "redirects to the service homepage" do
+        get registration_interest_sign_up_confirm_path(email: "jane@example.com")
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#561


### Changes proposed in this pull request

Restricts the Expression of Interest (EOI) sign-up flow so it is only reachable while registration is closed.

Reuses the existing Feature.registration_closed?