### PR TITLE
[649] Update clawback declaration initial state

### DIFF
--- a/app/models/clawback_declaration.rb
+++ b/app/models/clawback_declaration.rb
@@ -4,11 +4,16 @@ class ClawbackDeclaration < Declaration
   validates :paid_declaration, presence: true
 
   enum :state, {
+    submitted: "submitted",
     awaiting_clawback: "awaiting_clawback",
     clawed_back: "clawed_back",
   }, suffix: true
 
-  state_machine :state, initial: :awaiting_clawback do
+  state_machine :state, initial: :submitted do
+    event :mark_awaiting_clawback do
+      transition %i[submitted] => :awaiting_clawback
+    end
+
     event :mark_clawed_back do
       transition %i[awaiting_clawback] => :clawed_back
     end

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -115,7 +115,7 @@ class Declaration < ApplicationRecord
   validate :delivery_partners_are_not_the_same, if: :delivery_partner
 
   validates :milestone_id,
-            uniqueness: { scope: :application_id, conditions: -> { where(state: UNIQUE_MILESTONE_STATES) } },
+            uniqueness: { scope: %i[application_id type], conditions: -> { where(state: UNIQUE_MILESTONE_STATES) } },
             if: -> { milestone_id.present? && state.in?(UNIQUE_MILESTONE_STATES) }
 
   validates :value, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
@@ -141,7 +141,6 @@ class Declaration < ApplicationRecord
       secondary_delivery_partner: secondary_delivery_partner,
       declaration_type: declaration_type,
       declaration_date: declaration_date,
-      state: "awaiting_clawback",
     )
     save!
   end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -92,7 +92,7 @@ class Statement < ApplicationRecord
   def prepare_to_freeze!
     transaction do
       declarations.eligible_state.each(&:mark_payable!)
-      clawback_declarations.awaiting_clawback_state.each(&:mark_awaiting_clawback!)
+      clawback_declarations.submitted_state.each(&:mark_awaiting_clawback!)
       mark_payable!
     end
   end

--- a/db/migrate/20260810142408_add_type_to_declaration_milestone_unique_index.rb
+++ b/db/migrate/20260810142408_add_type_to_declaration_milestone_unique_index.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AddTypeToDeclarationMilestoneUniqueIndex < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :declarations,
+                 name: :index_declarations_on_application_id_and_milestone_id,
+                 algorithm: :concurrently
+
+    add_index :declarations,
+              %i[application_id milestone_id type],
+              unique: true,
+              where: "(state = ANY (ARRAY['eligible'::declaration_states, 'payable'::declaration_states, 'paid'::declaration_states, 'submitted'::declaration_states]))",
+              name: :index_declarations_on_application_id_and_milestone_id,
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :declarations,
+                 name: :index_declarations_on_application_id_and_milestone_id,
+                 algorithm: :concurrently
+
+    add_index :declarations,
+              %i[application_id milestone_id],
+              unique: true,
+              where: "(state = ANY (ARRAY['eligible'::declaration_states, 'payable'::declaration_states, 'paid'::declaration_states, 'submitted'::declaration_states]))",
+              name: :index_declarations_on_application_id_and_milestone_id,
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_07_120800) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_142408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -301,7 +301,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_07_120800) do
     t.string "type"
     t.datetime "updated_at", null: false
     t.decimal "value"
-    t.index ["application_id", "milestone_id"], name: "index_declarations_on_application_id_and_milestone_id", unique: true, where: "(state = ANY (ARRAY['eligible'::declaration_states, 'payable'::declaration_states, 'paid'::declaration_states, 'submitted'::declaration_states]))"
+    t.index ["application_id", "milestone_id", "type"], name: "index_declarations_on_application_id_and_milestone_id", unique: true, where: "(state = ANY (ARRAY['eligible'::declaration_states, 'payable'::declaration_states, 'paid'::declaration_states, 'submitted'::declaration_states]))"
     t.index ["application_id"], name: "index_declarations_on_application_id"
     t.index ["clawback_declaration_id"], name: "index_declarations_on_clawback_declaration_id"
     t.index ["cohort_id"], name: "index_declarations_on_cohort_id"

--- a/public/api/docs/v1/swagger.yaml
+++ b/public/api/docs/v1/swagger.yaml
@@ -2339,6 +2339,7 @@ components:
               - voided
               - payable
               - paid
+              - submitted
               - awaiting_clawback
               - clawed_back
             has_passed:

--- a/spec/models/clawback_declaration_spec.rb
+++ b/spec/models/clawback_declaration_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ClawbackDeclaration, type: :model do
     it {
       expect(subject).to define_enum_for(:state)
                            .with_values(
+                             submitted: "submitted",
                              awaiting_clawback: "awaiting_clawback",
                              clawed_back: "clawed_back",
                            ).backed_by_column_of_type(:enum).with_suffix
@@ -17,6 +18,18 @@ RSpec.describe ClawbackDeclaration, type: :model do
 
   describe "state transition" do
     let(:clawback_declaration) { create(:clawback_declaration, state:) }
+
+    describe ".mark_awaiting_clawback" do
+      let(:state) { :submitted }
+
+      it { expect { clawback_declaration.mark_awaiting_clawback }.to change(clawback_declaration, :state).from("submitted").to("awaiting_clawback") }
+
+      context "when not submitted" do
+        let(:state) { :awaiting_clawback }
+
+        it { expect { clawback_declaration.mark_awaiting_clawback! }.to raise_error(StateMachines::InvalidTransition) }
+      end
+    end
 
     describe ".mark_clawed_back" do
       let(:state) { :awaiting_clawback }

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -405,6 +405,7 @@ RSpec.describe Declaration, type: :model do
     before { paid_declaration.clawback! }
 
     it { expect(paid_declaration.clawback_declaration).to be_present }
+    it { expect(paid_declaration.clawback_declaration.state).to eq("submitted") }
     it { expect(paid_declaration.state).to eq("paid") }
     it { expect(paid_declaration.clawback_declaration.paid_declaration).to eq(paid_declaration) }
   end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#649

Having a different initial state between declaration and clawback declaration could cause some issues down the line .

### Changes proposed in this pull request

Update clawback declaration initial state to be identical to declaration

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
