### PR TITLE
Add ClawbackDeclaration

### DIFF
--- a/app/models/clawback_declaration.rb
+++ b/app/models/clawback_declaration.rb
@@ -1,0 +1,16 @@
+# Internal declaration created when voiding a paid declaration
+# paid declaration references clawback declaration
+class ClawbackDeclaration < Declaration
+  belongs_to :paid_declaration, class_name: "Declaration"
+
+  enum :state, {
+    awaiting_clawback: "awaiting_clawback",
+    clawed_back: "clawed_back",
+  }, suffix: true
+
+  state_machine :state, initial: :awaiting_clawback do
+    event :mark_clawed_back do
+      transition %i[awaiting_clawback] => :clawed_back
+    end
+  end
+end

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -1,7 +1,7 @@
 class Declaration < ApplicationRecord
   BILLABLE_STATES = %w[eligible payable paid].freeze
   CHANGEABLE_STATES = %w[eligible submitted].freeze
-  UPLIFT_PAID_STATES = %w[paid awaiting_clawback clawed_back].freeze
+  UPLIFT_PAID_STATES = %w[paid].freeze
   COURSE_IDENTIFIERS_INELIGIBLE_FOR_UPLIFT = %w[npq-additional-support-offer npq-early-headship-coaching-offer].freeze
   VOIDABLE_STATES = %w[submitted eligible payable ineligible].freeze
   DELIVER_PARTNER_REQUIRED_FROM = 2024
@@ -23,6 +23,7 @@ class Declaration < ApplicationRecord
   belongs_to :superseded_by, class_name: "Declaration", optional: true
   belongs_to :delivery_partner, optional: true
   belongs_to :secondary_delivery_partner, class_name: "DeliveryPartner", optional: true
+  belongs_to :clawback_declaration, optional: true
   has_many :participant_outcomes, dependent: :destroy
   has_many :statement_items
   has_many :statements, through: :statement_items
@@ -60,8 +61,6 @@ class Declaration < ApplicationRecord
     paid: "paid",
     voided: "voided",
     ineligible: "ineligible",
-    awaiting_clawback: "awaiting_clawback",
-    clawed_back: "clawed_back",
   }, suffix: true
 
   state_machine :state, initial: :submitted do
@@ -79,14 +78,6 @@ class Declaration < ApplicationRecord
 
     event :mark_ineligible do
       transition %i[submitted] => :ineligible
-    end
-
-    event :mark_awaiting_clawback do
-      transition %i[paid] => :awaiting_clawback
-    end
-
-    event :mark_clawed_back do
-      transition %i[awaiting_clawback] => :clawed_back
     end
 
     event :mark_voided do

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -1,4 +1,5 @@
 class Declaration < ApplicationRecord
+  REVERTABLE_STATES = %w[ineligible voided].freeze
   BILLABLE_STATES = %w[eligible payable paid].freeze
   CHANGEABLE_STATES = %w[eligible submitted].freeze
   UPLIFT_PAID_STATES = %w[paid].freeze
@@ -57,10 +58,10 @@ class Declaration < ApplicationRecord
   enum :state, {
     submitted: "submitted",
     eligible: "eligible",
+    ineligible: "ineligible",
+    voided: "voided",
     payable: "payable",
     paid: "paid",
-    voided: "voided",
-    ineligible: "ineligible",
   }, suffix: true
 
   state_machine :state, initial: :submitted do

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -16,7 +16,9 @@ class Declaration < ApplicationRecord
   has_paper_trail ignore: [:updated_at]
 
   belongs_to :application
-  belongs_to :cohort
+  # milestone will take over cohort once transition is done
+  belongs_to :cohort, deprecated: true # DEPRECATED
+  belongs_to :milestone, optional: true
   belongs_to :lead_provider
   belongs_to :superseded_by, class_name: "Declaration", optional: true
   belongs_to :delivery_partner, optional: true

--- a/app/services/applications/revert_to_pending.rb
+++ b/app/services/applications/revert_to_pending.rb
@@ -1,7 +1,5 @@
 module Applications
   class RevertToPending
-    REVERTABLE_DECLARATION_STATES = %w[voided ineligible awaiting_clawback clawed_back].freeze
-
     include ActiveModel::Model
     include ActiveModel::Attributes
 
@@ -29,7 +27,7 @@ module Applications
   private
 
     def application_has_no_unremoveable_declarations
