### PR TITLE
Fix translation error on applications#show

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -801,12 +801,7 @@ en:
     'yes': 'Yes'
     'no': 'No'
     change: Change
-  admin:
-    layout:
-    applications:
-      show:
-    users:
-      show:
+  course:
     outcome:
       passed_html: <a href="/certificates" class="govuk-link">Download your certificate</a>
   funding_details:


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#575

A previous merge of the locale file has caused an a translation error to be raised when someone has passed their course

### Changes proposed in this pull request

Update the locale file to fix