### PR TITLE
[596] Update application#updated_at when changing provider

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -133,6 +133,10 @@ class Application < ApplicationRecord
   validate :funded_place_nil_for_cohort_with_ineligible_for_funding_cap
   validate :eligible_for_funded_place
 
+  def lead_provider=(new_provider)
+    change_provider!(to: new_provider)
+  end
+
   def change_provider!(to:)
     return if to == lead_provider
 
@@ -147,7 +151,7 @@ class Application < ApplicationRecord
       current: true,
       assigned_at: timestamp,
     )
-    touch
+    touch_later
   end
 
   def assigned_at

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -133,8 +133,8 @@ class Application < ApplicationRecord
   validate :funded_place_nil_for_cohort_with_ineligible_for_funding_cap
   validate :eligible_for_funded_place
 
-  def lead_provider=(new_provider)
-    return if new_provider == lead_provider
+  def change_provider!(to:)
+    return if to == lead_provider
 
     timestamp = Time.zone.now
     application_lead_providers.current.update_all(
@@ -143,10 +143,11 @@ class Application < ApplicationRecord
       unassigned_at: timestamp,
     )
     application_lead_providers.create!(
-      lead_provider: new_provider,
+      lead_provider: to,
       current: true,
       assigned_at: timestamp,
     )
+    touch
   end
 
   def assigned_at

--- a/app/services/applications/change_lead_provider.rb
+++ b/app/services/applications/change_lead_provider.rb
@@ -18,7 +18,7 @@ module Applications
       return unless valid?
 
       Application.transaction do
-        @application.update!(lead_provider: @new_provider)
+        @application.change_provider!(to: @new_provider)
         @application.application_events.create!(
           event: :changed_provider,
           metadata: { reason: }.compact,

--- a/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
+++ b/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
@@ -558,7 +558,7 @@ module ValidTestDataGenerators
 
     def change_provider(application:)
       new_provider = LeadProvider.where.not(id: @lead_provider.id).order("RANDOM()").first
-      application.update!(lead_provider: new_provider)
+      application.change_provider!(to: new_provider)
     end
 
     def statements_setup(course_cohort:)

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -752,7 +752,7 @@ RSpec.describe Application do
       application.update!(updated_at: 2.days.ago)
 
       expect { application.change_provider!(to: another_lead_provider) }
-        .to change { application.reload.updated_at }
+        .to(change { application.reload.updated_at })
     end
 
     it "does nothing when setting the same lead provider" do
@@ -764,5 +764,4 @@ RSpec.describe Application do
       expect(application.application_lead_providers.current.count).to eq(1)
     end
   end
-
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -748,11 +748,10 @@ RSpec.describe Application do
       expect(application.reload.lead_provider).to eq(another_lead_provider)
     end
 
-    it "touches the application" do
-      application.update!(updated_at: 2.days.ago)
+    it "touches the application later" do
+      expect(application).to receive(:touch_later).and_call_original
 
-      expect { application.change_provider!(to: another_lead_provider) }
-        .to(change { application.reload.updated_at })
+      application.change_provider!(to: another_lead_provider)
     end
 
     it "does nothing when setting the same lead provider" do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -712,7 +712,7 @@ RSpec.describe Application do
     end
   end
 
-  describe "#lead_provider=" do
+  describe "#change_provider!" do
     let(:lead_provider) { create(:lead_provider) }
     let(:another_lead_provider) { create(:lead_provider) }
     let(:assignment_date) { 1.day.ago }
@@ -727,7 +727,7 @@ RSpec.describe Application do
       expect(application.current_application_lead_provider.assigned_at.to_fs).to eq(assignment_date.to_fs)
       expect(application.current_application_lead_provider.unassigned_at).to be_nil
 
-      application.lead_provider = another_lead_provider
+      application.change_provider!(to: another_lead_provider)
 
       application_lead_providers = application.application_lead_providers.reload
 
@@ -748,13 +748,21 @@ RSpec.describe Application do
       expect(application.reload.lead_provider).to eq(another_lead_provider)
     end
 
+    it "touches the application" do
+      application.update!(updated_at: 2.days.ago)
+
+      expect { application.change_provider!(to: another_lead_provider) }
+        .to change { application.reload.updated_at }
+    end
+
     it "does nothing when setting the same lead provider" do
       expect {
-        application.lead_provider = lead_provider
+        application.change_provider!(to: lead_provider)
       }.not_to change(application.application_lead_providers, :count)
 
       expect(application.reload.current_application_lead_provider.lead_provider).to eq(lead_provider)
       expect(application.application_lead_providers.current.count).to eq(1)
     end
   end
+
 end

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -158,6 +158,21 @@ RSpec.describe "Application endpoints", type: :request do
         end
       end
 
+      context "when filtering by updated_since after the provider changes" do
+        let(:old_lead_provider) { create(:lead_provider) }
+        let(:new_lead_provider) { create(:lead_provider) }
+        let(:application) { create(:application, :pending, lead_provider: old_lead_provider, updated_at: 2.days.ago) }
+
+        it "includes the reassigned application for the old provider" do
+          Applications::ChangeLeadProvider.new(application:, new_provider: new_lead_provider).call
+
+          api_get(path, lead_provider: old_lead_provider, params: { filter: { updated_since: 1.hour.ago.iso8601 } })
+
+          expect(response_ids).to contain_exactly(application.ecf_id)
+          expect(JSON.parse(response.body)["data"].first["attributes"]["status"]).to eq(Application::REASSIGNED)
+        end
+      end
+
       context "with the a provider never assigned to the application" do
         it "cannot see the application" do
           api_get(path, lead_provider: create(:lead_provider))

--- a/spec/services/applications/change_lead_provider_spec.rb
+++ b/spec/services/applications/change_lead_provider_spec.rb
@@ -25,11 +25,10 @@ RSpec.describe Applications::ChangeLeadProvider, type: :model do
       expect(application.application_events.last&.reason).to eq("Changed lead provider from #{old_provider.name} to #{new_provider.name}")
     end
 
-    it "touches the application so API consumers can sync the provider change" do
-      application.update!(updated_at: 1.day.ago)
+    it "touches the application later so API consumers can sync the provider change" do
+      expect(application).to receive(:touch_later).and_call_original
 
-      expect { service.call }
-        .to(change { application.reload.updated_at })
+      service.call
     end
 
     context "when application not pending or accepted" do

--- a/spec/services/applications/change_lead_provider_spec.rb
+++ b/spec/services/applications/change_lead_provider_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Applications::ChangeLeadProvider, type: :model do
       expect(application.application_events.last&.reason).to eq("Changed lead provider from #{old_provider.name} to #{new_provider.name}")
     end
 
+    it "touches the application so API consumers can sync the provider change" do
+      application.update!(updated_at: 1.day.ago)
+
+      expect { service.call }
+        .to change { application.reload.updated_at }
+    end
+
     context "when application not pending or accepted" do
       let(:application) { create(:application, :started, lead_provider: old_provider) }
 

--- a/spec/services/applications/change_lead_provider_spec.rb
+++ b/spec/services/applications/change_lead_provider_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Applications::ChangeLeadProvider, type: :model do
       application.update!(updated_at: 1.day.ago)
 
       expect { service.call }
-        .to change { application.reload.updated_at }
+        .to(change { application.reload.updated_at })
     end
 
     context "when application not pending or accepted" do


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#596

The change provider feature currently doesn't keep the application.updated_at in sync
This prevent LP doing efficient application sync with their CRM.

### Changes proposed in this pull request

[596] Update application#updated_at when changing provider and introduce and explicit domain method

## Checklists:


### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [X] API
