### PR TITLE
[578] Fix  change provider bug

### DIFF
--- a/app/models/application_lead_provider.rb
+++ b/app/models/application_lead_provider.rb
@@ -2,8 +2,6 @@ class ApplicationLeadProvider < ApplicationRecord
   belongs_to :application
   belongs_to :lead_provider
 
-  validates :lead_provider_id, uniqueness: { scope: :application_id }
-
   scope :current, -> { where(current: true) }
   scope :previous, -> { where(current: false) }
 

--- a/app/models/application_lead_provider.rb
+++ b/app/models/application_lead_provider.rb
@@ -2,6 +2,13 @@ class ApplicationLeadProvider < ApplicationRecord
   belongs_to :application
   belongs_to :lead_provider
 
+  validates :lead_provider_id,
+            uniqueness: {
+              scope: :application_id,
+              conditions: -> { where(current: true) },
+            },
+            if: :current?
+
   scope :current, -> { where(current: true) }
   scope :previous, -> { where(current: false) }
 

--- a/db/migrate/20260707072100_remove_unique_index_from_application_lead_providers.rb
+++ b/db/migrate/20260707072100_remove_unique_index_from_application_lead_providers.rb
@@ -1,0 +1,17 @@
+class RemoveUniqueIndexFromApplicationLeadProviders < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :application_lead_providers,
+                 name: "idx_on_application_id_lead_provider_id_f38fa4893f",
+                 algorithm: :concurrently
+  end
+
+  def down
+    add_index :application_lead_providers,
+              %i[application_id lead_provider_id],
+              unique: true,
+              name: "idx_on_application_id_lead_provider_id_f38fa4893f",
+              algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260707073000_add_current_unique_index_to_application_lead_providers.rb
+++ b/db/migrate/20260707073000_add_current_unique_index_to_application_lead_providers.rb
@@ -1,0 +1,12 @@
+class AddCurrentUniqueIndexToApplicationLeadProviders < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :application_lead_providers,
+              %i[lead_provider_id application_id],
+              unique: true,
+              where: "current = true",
+              name: "idx_unique_current_application_lead_providers",
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_07_072100) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_07_073000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -117,6 +117,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_07_072100) do
     t.datetime "unassigned_at"
     t.datetime "updated_at", null: false
     t.index ["application_id"], name: "index_application_lead_providers_on_application_id"
+    t.index ["lead_provider_id", "application_id"], name: "idx_unique_current_application_lead_providers", unique: true, where: "(current = true)"
     t.index ["lead_provider_id"], name: "index_application_lead_providers_on_lead_provider_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_10_105000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_07_072100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -116,7 +116,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_105000) do
     t.bigint "lead_provider_id"
     t.datetime "unassigned_at"
     t.datetime "updated_at", null: false
-    t.index ["application_id", "lead_provider_id"], name: "idx_on_application_id_lead_provider_id_f38fa4893f", unique: true
     t.index ["application_id"], name: "index_application_lead_providers_on_application_id"
     t.index ["lead_provider_id"], name: "index_application_lead_providers_on_lead_provider_id"
   end

--- a/spec/models/application_lead_provider_spec.rb
+++ b/spec/models/application_lead_provider_spec.rb
@@ -9,14 +9,13 @@ RSpec.describe ApplicationLeadProvider, type: :model do
   end
 
   describe "validations" do
-    describe "uniqueness" do
-      subject { described_class.new }
+    it "allows the same lead provider to be assigned to an application more than once" do
+      application = create(:application)
+      lead_provider = application.lead_provider
 
-      before { create(:application_lead_provider) }
+      application_lead_provider = build(:application_lead_provider, application:, lead_provider:)
 
-      it "lead provider must be unique for a given application" do
-        expect(subject).to validate_uniqueness_of(:lead_provider_id).scoped_to(:application_id)
-      end
+      expect(application_lead_provider).to be_valid
     end
   end
 end

--- a/spec/models/application_lead_provider_spec.rb
+++ b/spec/models/application_lead_provider_spec.rb
@@ -17,5 +17,15 @@ RSpec.describe ApplicationLeadProvider, type: :model do
 
       expect(application_lead_provider).to be_valid
     end
