### PR TITLE
[647] Update delivery partner services

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -168,9 +168,9 @@ class Declaration < ApplicationRecord
   end
 
   def available_delivery_partner_ids
-    return [] unless lead_provider && milestone&.cohort
+    return [] unless lead_provider && milestone&.course_cohort
 
-    lead_provider.delivery_partners_for_cohort(milestone&.cohort).map(&:id)
+    lead_provider.delivery_partners_for_course_cohort(course_cohort: milestone.course_cohort).map(&:id)
   end
 
   def delivery_partners

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -28,7 +28,11 @@ class DeliveryPartner < ApplicationRecord
     Declaration.for_delivery_partners(self)
   end
 
-  def cohorts_for_lead_provider(lead_provider)
-    delivery_partnerships.select { |delivery_partnership| delivery_partnership.lead_provider_id == lead_provider.id }.map(&:cohort)
+  def course_cohorts_for_lead_provider(lead_provider)
+    delivery_partnerships
+      .select { |delivery_partnership| delivery_partnership.lead_provider_id == lead_provider.id }
+      .map(&:course_cohort)
+      .compact
+      .uniq
   end
 end

--- a/app/models/delivery_partnership.rb
+++ b/app/models/delivery_partnership.rb
@@ -1,11 +1,17 @@
 class DeliveryPartnership < ApplicationRecord
   belongs_to :delivery_partner
   belongs_to :lead_provider
-  belongs_to :cohort
+  belongs_to :cohort, optional: true
   belongs_to :course_cohort, optional: true
 
   validates :delivery_partner_id, presence: true
   validates :lead_provider_id, presence: true
-  validates :cohort_id, presence: true
-  validates :delivery_partner_id, uniqueness: { scope: %i[lead_provider_id cohort_id] }
+  validates :cohort_id, presence: true, unless: :course_cohort_id?
+  validates :course_cohort_id, presence: true, unless: :cohort_id?
+  validates :delivery_partner_id,
+            uniqueness: { scope: %i[lead_provider_id course_cohort_id] },
+            if: :course_cohort_id?
+  validates :delivery_partner_id,
+            uniqueness: { scope: %i[lead_provider_id cohort_id] },
+            unless: :course_cohort_id?
 end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -22,6 +22,10 @@ class LeadProvider < ApplicationRecord
     delivery_partners.where(delivery_partnerships: { cohort: })
   end
 
+  def delivery_partners_for_course_cohort(course_cohort:)
+    delivery_partners.where(delivery_partnerships: { course_cohort: })
+  end
+
   def contract(course_cohort:)
     ComputedContract.draw(lead_provider: self, course_cohort:)
   end

--- a/app/serializers/api/delivery_partner_serializer.rb
+++ b/app/serializers/api/delivery_partner_serializer.rb
@@ -10,7 +10,7 @@ module API
         field(:name)
         field(:cohort) do |object, options|
           object.course_cohorts_for_lead_provider(options[:lead_provider])
-                .map { |course_cohort| course_cohort.cohort.start_year }
+                .map(&:academic_year)
                 .uniq
                 .sort
         end

--- a/app/serializers/api/delivery_partner_serializer.rb
+++ b/app/serializers/api/delivery_partner_serializer.rb
@@ -9,8 +9,8 @@ module API
       view :v1 do
         field(:name)
         field(:cohort) do |object, options|
-          object.cohorts_for_lead_provider(options[:lead_provider])
-                .map(&:start_year)
+          object.course_cohorts_for_lead_provider(options[:lead_provider])
+                .map { |course_cohort| course_cohort.cohort.start_year }
                 .uniq
                 .sort
         end

--- a/app/services/delivery_partners/query.rb
+++ b/app/services/delivery_partners/query.rb
@@ -34,7 +34,7 @@ module DeliveryPartners
     def where_cohort_start_year_in(cohort_start_years)
       return if ignore?(filter: cohort_start_years)
 
-      scope.merge!(DeliveryPartner.where(delivery_partnerships: { cohorts: { start_year: extract_conditions(cohort_start_years) } }))
+      scope.merge!(DeliveryPartner.where(cohorts: { start_year: extract_conditions(cohort_start_years) }))
     end
 
     def order_by
