### PR TITLE
Redirect to root path if no current user and not start or closed step

### DIFF
--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -1,5 +1,6 @@
 class RegistrationWizardController < PublicPagesController
   before_action :registration_closed
+  before_action :redirect_to_start_if_signed_out
   before_action :set_wizard
   before_action :set_form
   before_action :check_duplicate_applications, only: %i[update]
@@ -71,6 +72,13 @@ private
 
     redirect_to root_path if store.except("current_user_id").blank? &&
       !params[:step].in?(RegistrationWizard::VALID_BLANK_STEPS)
+  end
+
+  def redirect_to_start_if_signed_out
+    return if current_user.present?
+    return if params[:step].to_s.in?(%w[start closed])
+
+    redirect_to root_path
   end
 
   def redirect_to_course_start_date

--- a/spec/controllers/registration_wizard_controller_spec.rb
+++ b/spec/controllers/registration_wizard_controller_spec.rb
@@ -51,6 +51,26 @@ RSpec.describe RegistrationWizardController do
     it { is_expected.to have_http_status :success }
     it { expect(page_response.headers).to include "cache-control" => "no-store" }
 
+    context "when the user session is stale" do
+      before { session["user_id"] = "999999" }
+
+      it "redirects registration steps to the start page" do
+        make_request
+
+        expect(response).to redirect_to(root_path)
+      end
+
+      context "when loading the start page" do
+        let(:make_request) { get(:show, params: { step: "start" }) }
+
+        it "renders the start page" do
+          make_request
+
+          expect(response).to be_successful
+        end
+      end
+    end
+
     context "when application already submitted for course" do
       let(:course) { Course.reception || create(:course) }
       let(:course_cohort) { CourseCohort.next_open_for(course:) || create(:course_cohort, course:) }
@@ -86,6 +106,16 @@ RSpec.describe RegistrationWizardController do
     let(:make_request) { patch :update, params: { step: "course-start-date", registration_wizard: wizard_params } }
 
     it_behaves_like "it redirects on missing mandatory institution"
+
+    context "when the user session is stale" do
+      before { session["user_id"] = "999999" }
+
+      it "redirects to the start page" do
+        make_request
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
 
     it "persists data to session" do
       make_request


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#576

If a user is in the registration flow and the page times out you get signed out.
However if they revisit/reload the last page they were on, then they get an error.

Sentry bug ID 7554981894

### Changes proposed in this pull request

Redirect the user to the start/root path if they are signed out and not on the start or closed step