+
+    it "does not allow the same lead provider to be current for an application more than once" do
+      application = create(:application)
+      lead_provider = application.lead_provider
+
+      application_lead_provider = build(:application_lead_provider, :current, application:, lead_provider:)
+
+      expect(application_lead_provider).to be_invalid
+      expect(application_lead_provider.errors[:lead_provider_id]).to include("has already been taken")
+    end
   end
 end

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -34,6 +34,63 @@ RSpec.describe "Application endpoints", type: :request do
           expect(JSON.parse(response.body)["data"]["attributes"]["status"]).to eq(application.status)
         end
       end
+
+      describe "when viewing as a provider with previous and current assignments" do
+        let(:another_old_lead_provider) { create(:lead_provider) }
+
+        before do
+          # Set up the data so the current_lead_provider was also assigned once before
+          # another_old_lead_provider was assigned, and then once again current_lead_provider
+          # was once again asssigned.
+          #
+          # This creates the history as changed lead provider like this:
+          # current_lead_provider --> another_old_lead_provider --> current_lead_provider
+          #
+          # So application_lead_providers table looks like (newest first):
+          # |lead_provider|current|
+          # |Current LP|true
+          # |Another old LP|false
+          # |Current LP|false
+          create(:application_lead_provider, :unassigned, application:, lead_provider: current_lead_provider)
+          create(:application_lead_provider, :unassigned, application:, lead_provider: another_old_lead_provider)
+        end
+
+        it "can see the application with a pending status" do
+          api_get(api_v1_application_path(application.ecf_id), lead_provider: current_lead_provider)
+
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)["data"]["attributes"]["status"]).to eq(Application::PENDING)
+        end
+      end
+
+      describe "when viewing as a provider with multiple previous assignments" do
+        let(:another_old_lead_provider) { create(:lead_provider) }
+
+        # Set up the data so the another_old_lead_provider was assigned a couple of times,
+        # but is not the current provider.
+        #
+        # This creates the history as changed lead provider like this:
+        # another_old_lead_provider --> current_lead_provider -->  another_old_lead_provider --> current_lead_provider
+        #
+        # So application_lead_providers table looks like (newest first):
+        # |lead_provider|current|
+        # |Current LP|true
+        # |Another old LP|false
+        # |Current LP|false
+        # |Another old LP|false
+        before do
+          create(:application_lead_provider, :unassigned, application:, lead_provider: another_old_lead_provider)
+          create(:application_lead_provider, :unassigned, application:, lead_provider: current_lead_provider)
+          create(:application_lead_provider, :unassigned, application:, lead_provider: another_old_lead_provider)
+        end
+
+        it "can see the application with a reassigned status" do
+          api_get(api_v1_application_path(application.ecf_id), lead_provider: another_old_lead_provider)
+
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)["data"]["attributes"]["status"]).to eq(Application::REASSIGNED)
+        end
+      end
     end
   end
 

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -38,19 +38,20 @@ RSpec.describe "Application endpoints", type: :request do
       describe "when viewing as a provider with previous and current assignments" do
         let(:another_old_lead_provider) { create(:lead_provider) }
 
+        # Set up the data so current_lead_provider was assigned, replaced, and
+        # then assigned again as the current provider.
+        #
+        # Assignment history:
+        # current_lead_provider -> another_old_lead_provider -> current_lead_provider
+        #
+        # application_lead_providers, newest first:
+        #
+        # | lead_provider             | current |
+        # |---------------------------|---------|
+        # | current_lead_provider     | true    |
+        # | another_old_lead_provider | false   |
+        # | current_lead_provider     | false   |
         before do
-          # Set up the data so the current_lead_provider was also assigned once before
-          # another_old_lead_provider was assigned, and then once again current_lead_provider
-          # was once again asssigned.
-          #
-          # This creates the history as changed lead provider like this:
-          # current_lead_provider --> another_old_lead_provider --> current_lead_provider
-          #
-          # So application_lead_providers table looks like (newest first):
-          # |lead_provider|current|
-          # |Current LP|true
-          # |Another old LP|false
-          # |Current LP|false
           create(:application_lead_provider, :unassigned, application:, lead_provider: current_lead_provider)
           create(:application_lead_provider, :unassigned, application:, lead_provider: another_old_lead_provider)
         end