@@ -42,7 +42,9 @@ module DeliveryPartners
     end
 
     def all_delivery_partners
-      DeliveryPartner.distinct.joins(delivery_partnerships: %i[cohort lead_provider]).includes(delivery_partnerships: %i[cohort])
+      DeliveryPartner.distinct
+                     .joins(delivery_partnerships: [{ course_cohort: :cohort }, :lead_provider])
+                     .includes(delivery_partnerships: { course_cohort: :cohort })
     end
   end
 end

--- a/app/services/delivery_partners/query.rb
+++ b/app/services/delivery_partners/query.rb
@@ -34,7 +34,7 @@ module DeliveryPartners
     def where_cohort_start_year_in(cohort_start_years)
       return if ignore?(filter: cohort_start_years)
 
-      scope.merge!(DeliveryPartner.where(cohorts: { start_year: extract_conditions(cohort_start_years) }))
+      scope.merge!(DeliveryPartner.where(course_cohorts: { academic_year: extract_conditions(cohort_start_years) }))
     end
 
     def order_by

--- a/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
+++ b/app/services/valid_test_data_generators/api_test_scenarios_seeder.rb
@@ -302,11 +302,11 @@ module ValidTestDataGenerators
         training_ends_at:,
       )
 
-      cc = CourseCohort.find_by(course:, cohort: current_cohort)
-      if cc
-        cc.update!(schedule:, academic_year:)
+      course_cohort = CourseCohort.find_by(course:, cohort: current_cohort)
+      if course_cohort
+        course_cohort.update!(schedule:, academic_year:)
       else
