### PR TITLE
Send omniauth error type to Sentry

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -29,10 +29,14 @@ class OmniauthController < Devise::OmniauthCallbacksController
 
     Rails.logger.info("[TeacherAuth][omniauth_failure] uid=#{try_to_extract_user_uid} error=#{try_to_extract_error_type}")
     send_error_to_sentry(
-      "Omniauth login failure",
+      "Omniauth login failure (#{try_to_extract_error_type})",
       contexts: {
-        "Strategy" => { name: request.env["omniauth.error.strategy"].name },
-        "Error" => { "omniauth.error.type" => Base64.encode64(request.env["omniauth.error.type"].to_s) },
+        "OmniAuth" => {
+          error_type: try_to_extract_error_type.to_s,
+          strategy: request.env["omniauth.error.strategy"]&.name,
+          origin: request.env["omniauth.origin"],
+          uid: try_to_extract_user_uid,
+        },
       },
     )
 

--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -33,6 +33,7 @@ class OmniauthController < Devise::OmniauthCallbacksController
       contexts: {
         "OmniAuth" => {
           error_type: try_to_extract_error_type.to_s,
+          error: request.env["omniauth.error"].inspect,
           strategy: request.env["omniauth.error.strategy"]&.name,
           origin: request.env["omniauth.origin"],
           uid: try_to_extract_user_uid,


### PR DESCRIPTION
### Context

To find out the type of Omniauth error, we currently have to cross reference the logs


### Changes proposed in this pull request
 
Send omniauth error type to Sentry

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
