### PR TITLE
[594] Fix bug in change provider where a provider with multiple assig…

### DIFF
--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -84,7 +84,10 @@ module API
               application: [:user,
                             :institution,
                             { course_cohort: %i[course cohort schedule] }],
-            ).find_by!(application: { ecf_id: })
+            )
+            .where(application: { ecf_id: })
+            .order(current: :desc, updated_at: :desc)
+            .first!
       end
 
       def filter_params

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -211,6 +211,28 @@ RSpec.describe "Application endpoints", type: :request do
         expect(response).to be_forbidden
       end
     end
+
+    context "when an application is reassigned back to the original provider" do
+      let(:original_lead_provider) { current_lead_provider }
+      let(:intermediate_lead_provider) { create(:lead_provider) }
+      let(:application) { create(:application, :pending, lead_provider: original_lead_provider) }
+      let(:path) { accept_api_v1_application_path(ecf_id: application.ecf_id) }
+      let(:attributes) { { funded_place: false } }
+      let(:params) { { data: { attributes: } } }
+
+      before do
+        application.current_application_lead_provider.update!(current: false, unassigned_at: 2.days.ago)
+        create(:application_lead_provider, :unassigned, application:, lead_provider: intermediate_lead_provider)
+        create(:application_lead_provider, :current, application:, lead_provider: original_lead_provider)
+      end
+
+      it "allows the current provider to accept the application" do
+        api_put(path, lead_provider: original_lead_provider, params:)
+
+        expect(response).to have_http_status(:ok)
+        expect(application.reload.status).to eq(Application::ACCEPTED)
+      end
+    end
   end
 
   describe "PUT /api/v1/applications/:ecf_id/reject" do


### PR DESCRIPTION
…nments cannot accept via the API

### Context

Fixes DFE-Digital/teacher-training-entitlement-board#594

When a participant changes its providers multiple times
the API :: V1 :: ApplicationController is not able to retrieve the correct application_lead_provider

### Changes proposed in this pull request

Fix the query so that the most recent application_lead_provider entry is found for a provider

## Checklists:

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [X] API