### PR TITLE
2896 - Switch Redis to Managed in staging

### DIFF
--- a/terraform/application/config/staging.tfvars.json
+++ b/terraform/application/config/staging.tfvars.json
@@ -4,5 +4,6 @@
     "namespace": "cpd-development",
     "blob_delete_retention_days": 7,
     "container_delete_retention_days": 7,
-    "enable_dfe_analytics_federated_auth": false
+    "enable_dfe_analytics_federated_auth": false,
+    "redis_mode": "managed"
 }


### PR DESCRIPTION
### Context

Microsoft has announced the retirement of Azure Cache for Redis and we therefore need to migrate from Azure Cache for Redis to Azure Managed Redis.
[Redis Migration](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/redis-migration.md)
[Procedure](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/redis-migration-deployment-steps.md)

### Changes proposed in this pull request

- Switch to use Managed Redis by adding variable `redis_mode` equal to `managed` from the default, `legacy`.

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

No data or schema  changes

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

No changes to existing data.

### Guidance to review

- Run `make staging terraform-plan` where you should see a change to a kubernetes_secret which is the URL for Redis.

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally