### PR TITLE
Add cooldown periods to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
 
   # JavaScript dependencies (package.json)
   - package-ecosystem: npm
@@ -30,6 +35,11 @@ updates:
       prefix: "chore"
       include: "scope"
     versioning-strategy: increase
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
 
   # Docker dependencies (Dockerfile)
   - package-ecosystem: docker
@@ -46,6 +56,8 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    cooldown:
+      default-days: 7
 
   # GitHub Actions dependencies
   - package-ecosystem: github-actions
@@ -62,3 +74,5 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
### Context

This is a security best practice to reduce exposure to attacks from newly compromised packages. 
Security updates are not affected and will still be raised immediately.

NPQ introduced this in the Gemfile,
https://github.com/DFE-Digital/npq-registration/blob/3bb69ad9779be7347de305028fc179fe0b845066/Gemfile#L1

But this covers all package managers, and we can still manually update a gem, if needed.

### Changes proposed in this pull request

Dependabot delays PRs for:
 - Major versions: 30 days
 - Minor versions: 7 days
 - Patch versions: 3 days
 - Security patches: 0 days

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