-        cc = CourseCohort.create!(
+        course_cohort = CourseCohort.create!(
           course:,
           cohort: current_cohort,
           schedule:,
@@ -315,7 +315,7 @@ module ValidTestDataGenerators
       end
 
       create_or_update_milestone!(
-        course_cohort: cc,
+        course_cohort:,
         declaration_type: Milestone::STARTED,
         acceptance_window_start_date: training_starts_at,
         acceptance_window_end_date: training_starts_at + 2.months,
@@ -328,20 +328,20 @@ module ValidTestDataGenerators
                      training_ends_at
                    end
       create_or_update_milestone!(
-        course_cohort: cc,
+        course_cohort:,
         declaration_type: Milestone::COMPLETED,
         acceptance_window_start_date: start_date,
         acceptance_window_end_date: training_ends_at + 2.months,
         payment_amount: 40,
       )
 
-      create_or_update_lead_provider_contract(course_cohort: cc, lead_provider:)
+      create_or_update_lead_provider_contract(course_cohort:, lead_provider:)
 
       delivery_partners.each do |dp|
-        dp.delivery_partnerships.find_or_create_by!(lead_provider:, cohort: current_cohort)
+        dp.delivery_partnerships.find_or_create_by!(lead_provider:, course_cohort:)
       end
 
-      cc
+      course_cohort
     end
 
     def create_or_update_lead_provider_contract(course_cohort:, lead_provider:)

--- a/lib/tasks/delivery_partners.rake
+++ b/lib/tasks/delivery_partners.rake
@@ -53,13 +53,14 @@ namespace :delivery_partners do
         raise "Delivery Partnerships already exist" unless DeliveryPartnership.count.zero?
 
         lead_providers = LeadProvider.all.index_by(&:ecf_id)
-        cohorts = Cohort.all.index_by(&:identifier).transform_keys(&:to_s)
+        course_cohorts = CourseCohort.all.index_by { |course_cohort| course_cohort.ecf_id.to_s }
         delivery_partners = DeliveryPartner.all.index_by(&:ecf_id)
 
         CSV.foreach(args[:import_file], headers: true) do |row|
           DeliveryPartnership.create!(
             lead_provider: lead_providers[row["Lead Provider ECF Id"]],
-            cohort: cohorts[row["Cohort"]],
+            course_cohort: course_cohorts[row["Course Cohort ECF Id"]],
+            cohort: course_cohorts[row["Course Cohort ECF Id"]]&.cohort,
             delivery_partner: delivery_partners[row["Delivery Partner ECF Id"]],
           )
         end
@@ -77,15 +78,15 @@ namespace :delivery_partners do
       raise "Export file not specified" if args[:export_file].blank?
 
       CSV.open(args[:export_file], "w") do |csv|
-        csv << ["Lead Provider ECF Id", "Cohort", "Delivery Partner ECF Id"]
+        csv << ["Lead Provider ECF Id", "Course Cohort ECF Id", "Delivery Partner ECF Id"]
 
         DeliveryPartnership
             .order(id: :asc)
-            .includes(:lead_provider, :cohort, :delivery_partner)
+            .includes(:lead_provider, :course_cohort, :delivery_partner)
             .find_each(batch_size: 500) do |partnership|
           csv << [
             partnership.lead_provider.ecf_id,
-            partnership.cohort.identifier,
+            partnership.course_cohort.ecf_id,
             partnership.delivery_partner.ecf_id,
           ]
         end

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
       end
     end
     declaration_type { Milestone::STARTED }
-    delivery_partner { create(:delivery_partner, lead_providers: { milestone.cohort => lead_provider }) }
+    delivery_partner { create(:delivery_partner, lead_providers: { milestone.course_cohort => lead_provider }) }
     declaration_date { milestone.acceptance_window_start_date + 1.day }
     submitted
     ecf_id { SecureRandom.uuid }
@@ -86,21 +86,21 @@ FactoryBot.define do
     end
 
     trait :with_delivery_partner do
-      delivery_partner { create(:delivery_partner, lead_providers: { milestone.cohort => lead_provider }) }
+      delivery_partner { create(:delivery_partner, lead_providers: { milestone.course_cohort => lead_provider }) }
     end
 
     trait :with_sometimes_nil_delivery_partner do
       delivery_partner do
         if milestone.cohort.start_year.between?(2021, 2023)
-          [nil, create(:delivery_partner, lead_providers: { milestone.cohort => lead_provider })].sample
+          [nil, create(:delivery_partner, lead_providers: { milestone.course_cohort => lead_provider })].sample
         else
-          create(:delivery_partner, lead_providers: { milestone.cohort => lead_provider })
+          create(:delivery_partner, lead_providers: { milestone.course_cohort => lead_provider })
         end
       end
     end
 
     trait :with_secondary_delivery_partner do
-      secondary_delivery_partner { create(:delivery_partner, lead_providers: { milestone.cohort => lead_provider }) }
+      secondary_delivery_partner { create(:delivery_partner, lead_providers: { milestone.course_cohort => lead_provider }) }
     end
   end
 end

--- a/spec/factories/delivery_partners.rb
+++ b/spec/factories/delivery_partners.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :delivery_partner do
     transient do
-      # either an array or a hash of cohort + array of lead providers
+      # either an array or a hash of course cohort + array of lead providers
       lead_providers { Array.wrap(lead_provider) }
       lead_provider { nil }
     end
@@ -13,15 +13,17 @@ FactoryBot.define do
       partnerships = if evaluator.lead_providers.is_a?(Hash)
                        evaluator.lead_providers
                      elsif evaluator.lead_providers&.any?
-                       { create(:cohort, :current) => evaluator.lead_providers }
+                       { create(:course_cohort, cohort: create(:cohort, :current)) => evaluator.lead_providers }
                      else
                        {}
                      end
 
-      partnerships.each do |cohort, lead_providers|
+      partnerships.each do |course_cohort, lead_providers|
+        course_cohort = CourseCohort.find_by(cohort: course_cohort) || create(:course_cohort, cohort: course_cohort) if course_cohort.is_a?(Cohort)
+
         Array.wrap(lead_providers).each do |lead_provider|
           if LeadProvider.where(id: lead_provider.id).exists?
-            delivery_partner.delivery_partnerships.create! lead_provider:, cohort:
+            delivery_partner.delivery_partnerships.create! lead_provider:, cohort: course_cohort.cohort, course_cohort:
           end
         end
       end

--- a/spec/factories/delivery_partnerships.rb
+++ b/spec/factories/delivery_partnerships.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :delivery_partnership do
     association(:delivery_partner)
     association(:lead_provider)
-    cohort { create :cohort, :current }
+    course_cohort
+    cohort { course_cohort.cohort }
   end
 end

--- a/spec/factories/lead_providers.rb
+++ b/spec/factories/lead_providers.rb
@@ -14,14 +14,16 @@ FactoryBot.define do
       partnerships = if evaluator.delivery_partners.is_a?(Hash)
                        evaluator.delivery_partners
                      elsif evaluator.delivery_partners&.any?
-                       { create(:cohort, :current) => evaluator.delivery_partners }
+                       { create(:course_cohort, cohort: create(:cohort, :current)) => evaluator.delivery_partners }
                      else
                        {}
                      end
 
-      partnerships.each do |cohort, delivery_partners|
+      partnerships.each do |course_cohort, delivery_partners|
+        course_cohort = CourseCohort.find_by(cohort: course_cohort) || create(:course_cohort, cohort: course_cohort) if course_cohort.is_a?(Cohort)
+
         Array.wrap(delivery_partners).each do |delivery_partner|
-          lead_provider.delivery_partnerships.create! delivery_partner:, cohort:
+          lead_provider.delivery_partnerships.create! delivery_partner:, course_cohort:
         end
       end
     end

--- a/spec/features/admin/bulk_operations/submit_declarations_spec.rb
+++ b/spec/features/admin/bulk_operations/submit_declarations_spec.rb
@@ -100,10 +100,10 @@ RSpec.feature "submit declarations", :rack_test_driver, :revisit, type: :feature
       delivery_partner = create(:delivery_partner)
 
       schedule = create(:schedule, cohort: cohort, course_group: course.course_group, allowed_declaration_types: %w[started])
-      create(:application, :accepted, user: participant, cohort: cohort, course: course, lead_provider: lead_provider, schedule: schedule)
+      application = create(:application, :accepted, user: participant, cohort: cohort, course: course, lead_provider: lead_provider, schedule: schedule)
 
       # Create required partnerships
-      create(:delivery_partnership, cohort: cohort, delivery_partner: delivery_partner, lead_provider: lead_provider)
+      create(:delivery_partnership, cohort:, course_cohort: application.course_cohort, delivery_partner: delivery_partner, lead_provider: lead_provider)
 
       mixed_csv_content = <<~CSV
         participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name,has_passed

--- a/spec/features/admin/delivery_partnerships_spec.rb
+++ b/spec/features/admin/delivery_partnerships_spec.rb
@@ -97,12 +97,12 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
       partnership1 = create(:delivery_partnership,
                             delivery_partner: delivery_partner,
                             lead_provider: lead_provider,
-                            cohort: cohort1)
+                            course_cohort: create(:course_cohort, cohort: cohort1))
 
       partnership2 = create(:delivery_partnership,
                             delivery_partner: delivery_partner,
                             lead_provider: lead_provider,
-                            cohort: cohort2)
+                            course_cohort: create(:course_cohort, cohort: cohort2))
 
       visit edit_admin_delivery_partner_delivery_partnerships_path(delivery_partner)
 

--- a/spec/lib/tasks/delivery_partners_spec.rb
+++ b/spec/lib/tasks/delivery_partners_spec.rb
@@ -130,13 +130,14 @@ RSpec.describe "Delivery Partners rake tasks" do
 
     let(:lead_provider) { create :lead_provider }
     let(:cohort) { create(:cohort, :current) }
+    let(:course_cohort) { create(:course_cohort, cohort:, lead_provider:) }
     let(:delivery_partners) { create_list(:delivery_partner, 3) }
     let(:dry_run) { "false" }
     let(:csv_path) { csv_file.path }
 
     let :partnerships do
       delivery_partners.map do |partner|
-        [lead_provider.ecf_id, cohort.identifier, partner.ecf_id]
+        [lead_provider.ecf_id, course_cohort.ecf_id, partner.ecf_id]
       end
     end
 
@@ -145,7 +146,7 @@ RSpec.describe "Delivery Partners rake tasks" do
         CSV.open(tmp.path, "w") do |csv|
           csv << [
             "Lead Provider ECF Id",
-            "Cohort",
+            "Course Cohort ECF Id",
             "Delivery Partner ECF Id",
           ]
 
@@ -159,7 +160,7 @@ RSpec.describe "Delivery Partners rake tasks" do
 
       let :imported_partnership do
         DeliveryPartnership.find_by(delivery_partner: delivery_partners[0],
-                                    cohort:,
+                                    course_cohort:,
                                     lead_provider:)
       end
 
@@ -192,7 +193,7 @@ RSpec.describe "Delivery Partners rake tasks" do
     context "with invalid file" do
       let :partnerships do
         delivery_partners.map do
-          [lead_provider.ecf_id, cohort.identifier, delivery_partners[0].ecf_id]
+          [lead_provider.ecf_id, course_cohort.ecf_id, delivery_partners[0].ecf_id]
         end
       end
 
@@ -241,7 +242,7 @@ RSpec.describe "Delivery Partners rake tasks" do
       subject { csv_data[0].to_h.keys }
 
       let :expected_header do
-        ["Lead Provider ECF Id", "Cohort", "Delivery Partner ECF Id"]
+        ["Lead Provider ECF Id", "Course Cohort ECF Id", "Delivery Partner ECF Id"]
       end
 
       it { is_expected.to eq expected_header }
@@ -254,7 +255,7 @@ RSpec.describe "Delivery Partners rake tasks" do
 
       it { is_expected.to have_attributes length: 3 }
       it { is_expected.to include "Lead Provider ECF Id" => partnership.lead_provider.ecf_id }
-      it { is_expected.to include "Cohort" => partnership.cohort.identifier }
+      it { is_expected.to include "Course Cohort ECF Id" => partnership.course_cohort.ecf_id }
       it { is_expected.to include "Delivery Partner ECF Id" => partnership.delivery_partner.ecf_id }
     end
 

--- a/spec/models/bulk_operation/submit_declarations_spec.rb
+++ b/spec/models/bulk_operation/submit_declarations_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe BulkOperation::SubmitDeclarations do
 
     before do
       started_milestone
-      create(:delivery_partnership, cohort:, delivery_partner:, lead_provider:)
+      create(:delivery_partnership, cohort:, course_cohort: application.course_cohort, delivery_partner:, lead_provider:)
 
       bulk_operation.file.attach(csv_file.open)
       bulk_operation.save!

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -691,8 +691,8 @@ RSpec.describe Declaration, type: :model do
 
     let :lead_provider do
       create :lead_provider, delivery_partners: {
-        twenty_three => twenty_three_partner,
-        create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) => twenty_four_partner,
+        course_cohort => twenty_three_partner,
+        create(:course_cohort, cohort: create(:cohort, registration_starts_at: Date.new(2024, 4, 1))) => twenty_four_partner,
       }
     end
 
