### PR TITLE
Fix duplicate applications in API if changed provider multiple times …

### DIFF
--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -86,7 +86,7 @@ module API
                             { course_cohort: %i[course cohort schedule] }],
             )
             .where(application: { ecf_id: })
-            .order(current: :desc, updated_at: :desc)
+            .order(current: :desc, updated_at: :desc, id: :desc)
             .first!
       end
 

--- a/app/models/application_lead_provider.rb
+++ b/app/models/application_lead_provider.rb
@@ -11,6 +11,10 @@ class ApplicationLeadProvider < ApplicationRecord
 
   scope :current, -> { where(current: true) }
   scope :previous, -> { where(current: false) }
+  scope :preferred_per_application, lambda {
+    select("DISTINCT ON (application_id) application_lead_providers.id")
+      .order(:application_id, current: :desc, updated_at: :desc, id: :desc)
+  }
 
   delegate :user, :ecf_id, to: :application
 end

--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -9,6 +9,7 @@ module Applications
     def initialize(lead_provider:, cohort_start_years: :ignore, updated_since: :ignore, participant_ids: :ignore, status: :ignore, course_identifier: :ignore, sort: nil)
       @scope = lead_provider
                  .application_lead_providers
+                 .where(id: lead_provider.application_lead_providers.preferred_per_application)
                  .joins(:application)
                  .includes(
                    application: [:user,

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -211,6 +211,22 @@ RSpec.describe Applications::Query do
           end
         end
 
+        context "when lead provider has previous and current assignments for the application" do
+          let(:lead_provider) { current_lead_provider }
+
+          before do
+            create(:application_lead_provider, :unassigned, application:, lead_provider:)
+          end
+
+          it "only includes the application once" do
+            expect(query.applications).to eq([application])
+          end
+
+          it "returns the current assignment" do
+            expect(query.application_lead_providers).to contain_exactly(application.current_application_lead_provider)
+          end
+        end
+
         context "when lead provider is no longer the current provider" do
           let(:lead_provider) { old_lead_provider }
 
@@ -218,6 +234,21 @@ RSpec.describe Applications::Query do
             expect(application.application_lead_providers.map(&:lead_provider_id).sort)
               .to eq([current_lead_provider.id, old_lead_provider.id].sort)
             expect(query.applications).to contain_exactly(application)
+          end
+        end
+
+        context "when lead provider has multiple previous assignments for the application" do
+          let(:lead_provider) { old_lead_provider }
+          let!(:latest_previous_assignment) do
+            create(:application_lead_provider, :unassigned, application:, lead_provider:)
+          end
+
+          it "only includes the application once" do
+            expect(query.applications).to eq([application])
+          end
+
+          it "returns the latest previous assignment" do
+            expect(query.application_lead_providers).to contain_exactly(latest_previous_assignment)
           end
         end
 


### PR DESCRIPTION
…to one provider

### Context

Fixes DFE-Digital/teacher-training-entitlement-board#598

If an application changes provider multiple times to one provider they will see duplications in the applications query

### Changes proposed in this pull request

Alter Applications::Query to handle mupltipe application_lead_provider entries

## Checklists:
### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [X] API