-      if application.declarations.where.not(state: REVERTABLE_DECLARATION_STATES).any?
+      if application.declarations.where.not(state: Declaration::REVERTABLE_STATES).any?
         errors.add :base, :pending_unremoveable_declarations
       end
     end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -135,6 +135,7 @@ shared:
     - superseded_by_id
     - lead_provider_id
     - cohort_id
+    - milestone_id
     - declaration_type
     - declaration_date
     - state

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -131,6 +131,7 @@ shared:
   :declarations:
     - id
     - ecf_id
+    - type
     - application_id
     - superseded_by_id
     - lead_provider_id
@@ -144,6 +145,8 @@ shared:
     - updated_at
     - delivery_partner_id
     - secondary_delivery_partner_id
+    - paid_declaration_id
+    - clawback_declaration_id
   :courses:
     - id
     - name

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -71,8 +71,8 @@
   :course_cohort_providers:
   - recruitment_target
   :course_cohorts:
-  - service_fee
   - participant_funding
+  - service_fee
   :contract_templates:
   - id
   - created_at
@@ -128,6 +128,8 @@
   - updated_at
   :applications:
   - raw_application_data
+  :institutions:
+  - search_vector
   :users:
   - archived_email
   - date_of_birth
@@ -160,5 +162,3 @@
   - created_at
   - key
   - updated_at
-  :institutions:
-  - search_vector

--- a/db/migrate/20260720075608_add_milestone_to_declaration.rb
+++ b/db/migrate/20260720075608_add_milestone_to_declaration.rb
@@ -1,0 +1,8 @@
+class AddMilestoneToDeclaration < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    # the foreign_key will be added later once the course_cohort has its milestones setup
+    add_reference :declarations, :milestone, null: true, index: { algorithm: :concurrently }
+  end
+end

--- a/db/migrate/20260720093804_declaration_sti.rb
+++ b/db/migrate/20260720093804_declaration_sti.rb
@@ -1,0 +1,11 @@
+class DeclarationSti < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :declarations, :type, :string
+    add_index :declarations, :type, algorithm: :concurrently
+    # reference to paid declaration that triggered the clawback declaration
+    add_reference :declarations, :paid_declaration, null: true, index: { algorithm: :concurrently }
+    add_reference :declarations, :clawback_declaration, null: true, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_17_091737) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_20_075608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -272,6 +272,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_17_091737) do
     t.bigint "delivery_partner_id"
     t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
     t.bigint "lead_provider_id", null: false
+    t.bigint "milestone_id"
     t.bigint "secondary_delivery_partner_id"
     t.enum "state", default: "submitted", null: false, enum_type: "declaration_states"
     t.enum "state_reason", enum_type: "declaration_state_reasons"
@@ -282,6 +283,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_17_091737) do
     t.index ["delivery_partner_id"], name: "index_declarations_on_delivery_partner_id"
     t.index ["ecf_id"], name: "index_declarations_on_ecf_id", unique: true
     t.index ["lead_provider_id"], name: "index_declarations_on_lead_provider_id"
+    t.index ["milestone_id"], name: "index_declarations_on_milestone_id"
     t.index ["secondary_delivery_partner_id"], name: "index_declarations_on_secondary_delivery_partner_id"
     t.index ["superseded_by_id"], name: "index_declarations_on_superseded_by_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_20_075608) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_20_093804) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -265,6 +265,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_20_075608) do
 
   create_table "declarations", force: :cascade do |t|
     t.bigint "application_id", null: false
+    t.bigint "clawback_declaration_id"
     t.bigint "cohort_id", null: false
     t.datetime "created_at", null: false
     t.datetime "declaration_date", precision: nil
@@ -273,19 +274,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_20_075608) do
     t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
     t.bigint "lead_provider_id", null: false
     t.bigint "milestone_id"
+    t.bigint "paid_declaration_id"
     t.bigint "secondary_delivery_partner_id"
     t.enum "state", default: "submitted", null: false, enum_type: "declaration_states"
     t.enum "state_reason", enum_type: "declaration_state_reasons"
     t.bigint "superseded_by_id"
+    t.string "type"
     t.datetime "updated_at", null: false
     t.index ["application_id"], name: "index_declarations_on_application_id"