@@ -715,7 +715,7 @@ RSpec.describe Declaration, type: :model do
     end
 
     context "without milestone" do
-      before { allow(lead_provider).to receive(:delivery_partners_for_cohort) }
+      before { allow(lead_provider).to receive(:delivery_partners_for_course_cohort) }
 
       let(:declaration) { build(:declaration, delivery_partner: nil, lead_provider:, milestone: nil, declaration_date: 1.day.ago) }
 
@@ -724,7 +724,7 @@ RSpec.describe Declaration, type: :model do
       it "avoids querying the database" do
         available_delivery_partner_ids
 
-        expect(lead_provider).not_to have_received(:delivery_partners_for_cohort)
+        expect(lead_provider).not_to have_received(:delivery_partners_for_course_cohort)
       end
     end
   end

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -109,15 +109,20 @@ RSpec.describe DeliveryPartner, type: :model do
     end
   end
 
-  describe "#cohorts_for_lead_provider" do
-    subject { delivery_partner.cohorts_for_lead_provider(lead_provider) }
+  describe "#course_cohorts_for_lead_provider" do
+    subject { delivery_partner.course_cohorts_for_lead_provider(lead_provider) }
 
-    let(:delivery_partner) { create :delivery_partner, lead_providers: { cohort => lead_provider, other_cohort => other_lead_provider } }
-    let(:lead_provider) { create :lead_provider }
-    let(:other_lead_provider) { create :lead_provider }
-    let(:cohort) { create :cohort }
-    let(:other_cohort) { create :cohort, registration_starts_at: Date.new(2024, 5, 1) }
+    let(:delivery_partner) do
+      create(:delivery_partner, lead_providers: {
+        course_cohort => lead_provider,
+        other_course_cohort => other_lead_provider,
+      })
+    end
+    let(:lead_provider) { create(:lead_provider) }
+    let(:other_lead_provider) { create(:lead_provider) }
+    let(:course_cohort) { create(:course_cohort) }
+    let(:other_course_cohort) { create(:course_cohort, cohort: create(:cohort, registration_starts_at: Date.new(2024, 5, 1))) }
 
