### PR TITLE
Set assigned_at when creating application_lead_provider

### DIFF
--- a/app/services/handle_submission_for_store.rb
+++ b/app/services/handle_submission_for_store.rb
@@ -9,7 +9,7 @@ class HandleSubmissionForStore
     ActiveRecord::Base.transaction do
       @application = user.applications.create!(
         course_cohort:,
-        application_lead_providers: [ApplicationLeadProvider.new(current: true, lead_provider_id: store["lead_provider_id"])],
+        application_lead_providers: [ApplicationLeadProvider.new(current: true, lead_provider_id: store["lead_provider_id"], assigned_at: Time.zone.now)],
         institution: (institution_from_store if inside_catchment?),
         ukprn:,
         eligible_for_funding: funding_eligibility_service.funded?,

--- a/lib/tasks/backfill_assigned_at.rake
+++ b/lib/tasks/backfill_assigned_at.rake
@@ -1,7 +1,7 @@
 namespace :assignments do
   desc "update application lead_provider assigned_at"
   task update_assigned_at: :environment do
-    ApplicationLeadProvider.find_each do |alp|
+    ApplicationLeadProvider.where(assigned_at: nil).find_each do |alp|
       alp.assigned_at ||= alp.created_at
       alp.save!
     end

--- a/lib/tasks/backfill_assigned_at.rake
+++ b/lib/tasks/backfill_assigned_at.rake
@@ -2,7 +2,7 @@ namespace :assignments do
   desc "update application lead_provider assigned_at"
   task update_assigned_at: :environment do
     ApplicationLeadProvider.find_each do |alp|
-      alp.assigned_at ||= alp.application&.created_at
+      alp.assigned_at ||= alp.created_at
       alp.save!
     end
   end

--- a/lib/tasks/backfill_assigned_at.rake
+++ b/lib/tasks/backfill_assigned_at.rake
@@ -1,0 +1,9 @@
+namespace :assignments do
+  desc "update application lead_provider assigned_at"
+  task update_assigned_at: :environment do
+    ApplicationLeadProvider.find_each do |alp|
+      alp.assigned_at ||= alp.application&.created_at
+      alp.save!
+    end
+  end
+end

--- a/spec/services/handle_submission_for_store_spec.rb
+++ b/spec/services/handle_submission_for_store_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe HandleSubmissionForStore do
         expect(user.applications.reload.count).to eq 1
         last_application = user.applications.last
         expect(last_application.lead_provider).to eq(lead_provider)
+        expect(last_application.application_lead_providers.first.assigned_at).to be_present
         expect(stable_as_json(last_application)).to match({
           "course_cohort_id" => course_cohort.id,
           "ecf_id" => last_application.ecf_id,


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#595

When an application is submitted, the associated application_lead_provider.assigned_at should have the application.created_at date set

### Changes proposed in this pull request

- add assigned_at when an application is submitted 
- after deploy, run the rake task `assignments:update_assigned_at`

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
