### PR TITLE
Add application rejection to admin user

### DIFF
--- a/app/controllers/admin/applications/rejection_controller.rb
+++ b/app/controllers/admin/applications/rejection_controller.rb
@@ -1,0 +1,32 @@
+module Admin
+  module Applications
+    class RejectionController < ApplicationsController
+      before_action :set_application
+
+      def edit; end
+
+      def update
+        if @application.pending_status?
+          service = ::Applications::Reject.new(
+            application: @application,
+            reason: "rejected-by-admin-user",
+          )
+          service.call
+          if service.errors.blank?
+            redirect_to admin_application_path(@application)
+          else
+            render :edit, status: :unprocessable_content
+          end
+        else
+          render :edit, status: :unprocessable_content
+        end
+      end
+
+    private
+
+      def set_application
+        @application = Application.find(params[:id])
+      end
+    end
+  end
+end

--- a/app/services/applications/reject.rb
+++ b/app/services/applications/reject.rb
@@ -8,6 +8,7 @@ module Applications
       registration-expired
       rejected-by-provider
       other-application-in-this-cohort-accepted
+      rejected-by-admin-user
     ].freeze
 
     attribute :application

--- a/app/views/admin/applications/rejection/edit.html.erb
+++ b/app/views/admin/applications/rejection/edit.html.erb
@@ -1,0 +1,22 @@
+<%= govuk_back_link href: admin_application_path(@application) %>
+
+<h1 class="govuk-heading-l">
+  Are you sure you want to reject the application?
+</h1>
+
+<div class="govuk-inset-text">
+  <p class="govuk-body">
+    Application status:
+    <br />
+    <strong><%= @application.status&.humanize %></strong>
+  </p>
+</div>
+
+<%= form_for @application, url: admin_applications_reject_path(@application), method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-button-group">
+    <%= f.govuk_submit "Reject application" %>
+    <%= govuk_link_to t("shared.cancel"), admin_application_path(@application) %>
+  </div>
+<% end %>

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -39,37 +39,43 @@ govuk_summary_list(card: { title: "Overview" }) do |sl|
     row.with_key(text: "Application status")
     row.with_value(text: @application.status.try(:humanize))
 
-    if @application.started_status?
+    if @application.pending_status?
       row.with_action(
-        text: "Defer/Withdraw",
-        href: new_admin_applications_change_status_path(@application))
-    end
-    
-    if @application.accepted_status? || @application.rejected_status?
-      row.with_action(
-        text: "Revert to Pending",
-        href: new_admin_applications_revert_to_pending_path(@application))
+        text: "Reject",
+        href: edit_admin_applications_reject_path(@application))
       end
 
-      if @application.accepted_status?
+      if @application.started_status?
         row.with_action(
-          text: "Defer",
+          text: "Defer/Withdraw",
           href: new_admin_applications_change_status_path(@application))
-        elsif @application.deferred_status? || @application.withdrawn_status?
+        end
+
+        if @application.accepted_status? || @application.rejected_status?
           row.with_action(
-            text: "Accept",
-            href: new_admin_applications_change_status_path(@application))
+            text: "Revert to Pending",
+            href: new_admin_applications_revert_to_pending_path(@application))
           end
-        end
-        sl.with_row do |row|
-          row.with_key(text: "Created")
-          row.with_value(text: @application.created_at.to_fs(:govuk_short))
-        end
-        sl.with_row do |row|
-          row.with_key(text: "Updated")
-          row.with_value(text: @application.updated_at.to_fs(:govuk_short))
-        end
-      end
+
+          if @application.accepted_status?
+            row.with_action(
+              text: "Defer",
+              href: new_admin_applications_change_status_path(@application))
+            elsif @application.deferred_status? || @application.withdrawn_status?
+              row.with_action(
+                text: "Accept",
+                href: new_admin_applications_change_status_path(@application))
+              end
+            end
+            sl.with_row do |row|
+              row.with_key(text: "Created")
+              row.with_value(text: @application.created_at.to_fs(:govuk_short))
+            end
+            sl.with_row do |row|
+              row.with_key(text: "Updated")
+              row.with_value(text: @application.updated_at.to_fs(:govuk_short))
+            end
+          end
 %>
 
 <%=

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -85,6 +85,7 @@ namespace :admin do
         resource :change_lead_provider, controller: "change_lead_provider", only: %i[show create]
         resource :notes, only: %i[edit update]
         resource :change_cohort, controller: "change_cohort", only: %i[show create]
+        resource :reject, controller: "rejection", only: %i[edit update]
         resource :history, controller: "history", only: %i[show]
         resource :outcome, controller: "outcome", only: %i[show]
       end

--- a/spec/requests/admin/applications/rejection_controller_spec.rb
+++ b/spec/requests/admin/applications/rejection_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Applications::RejectionController, :ecf_api_disabled, type: :request do
+  include Helpers::NPQSeparationAdminLogin
+
+  subject { response }
+
+  context "when logged in" do
+    before { sign_in_as_admin }
+
+    describe "#update" do
+      before { patch admin_applications_reject_path(application) }
+
+      context "when application in rejectable state" do
+        let(:application) { create(:application, :pending) }
+
+        it { is_expected.to redirect_to admin_application_path(application) }
+        it { expect(application.reload.status).to eq("rejected") }
+      end
+
+      context "when application is not rejectable" do
+        let(:application) { create(:application, :accepted) }
+
+        it { is_expected.to have_http_status :unprocessable_content }
+        it { expect(application.reload.status).to eq("accepted") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#632



### Changes proposed in this pull request

Allow admin user to reject pending application


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>

<!-- Message of single commit: -->