-    it { is_expected.to eq [cohort] }
+    it { is_expected.to eq [course_cohort] }
   end
 end

--- a/spec/models/delivery_partnership_spec.rb
+++ b/spec/models/delivery_partnership_spec.rb
@@ -4,22 +4,33 @@ RSpec.describe DeliveryPartnership, type: :model do
   describe "relationships" do
     it { is_expected.to belong_to :delivery_partner }
     it { is_expected.to belong_to :lead_provider }
-    it { is_expected.to belong_to :cohort }
+    it { is_expected.to belong_to(:cohort).optional }
     it { is_expected.to belong_to(:course_cohort).optional }
   end
 
   describe "validations" do
     it { is_expected.to validate_presence_of :delivery_partner_id }
     it { is_expected.to validate_presence_of :lead_provider_id }
-    it { is_expected.to validate_presence_of :cohort_id }
+
+    it "requires either a cohort or course cohort" do
+      partnership = build(:delivery_partnership, cohort: nil, course_cohort: nil)
+
+      expect(partnership).not_to be_valid
+      expect(partnership.errors).to include(:cohort_id, :course_cohort_id)
+    end
 
     describe "uniqueness" do
-      subject { described_class.new }
+      let(:delivery_partner) { create(:delivery_partner) }
+      let(:lead_provider) { create(:lead_provider) }
 
