### PR TITLE
[506] Admin console changes (finance - summary screen)

### DIFF
--- a/app/components/admin/statement_selector_component.html.erb
+++ b/app/components/admin/statement_selector_component.html.erb
@@ -5,11 +5,11 @@
     <% unless format_for_sidebar %>
       <div class="<%= grid_column_class %>">
         <%= f.govuk_collection_select :payment_status,
-          ['Paid', 'Unpaid'],
+          ['Open', 'Payable', 'Paid'],
           :downcase,
           :to_s,
           options: { selected: payment_status, include_blank: 'All' },
-          label: { text: "Status", size: "s" }
+          label: { text: "Payment status", size: "s" }
         %>
       </div>
     <% end %>

--- a/app/components/admin/statements_table_component.rb
+++ b/app/components/admin/statements_table_component.rb
@@ -25,7 +25,7 @@ module Admin
         ("Provider" if show_lead_provider),
         "Cohort",
         "Statement date",
-        "Status",
+        "Payment status",
         "Payment run",
         "Actions",
       ].compact

--- a/app/controllers/admin/finance/statements_controller.rb
+++ b/app/controllers/admin/finance/statements_controller.rb
@@ -62,7 +62,8 @@ private
     return unless (payment_status = params.delete(:payment_status))
 
     params[:state] = {
-      "unpaid" => %w[open payable],
+      "open" => %w[open],
+      "payable" => %w[payable],
       "paid" => %w[paid],
     }.fetch(payment_status, [])
   end

--- a/app/views/admin/finance/statements/show.html.erb
+++ b/app/views/admin/finance/statements/show.html.erb
@@ -12,7 +12,7 @@
       &nbsp;<%= govuk_link_to "Change", admin_finance_statements_change_payment_date_path(@statement) %>
     </p>
     <p class="govuk-body govuk-!-margin-bottom-2">
-      <strong>Status:</strong>
+      <strong>Payment status:</strong>
       <%= @statement.state.humanize %>
     </p>
     <p class="govuk-body govuk-!-margin-bottom-2">

--- a/spec/components/admin/statement_selector_component_spec.rb
+++ b/spec/components/admin/statement_selector_component_spec.rb
@@ -32,11 +32,12 @@ RSpec.describe Admin::StatementSelectorComponent, type: :component do
     expect(rendered).to have_selector("form[method=get][action='/admin/finance/statements']")
   end
 
-  it "has dropdown with status" do
+  it "has dropdown with payment status" do
     expect(rendered).to have_selector(payment_status_selector)
     expect(rendered).to have_selector("#{payment_status_selector} option[value='']", text: "All")
+    expect(rendered).to have_selector("#{payment_status_selector} option[value='open']", text: "Open")
+    expect(rendered).to have_selector("#{payment_status_selector} option[value='payable']", text: "Payable")
     expect(rendered).to have_selector("#{payment_status_selector} option[value='paid']", text: "Paid")
-    expect(rendered).to have_selector("#{payment_status_selector} option[value='unpaid']", text: "Unpaid")
   end
 
   it "has dropdown with lead providers" do

--- a/spec/components/admin/statements_table_component_spec.rb
+++ b/spec/components/admin/statements_table_component_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Admin::StatementsTableComponent, type: :component do
 
   let(:statements) { FactoryBot.create_list(:statement, 3) }
   let(:show_lead_provider) { true }
-  let(:expected_columns) { %w[Provider Cohort Status] }
+  let(:expected_columns) { ["Provider", "Cohort", "Payment status"] }
 
-  it "renders a table with Course provider, Cohort and Status columns" do
+  it "renders a table with Provider, Cohort and Payment status columns" do
     expected_columns.each do |heading|
       expect(rendered_content).to have_css("th", text: heading)
     end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#506

Rename Status to Payment status and update Options

### Changes proposed in this pull request

Change/configure options for 'Status' dropdown filter to values of:
'Open'
'Payable'
'Paid'

Change of name in 'Filter statements by' box, and in the column heading - change from 'Status' to 'Payment status'
## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
