### PR TITLE
[596] Add rake task to update applications which have changed provider

### DIFF
--- a/lib/tasks/data_migrations/backfill_application_updated_at_from_provider_changes.rake
+++ b/lib/tasks/data_migrations/backfill_application_updated_at_from_provider_changes.rake
@@ -1,0 +1,35 @@
+namespace :data_migrations do
+  desc "Backfill application updated_at timestamps from provider change records"
+  task backfill_application_updated_at_from_provider_changes: :environment do
+    dry_run = ENV.fetch("DRY_RUN", "true") != "false"
+
+    changed_provider_applications = ApplicationLeadProvider
+      .select("application_id, MAX(updated_at) AS latest_provider_updated_at")
+      .group(:application_id)
+      .having("COUNT(*) > 1")
+
+    updated_count = 0
+    skipped_count = 0
+
+    Application
+      .joins("INNER JOIN (#{changed_provider_applications.to_sql}) latest_provider_changes ON latest_provider_changes.application_id = applications.id")
+      .select("applications.*, latest_provider_changes.latest_provider_updated_at")
+      .find_each do |application|
+        latest_provider_updated_at = application.latest_provider_updated_at
+
+        if latest_provider_updated_at <= application.updated_at
+          skipped_count += 1
+          next
+        end
+
+        puts "Application #{application.id}: #{application.updated_at} -> #{latest_provider_updated_at}"
+
+        application.update_columns(updated_at: latest_provider_updated_at) unless dry_run
+        updated_count += 1
+      end
+
+    puts "Dry run: #{dry_run}"
+    puts "#{dry_run ? 'Would update' : 'Updated'} #{updated_count} applications"
+    puts "Skipped #{skipped_count} applications already newer than their provider changes"
+  end
+end

--- a/spec/lib/tasks/data_migrations/backfill_application_updated_at_from_provider_changes_spec.rb
+++ b/spec/lib/tasks/data_migrations/backfill_application_updated_at_from_provider_changes_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe "data_migrations:backfill_application_updated_at_from_provider_changes" do
+  subject(:run_task) { Rake::Task[task_name].invoke }
+
+  let(:task_name) { "data_migrations:backfill_application_updated_at_from_provider_changes" }
+  let(:old_updated_at) { Time.zone.local(2026, 7, 1, 10, 0, 0) }
+  let(:older_provider_updated_at) { Time.zone.local(2026, 7, 2, 9, 0, 0) }
+  let(:latest_provider_updated_at) { Time.zone.local(2026, 7, 3, 12, 0, 0) }
+  let(:old_provider) { create(:lead_provider) }
+  let(:new_provider) { create(:lead_provider) }
+  let(:application) { create(:application, lead_provider: old_provider) }
+
+  before do
+    application.update_columns(updated_at: old_updated_at)
+    application.current_application_lead_provider.update_columns(updated_at: older_provider_updated_at)
+
+    create(
+      :application_lead_provider,
+      :unassigned,
+      application:,
+      lead_provider: new_provider,
+      updated_at: latest_provider_updated_at,
+    )
+  end
+
+  after do
+    ENV.delete("DRY_RUN")
+    Rake::Task[task_name].reenable
+  end
+
+  it "prints the application id and updated_at values without updating in dry-run mode" do
+    expect { run_task }
+      .to output(
+        a_string_including(
+          "Application #{application.id}: #{old_updated_at} -> #{latest_provider_updated_at}",
+          "Dry run: true",
+          "Would update 1 applications",
+        ),
+      ).to_stdout
+
+    expect(application.reload.updated_at).to eq(old_updated_at)
+  end
+
+  context "when DRY_RUN is false" do
+    before do
+      ENV["DRY_RUN"] = "false"
+    end
+
+    it "updates the application updated_at value" do
+      expect { run_task }
+        .to output(
+          a_string_including(
+            "Application #{application.id}: #{old_updated_at} -> #{latest_provider_updated_at}",
+            "Dry run: false",
+            "Updated 1 applications",
+          ),
+        ).to_stdout
+
+      expect(application.reload.updated_at).to eq(latest_provider_updated_at)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#596

### Changes proposed in this pull request

Add rake task to sync the application#updated_at to the latest changed provider 