-      before { create :delivery_partnership }
+      it "prevents duplicate course cohort partnerships" do
+        course_cohort = create(:course_cohort)
+        create(:delivery_partnership, delivery_partner:, lead_provider:, course_cohort:, cohort: nil)
 
-      it "delivery partner must be unique for a given lead provider and cohort" do
-        expect(subject).to validate_uniqueness_of(:delivery_partner_id).scoped_to(%i[lead_provider_id cohort_id])
+        duplicate = build(:delivery_partnership, delivery_partner:, lead_provider:, course_cohort:, cohort: nil)
+
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors.of_kind?(:delivery_partner_id, :taken)).to be true
       end
     end
   end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -13,25 +13,21 @@ RSpec.describe LeadProvider do
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
   end
 
-  describe "#delivery_partners_for_cohort" do
-    subject { lead_provider.delivery_partners_for_cohort(twenty_three) }
+  describe "#delivery_partners_for_course_cohort" do
+    subject { lead_provider.delivery_partners_for_course_cohort(course_cohort:) }
 
-    let :lead_provider do
-      create_list(:lead_provider, 2, delivery_partners: {
-        twenty_three => twenty_three_partner,
-        create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) => twenty_four_partner,
-      }).first
+    let(:lead_provider) do
+      create(:lead_provider, delivery_partners: {
+        course_cohort => course_cohort_partner,
+        other_course_cohort => other_course_cohort_partner,
+      })
     end
+    let(:course_cohort) { create(:course_cohort) }
+    let(:other_course_cohort) { create(:course_cohort, course: create(:course)) }
+    let(:course_cohort_partner) { create(:delivery_partner) }
+    let(:other_course_cohort_partner) { create(:delivery_partner) }
 
-    let(:twenty_three) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
-    let(:twenty_three_partner) { create(:delivery_partner) }
-    let(:twenty_four_partner) { create(:delivery_partner) }
-    let(:unrelated_partner) { create(:delivery_partner) }
-
-    it { is_expected.to have_attributes length: 1 }
-    it { is_expected.to include twenty_three_partner }
-    it { is_expected.not_to include twenty_four_partner }
-    it { is_expected.not_to include unrelated_partner }
+    it { is_expected.to contain_exactly(course_cohort_partner) }
   end
 
   describe "#contract" do

