### PR TITLE
Attempt to prevent sign in double click

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -15,10 +15,8 @@ import * as GOVUKFrontend from 'govuk-frontend'
 
 window.GOVUKFrontend = GOVUKFrontend;
 
-window.onload = function init() {
-  window.GOVUKFrontend.initAll();
-  HMRCFrontend.initAll();
-};
+GOVUKFrontend.initAll();
+HMRCFrontend.initAll();
 
 if (document.querySelector('[data-picker="school"]')) {
   institutionPicker.enhanceSelectElement({


### PR DESCRIPTION
### Context

We recently deployed a fix with `prevent_double_click` on the Log in button, but if
a user has a very slow connection, the javascript might not be loaded, so the double
click protection doesn't work 


### Changes proposed in this pull request

Remove window.onload for GovUK JS init

`Application.js` is loaded with `defer` so JS scripts
should run when the HTML is parsed, and
before `window.onload`

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
