### PR TITLE
Prevent double-click on Sign in buttons

### DIFF
--- a/app/components/govuk_component/continue_button_component.rb
+++ b/app/components/govuk_component/continue_button_component.rb
@@ -1,7 +1,7 @@
 class GovukComponent::ContinueButtonComponent < GovukComponent::Base
   BUTTON_ATTRIBUTES = {
     draggable: "false",
-    data: { module: "govuk-button" },
+    data: { module: "govuk-button", prevent_double_click: true },
   }.freeze
 
   LINK_ATTRIBUTES = BUTTON_ATTRIBUTES.merge({ role: "button" }).freeze


### PR DESCRIPTION
### Context

Attempts to resolve CSRF Sentry errors 

`Error Omniauth login failure (csrf_detected) (RuntimeError)`
### Changes proposed in this pull request

Prevent double clicking the Login button.

https://design-system.service.gov.uk/components/button/
"Stop users from accidentally sending information more than once"

To reproduce:
Click the Sign in button multiple times.
Authenticate with Teacher Auth
You should see an error and a Sentry alert

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