--- a/spec/requests/api/v1/delivery_partners_spec.rb
+++ b/spec/requests/api/v1/delivery_partners_spec.rb
@@ -33,9 +33,11 @@ RSpec.describe "Delivery Partner endpoints", type: :request do
     context "when filtering by cohort" do
       let(:cohort_2023) { create(:cohort, registration_starts_at: Date.new(2023, 4, 1)) }
       let(:cohort_2024) { create(:cohort, registration_starts_at: Date.new(2024, 4, 1)) }
-      let!(:delivery_partner_2023) { create(:delivery_partner, lead_providers: { cohort_2023 => current_lead_provider }) }
+      let(:course_cohort_2023) { create(:course_cohort, cohort: cohort_2023, academic_year: cohort_2023.start_year) }
+      let(:course_cohort_2024) { create(:course_cohort, cohort: cohort_2024, academic_year: cohort_2024.start_year) }
+      let!(:delivery_partner_2023) { create(:delivery_partner, lead_providers: { course_cohort_2023 => current_lead_provider }) }
 
-      before { create(:delivery_partner, lead_providers: { cohort_2024 => current_lead_provider }) }
+      before { create(:delivery_partner, lead_providers: { course_cohort_2024 => current_lead_provider }) }
 
       it "returns delivery partners for the specified cohort" do
         api_get(path, params: { filter: { cohort: "2023" } })

--- a/spec/serializers/api/delivery_partner_serializer_spec.rb
+++ b/spec/serializers/api/delivery_partner_serializer_spec.rb
@@ -3,12 +3,15 @@ require "rails_helper"
 RSpec.describe API::DeliveryPartnerSerializer, type: :serializer do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:other_lead_provider) { create(:lead_provider) }
+  let(:course_cohort_21) { create(:course_cohort, cohort: cohort_21, academic_year: cohort_21.start_year) }
+  let(:course_cohort_22) { create(:course_cohort, cohort: cohort_22, academic_year: cohort_22.start_year) }
+  let(:course_cohort_23) { create(:course_cohort, cohort: cohort_23, academic_year: cohort_23.start_year) }
   let(:delivery_partner) do
     create(:delivery_partner,
            lead_providers: {
-             cohort_21 => current_lead_provider,
-             cohort_22 => current_lead_provider,
-             cohort_23 => other_lead_provider,
+             course_cohort_21 => current_lead_provider,
+             course_cohort_22 => current_lead_provider,
+             course_cohort_23 => other_lead_provider,
            })
   end
   let(:cohort_21) { create :cohort, registration_starts_at: Date.new(2021, 4, 1) }

--- a/spec/services/delivery_partners/query_spec.rb
+++ b/spec/services/delivery_partners/query_spec.rb
@@ -7,15 +7,18 @@ RSpec.describe DeliveryPartners::Query do
   let(:cohort_22) { create :cohort, registration_starts_at: Date.new(2022, 4, 1) }
   let(:cohort_23) { create :cohort, registration_starts_at: Date.new(2023, 4, 1) }
   let(:cohort_21_2) { create :cohort, registration_starts_at: Date.new(2021, 10, 1) }
+  let(:course_cohort_21) { create(:course_cohort, cohort: cohort_21, academic_year: cohort_21.start_year) }
+  let(:course_cohort_22) { create(:course_cohort, cohort: cohort_22, academic_year: cohort_22.start_year) }
+  let(:course_cohort_23) { create(:course_cohort, cohort: cohort_23, academic_year: cohort_23.start_year) }
   let(:sort) { nil }
 
   subject(:query) { described_class.new(lead_provider: lead_provider_1, sort: sort) }
 
   describe "#delivery_partners" do
