### PR TITLE
Save AdminUser.email to lowercase

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -4,7 +4,15 @@ class AdminUser < ApplicationRecord
   validates :full_name, presence: true, length: { maximum: 64 }
   validates :email, presence: true, length: { maximum: 64 }
 
+  before_save :email_downcase, if: -> { email_changed? }
+
   def name_with_email
     "#{full_name} (#{email})"
+  end
+
+private
+
+  def email_downcase
+    email&.downcase!
   end
 end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -26,4 +26,14 @@ RSpec.describe AdminUser, type: :model do
 
     it { is_expected.to eq("#{admin.full_name} (#{admin.email})") }
   end
+
+  describe "#email downcase" do
+    subject(:email) { user.email }
+
+    let(:user) { build(:admin, email: "SOME@EDUCATION.GOV.UK") }
+
+    before { user.save! }
+
+    it { is_expected.to eq("some@education.gov.uk") }
+  end
 end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#601


### Changes proposed in this pull request


- when add a admin user save its email address in lower case
- search admin user by lower cased email address

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>

<!-- Message of single commit: -->