### PR TITLE
Add statement academic_year

### DIFF
--- a/app/models/course_cohort.rb
+++ b/app/models/course_cohort.rb
@@ -12,6 +12,7 @@ class CourseCohort < ApplicationRecord
 
   validates :ecf_id, uniqueness: { case_sensitive: false }
   validates :course_id, uniqueness: { scope: :cohort_id }
+  validates :academic_year, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
 
   delegate :name, to: :cohort
 

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -45,6 +45,7 @@ class Statement < ApplicationRecord
   enum :frequency, FREQUENCIES.keys.index_with(&:itself), suffix: true
 
   before_save :set_deadline_and_payment_date, if: -> { start_date_changed? }
+  before_save :set_academic_year, if: -> { start_date_changed? }
 
   def self.create_current!(lead_provider:, frequency: :monthly)
     create!(
@@ -121,6 +122,10 @@ class Statement < ApplicationRecord
   end
 
 private
+
+  def set_academic_year
+    self.academic_year = start_date.year - (start_date.month < 9 ? 1 : 0)
+  end
 
   def set_deadline_and_payment_date
     self.deadline_date = start_date + FREQUENCIES.fetch(frequency) - 1.day

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -24,6 +24,7 @@ class Statement < ApplicationRecord
   validate :payment_date_on_or_after_deadline_date
   validate :changing_attributes_when_payable, on: :update
   validate :changing_attributes_when_paid, on: :update
+  validates :academic_year, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
 
   scope :with_output_fee, ->(output_fee: true) { where(output_fee:) }
   scope :with_state, ->(*state) { where(state:) }

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -10,6 +10,7 @@ shared:
     - ecf_id
   :statements:
     - id
+    - academic_year
     - deadline_date
     - payment_date
     - output_fee

--- a/db/migrate/20260807120800_add_academic_year_to_statement.rb
+++ b/db/migrate/20260807120800_add_academic_year_to_statement.rb
@@ -1,0 +1,6 @@
+class AddAcademicYearToStatement < ActiveRecord::Migration[8.1]
+  def change
+    # track which academic year the course cohort belongs
+    add_column :statements, :academic_year, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_31_093900) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_07_120800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -582,6 +582,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_31_093900) do
   end
 
   create_table "statements", force: :cascade do |t|
+    t.integer "academic_year"
     t.bigint "cohort_id"
     t.datetime "created_at", null: false
     t.date "deadline_date"

--- a/lib/tasks/data_migrations/backfill_declaration_statement_id.rake
+++ b/lib/tasks/data_migrations/backfill_declaration_statement_id.rake
@@ -13,7 +13,7 @@ namespace :data_migrations do
         next
       end
 
-      statement.update_columns(start_date: Date.new(statement[:year], statement[:month], 1), frequency: "monthly", academic_year: params[:year]) unless dry_run
+      statement.update_columns(start_date: Date.new(statement[:year], statement[:month], 1), frequency: "monthly", academic_year: statement[:year]) unless dry_run
       updated_statement_count += 1
     end
 

--- a/lib/tasks/data_migrations/backfill_declaration_statement_id.rake
+++ b/lib/tasks/data_migrations/backfill_declaration_statement_id.rake
@@ -13,7 +13,7 @@ namespace :data_migrations do
         next
       end
 
-      statement.update_columns(start_date: Date.new(statement[:year], statement[:month], 1), frequency: "monthly") unless dry_run
+      statement.update_columns(start_date: Date.new(statement[:year], statement[:month], 1), frequency: "monthly", academic_year: params[:year]) unless dry_run
       updated_statement_count += 1
     end
 

--- a/spec/factories/statements.rb
+++ b/spec/factories/statements.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     state { "open" }
     ecf_id { SecureRandom.uuid }
     output_fee { true }
+    academic_year { Date.current.year }
 
     trait :next_output_fee do
       start_date { 1.month.from_now }

--- a/spec/models/course_cohort_spec.rb
+++ b/spec/models/course_cohort_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe CourseCohort do
 
   describe "validations" do
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive }
+    it { is_expected.to validate_numericality_of(:academic_year).only_integer.is_greater_than_or_equal_to(0).allow_nil }
   end
 
   describe ".next_open_for" do

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe Statement, type: :model do
         it "sets payment_date" do
           expect(statement.payment_date).to eq(Date.new(2026, 3, 31))
         end
+
+        it "sets academic_year" do
+          expect(statement.academic_year).to eq(2025)
+        end
+
+        context "when start_date is before dec" do
+          let(:start_date) { Date.new(2025, 9, 1) }
+
+          it "sets academic_year" do
+            expect(statement.academic_year).to eq(2025)
+          end
+        end
       end
 
       context "when there is no payment date" do

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Statement, type: :model do
                              .with_suffix
     end
 
+    it { is_expected.to validate_numericality_of(:academic_year).only_integer.is_greater_than_or_equal_to(0).allow_nil }
     it { is_expected.to validate_presence_of(:start_date) }
     it { is_expected.to allow_value(%w[true false]).for(:output_fee).with_message("Output fee must be true or false") }
     it { is_expected.not_to allow_value(nil).for(:output_fee).with_message("Choose yes or no for output fee") }


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#644
Fixes DFE-Digital/teacher-training-entitlement-board#650


### Changes proposed in this pull request

- [X] add academic_year to statement
- [X] updated backfill task with statement.academic_year


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>

<!-- Message of single commit: -->

Add academic_year to statement