+    t.index ["clawback_declaration_id"], name: "index_declarations_on_clawback_declaration_id"
     t.index ["cohort_id"], name: "index_declarations_on_cohort_id"
     t.index ["delivery_partner_id"], name: "index_declarations_on_delivery_partner_id"
     t.index ["ecf_id"], name: "index_declarations_on_ecf_id", unique: true
     t.index ["lead_provider_id"], name: "index_declarations_on_lead_provider_id"
     t.index ["milestone_id"], name: "index_declarations_on_milestone_id"
+    t.index ["paid_declaration_id"], name: "index_declarations_on_paid_declaration_id"
     t.index ["secondary_delivery_partner_id"], name: "index_declarations_on_secondary_delivery_partner_id"
     t.index ["superseded_by_id"], name: "index_declarations_on_superseded_by_id"
+    t.index ["type"], name: "index_declarations_on_type"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/factories/clawback_declarations.rb
+++ b/spec/factories/clawback_declarations.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :clawback_declaration do
+    milestone
+    cohort
+    declaration_date { milestone.acceptance_window_start_date }
+    declaration_type { milestone.declaration_type }
+    application { create(:application, :with_declaration) }
+    paid_declaration { application.declarations.first }
+    delivery_partner { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
+    lead_provider { application&.lead_provider || create(:lead_provider) }
+  end
+end

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -20,12 +20,6 @@ FactoryBot.define do
 
     after(:create) do |declaration, evaluator|
       if evaluator.statement && declaration.state != "submitted"
-        if declaration.state.in? %w[awaiting_clawback clawed_back]
-          raise ArgumentError, "Declaration state #{declaration.state} also requires paid_statement" if evaluator.paid_statement.nil?
-
-          create(:statement_item, declaration:, state: "paid", statement: evaluator.paid_statement)
-        end
-
         create(:statement_item, declaration:, state: declaration.state, statement: evaluator.statement)
       end
     end
@@ -69,10 +63,6 @@ FactoryBot.define do
 
     trait :from_ecf do
       ecf_id { SecureRandom.uuid }
-    end
-
-    trait :awaiting_clawback do
-      state { :awaiting_clawback }
     end
 
     trait :billable_or_voidable do

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     application { Application.has_been_accepted.find_by(user:, course_cohort:) || association(:application, :accepted, user:, course_cohort:) }
     lead_provider { application&.lead_provider || create(:lead_provider) }
     cohort { course_cohort.cohort }
-
+    milestone { build(:milestone) }
     delivery_partner { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
     started
     declaration_date { application.schedule.training_starts_at + 1.day }

--- a/spec/models/clawback_declaration_spec.rb
+++ b/spec/models/clawback_declaration_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe ClawbackDeclaration, type: :model do
+  subject(:clawback_declaration) { build(:clawback_declaration) }
+
+  it { is_expected.to belong_to(:paid_declaration) }
+
+  describe "enums" do
+    it {
+      expect(subject).to define_enum_for(:state)
+                           .with_values(
+                             awaiting_clawback: "awaiting_clawback",
+                             clawed_back: "clawed_back",
+                           ).backed_by_column_of_type(:enum).with_suffix
+    }
+  end
+
+  describe "state transition" do
+    let(:clawback_declaration) { create(:clawback_declaration, state:) }
+
+    describe ".mark_clawed_back" do
+      let(:state) { :awaiting_clawback }
+
+      it { expect { clawback_declaration.mark_clawed_back }.to change(clawback_declaration, :state).from("awaiting_clawback").to("clawed_back") }
+
+      context "when not awaiting_clawback" do
+        let(:state) { :clawed_back }
+
+        it { expect { clawback_declaration.mark_clawed_back! }.to raise_error(StateMachines::InvalidTransition) }
+      end
+    end
+  end
+end

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Declaration, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:application) }
     it { is_expected.to belong_to(:cohort) }
+    it { is_expected.to belong_to(:milestone).without_validating_presence }
     it { is_expected.to belong_to(:lead_provider) }
     it { is_expected.to belong_to(:superseded_by).optional }
     it { is_expected.to have_many(:participant_outcomes).dependent(:destroy) }

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Declaration, type: :model do
     it { is_expected.to have_many(:statements).through(:statement_items) }
     it { is_expected.to belong_to(:delivery_partner).without_validating_presence }
     it { is_expected.to belong_to(:secondary_delivery_partner).without_validating_presence }
+    it { is_expected.to belong_to(:clawback_declaration).without_validating_presence }
 
     context "with delivery partners" do
       subject do
@@ -268,8 +269,6 @@ RSpec.describe Declaration, type: :model do
         paid: "paid",
         voided: "voided",
         ineligible: "ineligible",
-        awaiting_clawback: "awaiting_clawback",
-        clawed_back: "clawed_back",
       ).backed_by_column_of_type(:enum).with_suffix
     }
 
@@ -339,30 +338,6 @@ RSpec.describe Declaration, type: :model do
         let(:state) { :voided }
 
         it { expect { declaration.mark_ineligible! }.to raise_error(StateMachines::InvalidTransition) }
-      end
-    end
-
-    describe ".mark_awaiting_clawback" do
-      let(:state) { :paid }
-
-      it { expect { declaration.mark_awaiting_clawback }.to change(declaration, :state).from("paid").to("awaiting_clawback") }
-
-      context "when not paid" do
-        let(:state) { :payable }
-
-        it { expect { declaration.mark_awaiting_clawback! }.to raise_error(StateMachines::InvalidTransition) }
-      end
-    end
-
-    describe ".mark_clawed_back" do
-      let(:state) { :awaiting_clawback }
-
-      it { expect { declaration.mark_clawed_back }.to change(declaration, :state).from("awaiting_clawback").to("clawed_back") }
-
-      context "when not awaiting_clawback" do
-        let(:state) { :clawed_back }
-
-        it { expect { declaration.mark_clawed_back! }.to raise_error(StateMachines::InvalidTransition) }
       end
     end
 
@@ -719,7 +694,6 @@ RSpec.describe Declaration, type: :model do
       let(:application) { create(:application, :accepted, cohort:, course:) }
 
       before do
-        create(:declaration, :completed, :clawed_back)
         create(:declaration, :completed, :payable)
         create(:declaration, :payable, declaration_type: "started")
         create(:declaration, :payable, declaration_type: "retained-1")
@@ -728,7 +702,7 @@ RSpec.describe Declaration, type: :model do
 
       it "sorts declarations properly" do
         declarations = Declaration.order_by_milestones
-        expected_types = %w[completed completed retained-2 retained-1 started]
+        expected_types = %w[completed retained-2 retained-1 started]
         expect(declarations.pluck(:declaration_type)).to eq expected_types
       end
 
@@ -790,26 +764,6 @@ RSpec.describe Declaration, type: :model do
 
     context "when a declaration has a different type" do
       before { create(:declaration, application:, declaration_type: :completed) }
-
-      it "returns no declarations" do
-        expect(declaration.duplicate_declarations).to be_empty
-      end
-    end
-
-    context "when a declaration has a not billable/submitted state" do
-      before { create(:declaration, application:, state: :clawed_back) }
-
-      it "returns no declarations" do
-        expect(declaration.duplicate_declarations).to be_empty
-      end
-    end
-
-    context "when declarations have been made for a different course", :npq do
-      before do
-        course = create(:course, :npd_eirt)
-        other_application = create(:application, :accepted, course:, cohort:, user: participant)
-        create(:declaration, application: other_application)
-      end
 
       it "returns no declarations" do
         expect(declaration.duplicate_declarations).to be_empty

--- a/spec/services/applications/revert_to_pending_spec.rb
+++ b/spec/services/applications/revert_to_pending_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Applications::RevertToPending, type: :model do
     end
 
     context "when application already has declarations" do
-      Applications::RevertToPending::REVERTABLE_DECLARATION_STATES.each do |declaration_state|
+      Declaration::REVERTABLE_STATES.each do |declaration_state|
         context "with a revertable state: #{declaration_state}" do
           let(:application) { create(:declaration, declaration_state).application }
 
@@ -154,7 +154,7 @@ RSpec.describe Applications::RevertToPending, type: :model do
         end
       end
 
-      Declaration.states.keys.excluding(Applications::RevertToPending::REVERTABLE_DECLARATION_STATES).each do |declaration_state|
+      Declaration.states.keys.excluding(Declaration::REVERTABLE_STATES).each do |declaration_state|
         context "with a state that cannot be reverted: #{declaration_state}" do
           let(:application) { create(:declaration, declaration_state).application }
 


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#627

Aim to address the issue that `paid declaration` can be mutated when a voiding declaration
is received. Which further creates the need for StatementItem with declaration duplicate states.



### Changes proposed in this pull request

ClawbackDeclaration split state upto payment then any further changes are tracked with ClawbackDeclaration with its own set of states as well as a reference to the paid declaration.


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [X] Adds/removes model validations
- [X] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [X] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>