### PR TITLE
[521] Fix incorrect funding text when previously funded

### DIFF
--- a/app/views/applications/applications/_funding_details.html.erb
+++ b/app/views/applications/applications/_funding_details.html.erb
@@ -11,7 +11,6 @@
           concat render("in_review_funding_details", application: @application)
         else
           concat tag.p(scholarship_funding_eligibility(application), class: "govuk-!-margin-top-2 govuk-!-margin-bottom-0")
-          concat tag.p(I18n.t("funding_details.ineligible_message"), class: "govuk-!-margin-top-2 govuk-!-margin-bottom-0")
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -814,15 +814,17 @@ en:
       class="govuk-link">targeted support funding</a> payment to support you to do
       this NPQ.
     ineligible_message: This means that you would need to pay for the course another way.
-    ineligible_setting: You're not eligible for scholarship funding as you
-      do not work in one of the eligible settings, such as state-funded schools.
+    ineligible_setting: <p>You're not eligible for scholarship funding as you
+      do not work in one of the eligible settings, such as state-funded schools.</p>
+      <p>This means that you would need to pay for the course another way.</p>
     inside_catchment: You're not eligible for scholarship funding as you do
       not work in England.
     no_Ofsted: You're not eligible for schools funding as you or your employer
       is not registered on the Ofsted Early Years Register or with a registered Childminder
       Agency.
-    previously_funded: You're not eligible for scholarship funding as you
-      do not work in one of the eligible settings, such as state-funded schools.
+    previously_funded: <p>You're not eligible for scholarship funding because
+      you have previously been funded for this course.</p>
+      <p>You can pay for the course another way.</p>
     not_eligible_ehco: You're not eligible for scholarship funding for %{course_name}.
     not_a_pp50: You're not eligible for scholarship funding for the NPQ as
       your workplace is not in the <a class="govuk-link" href="https://www.gov.uk/guidance/funding-for-national-professional-qualifications-npqs#scholarship-funding-for-autumn-2024">list

--- a/spec/views/applications/applications/_funding_details.html.erb_spec.rb
+++ b/spec/views/applications/applications/_funding_details.html.erb_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+RSpec.describe "applications/applications/_funding_details.html.erb", type: :view do
+  subject(:rendered_partial) do
+    render partial: "applications/applications/funding_details", locals: { application: }
+    Capybara.string(rendered)
+  end
+
+  let(:lead_provider) { create(:lead_provider, name: "Test Provider") }
+  let(:application) do
+    create(
+      :application,
+      :for_cohort_starting_on,
+      lead_provider:,
+      eligible_for_funding:,
+      funding_eligiblity_status_code:,
+      raw_application_data:,
+      registration_starts_at: Date.new(2025, 4, 1),
+    )
+  end
+  let(:eligible_for_funding) { false }
+  let(:funded) { false }
+  let(:funding_eligiblity_status_code) { FundingEligibility::INELIGIBLE_SETTING }
+  let(:raw_application_data) { {} }
+
+  before do
+    assign(:application, application)
+  end
+
+  context "when the application is eligible for scholarship funding" do
+    let(:eligible_for_funding) { true }
+    let(:funding_eligiblity_status_code) { FundingEligibility::FUNDED_ELIGIBILITY_RESULT }
+
+    it "shows the eligible funding details" do
+      expect(rendered_partial).to have_css(".govuk-summary-card__title", text: "Funding details")
+      expect(rendered_partial).to have_css(".govuk-tag", text: "Eligible")
+      expect(rendered_partial).to have_text("if Test Provider confirms that you have a scholarship funded space")
+      expect(rendered_partial).not_to have_text("Course funding")
+    end
+  end
+
+  context "when scholarship eligibility needs review" do
+    let(:raw_application_data) do
+      {
+        "teacher_catchment" => "england",
+        "referred_by_return_to_teaching_adviser" => "yes",
+      }
+    end
+
+    before do
+      application.update!(
+        funding_choice: nil,
+        teacher_catchment: "england",
+        referred_by_return_to_teaching_adviser: "yes",
+      )
+    end
+
+    it "shows the in-review funding details" do
+      expect(rendered_partial).to have_css(".govuk-tag", text: "Not eligible")
+      expect(rendered_partial).to have_text("The Department for Education (DfE) will review your registration")
+      expect(rendered_partial).to have_text("Contact Test Provider to check if they can offer you a scholarship-funded place")
+    end
+  end
+
+  context "when the application is not eligible because of setting" do
+    let(:raw_application_data) { { "funding" => "self" } }
+
+    it "shows the course funding row with ineligible_setting text" do
+      expect(rendered_partial).to have_css(".govuk-tag", text: "Not eligible")
+      expect(rendered_partial).to have_text("Course funding")
+
+      expected_funding_text = ActionView::Base.full_sanitizer.sanitize(I18n.t("funding_details.ineligible_setting"))
+      expect(rendered_partial).to have_text(expected_funding_text)
+    end
+  end
+
+  context "when the application is not eligible because of being previously funded" do
+    let(:raw_application_data) { { "funding" => "self" } }
+
+    before do
+      # An application funded on a different course
+      create(:application,
+             user: application.user,
+             eligible_for_funding: true,
+             funding_eligiblity_status_code: "funded",
+             status: Application::COMPLETED,
+             course_cohort: create(:course_cohort,
+                                   course: create(:course),
+                                   cohort: application.course_cohort.cohort))
+    end
+
+    it "shows the course funding row with ineligible_setting text" do
+      expect(rendered_partial).to have_css(".govuk-tag", text: "Not eligible")
+      expect(rendered_partial).to have_text("Course funding")
+
+      expected_funding_text = ActionView::Base.full_sanitizer.sanitize(I18n.t("funding_details.previously_funded"))
+      expect(rendered_partial).to have_text(expected_funding_text)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#563

When previously funded for a course, you are not eligible for funding.
The message you see on the applications#show route on the funding details section incorrectly shows the text for an ineligible setting

### Changes proposed in this pull request

Update the locale file to the correct text, add a view spec to ensure correct