@@ -66,18 +67,20 @@ RSpec.describe "Application endpoints", type: :request do
       describe "when viewing as a provider with multiple previous assignments" do
         let(:another_old_lead_provider) { create(:lead_provider) }
 
-        # Set up the data so the another_old_lead_provider was assigned a couple of times,
+        # Set up the data so another_old_lead_provider was assigned more than once,
         # but is not the current provider.
         #
-        # This creates the history as changed lead provider like this:
-        # another_old_lead_provider --> current_lead_provider -->  another_old_lead_provider --> current_lead_provider
+        # Assignment history:
+        # another_old_lead_provider -> current_lead_provider -> another_old_lead_provider -> current_lead_provider
         #
-        # So application_lead_providers table looks like (newest first):
-        # |lead_provider|current|
-        # |Current LP|true
-        # |Another old LP|false
-        # |Current LP|false
-        # |Another old LP|false
+        # application_lead_providers, newest first:
+        #
+        # | lead_provider             | current |
+        # |---------------------------|---------|
+        # | current_lead_provider     | true    |
+        # | another_old_lead_provider | false   |
+        # | current_lead_provider     | false   |
+        # | another_old_lead_provider | false   |
         before do
           create(:application_lead_provider, :unassigned, application:, lead_provider: another_old_lead_provider)
           create(:application_lead_provider, :unassigned, application:, lead_provider: current_lead_provider)

--- a/spec/services/applications/change_lead_provider_spec.rb
+++ b/spec/services/applications/change_lead_provider_spec.rb
@@ -10,13 +10,11 @@ RSpec.describe Applications::ChangeLeadProvider, type: :model do
   subject(:service) { described_class.new(application:, new_provider:) }
 
   describe ".call" do
-    before do
+    it do
       travel_to(new_assignment_date) do
         subject.call
       end
-    end
 
-    it do
       application.assignment = old_application_lead_provider
       expect(application.reload.lead_provider).to eq(new_provider)
       expect(application.assigned_at).to be_within(5.seconds).of(new_assignment_date)
@@ -40,6 +38,40 @@ RSpec.describe Applications::ChangeLeadProvider, type: :model do
 
       it do
         expect(subject).to have_error(:base, :provider_must_be_different)
+      end
+    end
+
+    context "when changing back to a previous provider" do
+      let(:original_provider) { create(:lead_provider) }
+      let(:current_provider) { create(:lead_provider) }
+      let(:new_provider) { original_provider }
+      let(:application) { create(:application, :pending, lead_provider: current_provider) }
+
+      before do
+        create(
+          :application_lead_provider,
+          :unassigned,
+          application:,
+          lead_provider: original_provider,
+        )
+      end
+
+      it "allows adding the original provider back to being current" do
+        expect(service).to be_valid
+
+        expect { service.call }
+          .to change(application.application_lead_providers, :count).by(1)
+
+        application.reload
+
+        expect(application.lead_provider).to eq(original_provider)
+        expect(application.application_lead_providers.current.count).to eq(1)
+        expect(application.current_application_lead_provider.lead_provider).to eq(original_provider)
+        expect(application.current_application_lead_provider.unassigned_at).to be_nil
+        expect(application.application_lead_providers.previous.pluck(:lead_provider_id)).to contain_exactly(
+          original_provider.id,
+          current_provider.id,
+        )
       end
     end
   end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#578

After registering, if you change provider from "Lead Provider 1" to "Lead Provider 2" and then bacl to "Lead Provider 1" you get an error.

### Changes proposed in this pull request

- Allow multiple lead providers to be added to application_lead_providers
- Alter the validation and unique id on application_lead_providers so that it is scoped to lead_provider_id/current:true
- Add further test coverage
- 
## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [x] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
