### PR TITLE
API Test tools - send X-With-Server-Date header for started/completed declarations

### DIFF
--- a/app/services/api_tests/call_api.rb
+++ b/app/services/api_tests/call_api.rb
@@ -2,25 +2,26 @@ require Rails.root.join("db/seeds/base/constants")
 
 module APITests
   module CallAPI
-    def api_post(lead_provider:, path:, body:)
-      call_api(lead_provider:, path:, body:, method: :post)
+    def api_post(lead_provider:, path:, body:, with_server_date: nil)
+      call_api(lead_provider:, path:, body:, method: :post, with_server_date:)
     end
 
-    def api_put(lead_provider:, path:, body:)
-      call_api(lead_provider:, path:, body:, method: :put)
+    def api_put(lead_provider:, path:, body:, with_server_date: nil)
+      call_api(lead_provider:, path:, body:, method: :put, with_server_date:)
     end
 
-    def api_get(lead_provider:, path:)
-      call_api(lead_provider:, path:, body: nil, method: :get)
+    def api_get(lead_provider:, path:, with_server_date: nil)
+      call_api(lead_provider:, path:, body: nil, method: :get, with_server_date:)
     end
 
-    def call_api(lead_provider:, path:, body:, method:)
+    def call_api(lead_provider:, path:, body:, method:, with_server_date: nil)
       api_token = token_for(lead_provider:)
 
       headers = {
         "Authorization" => "Bearer #{api_token}",
         "Content-Type" => "application/json",
       }
+      headers["X-With-Server-Date"] = with_server_date if with_server_date.present?
 
       HTTParty.send(method, build_url(path:), body:, headers:)
     end

--- a/app/services/api_tests/completed_declaration.rb
+++ b/app/services/api_tests/completed_declaration.rb
@@ -27,7 +27,7 @@ module APITests
 
       path = completed_declaration_api_v1_application_path(application.ecf_id)
 
-      api_post(lead_provider: application.lead_provider, path:, body:)
+      api_post(lead_provider: application.lead_provider, path:, body:, with_server_date: declaration_date)
     end
 
   private

--- a/app/services/api_tests/started_declaration.rb
+++ b/app/services/api_tests/started_declaration.rb
@@ -25,7 +25,7 @@ module APITests
 
       path = started_declaration_api_v1_application_path(application.ecf_id)
 
-      api_post(lead_provider: application.lead_provider, path:, body:)
+      api_post(lead_provider: application.lead_provider, path:, body:, with_server_date: declaration_date)
     end
 
   private

--- a/spec/services/api_tests/started_declaration_spec.rb
+++ b/spec/services/api_tests/started_declaration_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe APITests::StartedDeclaration, type: :model do
         headers: hash_including(
           "Authorization" => "Bearer test-token",
           "Content-Type" => "application/json",
+          "X-With-Server-Date" => declaration_date.utc.iso8601,
         ),
       )
     end
@@ -73,6 +74,7 @@ RSpec.describe APITests::StartedDeclaration, type: :model do
           headers: hash_including(
             "Authorization" => "Bearer test-token",
             "Content-Type" => "application/json",
+            "X-With-Server-Date" => declaration_date.utc.iso8601,
           ),
         )
       end
@@ -94,6 +96,7 @@ RSpec.describe APITests::StartedDeclaration, type: :model do
           headers: hash_including(
             "Authorization" => "Bearer test-token",
             "Content-Type" => "application/json",
+            "X-With-Server-Date" => declaration_date.utc.iso8601,
           ),
         )
       end


### PR DESCRIPTION
### Context

When using the API Test tools the started/completed declarations can fail because of validation rules around the cohort/schedule.
This makes use of the X-With-Server-Date  header in order to test declarations.
