### PR TITLE
Add defensive code around the institution picker and remove unused param

### DIFF
--- a/app/javascript/institution-picker.js
+++ b/app/javascript/institution-picker.js
@@ -11,8 +11,13 @@ function institutionPicker (options) {
   })
 }
 
-async function fetchSource(lookupPath, query, location) {
-  const res  = await fetch( `/${lookupPath}.json?location=${encodeURIComponent(location)}&name=${encodeURIComponent(query)}` );
+async function fetchSource(lookupPath, query) {
+  const res  = await fetch(`/${lookupPath}.json?name=${encodeURIComponent(query)}` );
+
+  if (!res.ok) {
+    return [];
+  }
+
   const data = await res.json();
   return data;
 }
@@ -47,11 +52,13 @@ institutionPicker.enhanceSelectElement = (configurationOptions) => {
     }
   }
 
-  const location = configurationOptions.selectElement.getAttribute("data-institution-location")
-
   configurationOptions.source = debounce( async ( query, populateResults ) => {
-    const res = await fetchSource(configurationOptions.lookupPath, query, location);
-    populateResults(res);
+    try {
+      const res = await fetchSource(configurationOptions.lookupPath, query);
+      populateResults(res);
+    } catch (_) {
+      populateResults([]);
+    }
   }, 300 )
 
   if (configurationOptions.name === undefined) configurationOptions.name = ''


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#580

There's a JS error in Sentry https://dfe-teacher-services.sentry.io/issues/7596165086
which I think is caused by a fetch failing when looking up a school name

### Changes proposed in this pull request

- Add defensive code around the institution picker
- Remove unused param to remove any ambiguity around what the server URL is