-    let!(:delivery_partner_1) { create :delivery_partner, name: "z", lead_providers: { cohort_21 => lead_provider_1 }, created_at: 2.minutes.ago }
-    let!(:delivery_partner_2) { create :delivery_partner, name: "a", lead_providers: { cohort_21 => lead_provider_1, cohort_22 => lead_provider_1 }, created_at: 1.minute.ago }
-    let!(:delivery_partner_other_lead_provider) { create :delivery_partner, lead_providers: { cohort_21 => lead_provider_2 }, created_at: 1.minute.ago }
-    let!(:delivery_partner_an_hour_ago) { create :delivery_partner, name: "c", lead_providers: { cohort_23 => lead_provider_1 }, created_at: 1.hour.ago }
+    let!(:delivery_partner_1) { create :delivery_partner, name: "z", lead_providers: { course_cohort_21 => lead_provider_1 }, created_at: 2.minutes.ago }
+    let!(:delivery_partner_2) { create :delivery_partner, name: "a", lead_providers: { course_cohort_21 => lead_provider_1, course_cohort_22 => lead_provider_1 }, created_at: 1.minute.ago }
+    let!(:delivery_partner_other_lead_provider) { create :delivery_partner, lead_providers: { course_cohort_21 => lead_provider_2 }, created_at: 1.minute.ago }
+    let!(:delivery_partner_an_hour_ago) { create :delivery_partner, name: "c", lead_providers: { course_cohort_23 => lead_provider_1 }, created_at: 1.hour.ago }
 
     it "returns delivery partners for the specified lead provider, ordered by name" do
       expect(query.delivery_partners).to eq([delivery_partner_2, delivery_partner_an_hour_ago, delivery_partner_1])
@@ -62,7 +65,7 @@ RSpec.describe DeliveryPartners::Query do
       end
 
       before do
-        course_cohort = create(:course_cohort, cohort: cohort_21_2, lead_provider: lead_provider_1)
+        course_cohort = create(:course_cohort, cohort: cohort_21_2, academic_year: cohort_21_2.start_year, lead_provider: lead_provider_1)
         create(:delivery_partnership, delivery_partner: delivery_partner_1,
                                       course_cohort:,
                                       lead_provider: lead_provider_1)
@@ -92,9 +95,9 @@ RSpec.describe DeliveryPartners::Query do
     let!(:delivery_partner) do
       create(:delivery_partner,
              lead_providers: {
-               cohort_21 => lead_provider_1,
-               cohort_22 => lead_provider_1,
-               cohort_23 => lead_provider_2,
+               course_cohort_21 => lead_provider_1,
+               course_cohort_22 => lead_provider_1,
+               course_cohort_23 => lead_provider_2,
              })
     end
 
@@ -115,7 +118,7 @@ RSpec.describe DeliveryPartners::Query do
     end
 
     context "when a `lead_provider` is specified" do
-      let!(:other_delivery_partner) { create(:delivery_partner, lead_providers: { cohort_23 => lead_provider_2 }) }
+      let!(:other_delivery_partner) { create(:delivery_partner, lead_providers: { course_cohort_23 => lead_provider_2 }) }
 
       subject(:query) { described_class.new(lead_provider: lead_provider_1) }
 

--- a/spec/services/delivery_partners/query_spec.rb
+++ b/spec/services/delivery_partners/query_spec.rb
@@ -62,8 +62,9 @@ RSpec.describe DeliveryPartners::Query do
       end
 
       before do
+        course_cohort = create(:course_cohort, cohort: cohort_21_2, lead_provider: lead_provider_1)
         create(:delivery_partnership, delivery_partner: delivery_partner_1,
-                                      cohort: cohort_21_2,
+                                      course_cohort:,
                                       lead_provider: lead_provider_1)
       end
 

--- a/spec/support/helpers/bulk_operations.rb
+++ b/spec/support/helpers/bulk_operations.rb
@@ -20,9 +20,10 @@ module Helpers
         lead_provider = create(:lead_provider)
         delivery_partner = create(:delivery_partner)
         schedule = create(:schedule, cohort:, course_group: course.course_group, allowed_declaration_types: %w[started completed], training_starts_at: Date.yesterday)
+        course_cohort = CourseCohort.find_by(course:, cohort:) || create(:course_cohort, course:, cohort:, schedule:, lead_provider:)
 
         # Create required partnerships
-        create(:delivery_partnership, cohort:, delivery_partner:, lead_provider:)
+        create(:delivery_partnership, course_cohort:, delivery_partner:, lead_provider:)
 
         participant1 = create(:user)
         participant2 = create(:user)


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#647

Move delivery partner/partnerships to use course cohort

### Changes proposed in this pull request

Update service & API code to use course_cohort instead of cohort

Note that this is the second of four stacked PRs

## Checklists:

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [X] API
