### PR TITLE
[647] Update delivery partner admin

### DIFF
--- a/app/controllers/admin/cohort_courses_controller.rb
+++ b/app/controllers/admin/cohort_courses_controller.rb
@@ -5,7 +5,7 @@ class Admin::CohortCoursesController < AdminController
   def show
     @cohorts = Cohort.where(id: @course.course_cohorts.select(:cohort_id)).order_by_latest
     @delivery_partner_counts = DeliveryPartnership
-      .where(cohort:, lead_provider_id: @course_cohort.lead_provider_ids)
+      .where(course_cohort: @course_cohort, lead_provider_id: @course_cohort.lead_provider_ids)
       .group(:lead_provider_id)
       .count
   end

--- a/app/controllers/admin/delivery_partners_controller.rb
+++ b/app/controllers/admin/delivery_partners_controller.rb
@@ -36,7 +36,7 @@ class Admin::DeliveryPartnersController < AdminController
   end
 
   def update
-    if @delivery_partner.name.present? && DeliveryPartner.name_similar_to(@delivery_partner.name).any?
+    if @delivery_partner.name.present? && @delivery_partner.will_save_change_to_name? && DeliveryPartner.name_similar_to(@delivery_partner.name).any?
       render :similar
     elsif save_delivery_partner
       redirect_to action: :index
@@ -60,7 +60,7 @@ private
       delivery_partnerships_attributes: %i[
         id
         lead_provider_id
-        cohort_id
+        course_cohort_id
         _destroy
       ],
     )

--- a/app/controllers/admin/delivery_partnerships_controller.rb
+++ b/app/controllers/admin/delivery_partnerships_controller.rb
@@ -2,6 +2,6 @@ class Admin::DeliveryPartnershipsController < AdminController
   def edit
     @delivery_partner = DeliveryPartner.find(params[:delivery_partner_id])
     @lead_providers = LeadProvider.all.order(:name)
-    @cohorts = Cohort.all.order(created_at: :desc)
+    @course_cohorts = CourseCohort.includes(:course, :cohort).order("cohorts.registration_starts_at DESC", "courses.name ASC")
   end
 end

--- a/app/controllers/admin/delivery_partnerships_controller.rb
+++ b/app/controllers/admin/delivery_partnerships_controller.rb
@@ -2,6 +2,6 @@ class Admin::DeliveryPartnershipsController < AdminController
   def edit
     @delivery_partner = DeliveryPartner.find(params[:delivery_partner_id])
     @lead_providers = LeadProvider.all.order(:name)
-    @course_cohorts = CourseCohort.includes(:course, :cohort).order("cohorts.registration_starts_at DESC", "courses.name ASC")
+    @course_cohorts = CourseCohort.includes(:course, :cohort).order(:academic_year)
   end
 end

--- a/app/controllers/admin/lead_providers_controller.rb
+++ b/app/controllers/admin/lead_providers_controller.rb
@@ -19,7 +19,11 @@ module Admin
       if @current_cohort
         applications_scope.merge!(Application.where(course_cohorts: { cohort: @current_cohort }))
         @pagy_applications, @applications = pagy(applications_scope, items: 25)
-        @pagy_delivery_partners, @delivery_partners = pagy(@lead_provider.delivery_partners_for_cohort(@current_cohort))
+        delivery_partners = @lead_provider.delivery_partners
+                                          .joins(delivery_partnerships: :course_cohort)
+                                          .where(course_cohorts: { cohort: @current_cohort })
+                                          .distinct
+        @pagy_delivery_partners, @delivery_partners = pagy(delivery_partners)
       else
         @pagy_applications, @applications = pagy(applications_scope, items: 25)
         @pagy_delivery_partners, @delivery_partners = pagy(@lead_provider.delivery_partners.distinct)

--- a/app/views/admin/delivery_partnerships/edit.html.erb
+++ b/app/views/admin/delivery_partnerships/edit.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_back_link(href: admin_delivery_partners_path) %>
 
 <h1 class="govuk-heading-l">Assign <%= @delivery_partner.name %> to provider</h1>
-<p class="govuk-caption-m">Select all providers and cohorts that apply</p>
+<p class="govuk-caption-m">Select all providers and course cohorts that apply</p>
 
 <%= form_with model: [:admin, @delivery_partner], method: :patch, id: 'delivery-partnerships-form' do |form| %>
   <%= form.govuk_error_summary %>
@@ -11,11 +11,11 @@
       <%= form.govuk_check_boxes_fieldset :lead_providers, legend: nil do %>
         <%= form.govuk_check_box :lead_provider_id, lead_provider.id, label: { text: lead_provider.name }, checked: @delivery_partner.delivery_partnerships.where(lead_provider:).any? do %>
           <p class="govuk-caption-m">Select all that apply</p>
-          <% @cohorts.each do |cohort| %>
-            <%= form.fields_for :delivery_partnerships, @delivery_partner.delivery_partnerships.find_or_initialize_by(lead_provider:, cohort:) do |delivery_partnership_form| %>
+          <% @course_cohorts.each do |course_cohort| %>
+            <%= form.fields_for :delivery_partnerships, @delivery_partner.delivery_partnerships.find_or_initialize_by(lead_provider:, course_cohort:) do |delivery_partnership_form| %>
               <%= delivery_partnership_form.hidden_field :lead_provider_id, value: lead_provider.id %>
-              <%= delivery_partnership_form.hidden_field :cohort_id, value: cohort.id %>
-              <%= delivery_partnership_form.govuk_check_box :_destroy, 0, 1, multiple: false, label: { text: "Cohort #{cohort.description}" }, checked: delivery_partnership_form.object.persisted? %>
+              <%= delivery_partnership_form.hidden_field :course_cohort_id, value: course_cohort.id %>
+              <%= delivery_partnership_form.govuk_check_box :_destroy, 0, 1, multiple: false, label: { text: "#{course_cohort.course.name} – #{course_cohort.cohort.description}" }, checked: delivery_partnership_form.object.persisted? %>
             <% end %>
           <% end %>
         <% end %>

--- a/spec/features/admin/delivery_partnerships_spec.rb
+++ b/spec/features/admin/delivery_partnerships_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
   let!(:delivery_partner) { create(:delivery_partner) }
   let!(:lead_providers) { create_list(:lead_provider, 3) }
   let!(:cohorts) { [create(:cohort, :current), create(:cohort, :next)] }
+  let!(:course_cohorts) { cohorts.map { |cohort| create(:course_cohort, cohort:) } }
 
   context "when not logged in" do
     scenario "delivery partnerships interface is inaccessible" do
@@ -32,14 +33,14 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
           expect(page).to have_content(lead_provider.name)
         end
 
-        # Cohorts are hidden until a course provider is selected
-        expect(page).not_to have_content("Cohort")
+        # Course cohorts are hidden until a course provider is selected
+        expect(page).not_to have_content(course_cohort_label(course_cohorts.first))
       end
     end
 
     scenario "assigning course providers and cohorts to a delivery partner" do
       lead_provider = lead_providers.first
-      cohort = cohorts.first
+      course_cohort = course_cohorts.first
 
       visit edit_admin_delivery_partner_delivery_partnerships_path(delivery_partner)
 
@@ -48,25 +49,25 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
 
       # Check the cohort checkbox for this course provider
       within("#delivery-partner-lead-provider-id-#{lead_provider.id}-conditional") do
-        check cohort_label(cohort), visible: :all
+        check course_cohort_label(course_cohort), visible: :all
       end
 
       click_button "Save"
 
       expect(page).to have_current_path(admin_delivery_partners_path)
       expect(page).to have_content("Delivery partner updated")
-      expect(DeliveryPartnership.where(delivery_partner:, lead_provider:, cohort:)).to exist
+      expect(DeliveryPartnership.where(delivery_partner:, lead_provider:, course_cohort:)).to exist
     end
 
     scenario "removing a course provider partnership" do
       # Create an existing partnership
       lead_provider = lead_providers.first
-      cohort = cohorts.first
+      course_cohort = course_cohorts.first
 
       delivery_partnership = create(:delivery_partnership,
                                     delivery_partner:,
                                     lead_provider:,
-                                    cohort:)
+                                    course_cohort:)
 
       visit edit_admin_delivery_partner_delivery_partnerships_path(delivery_partner)
 
@@ -75,7 +76,7 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
 
       # The cohort should be checked
       within("#delivery-partner-lead-provider-id-#{lead_provider.id}-conditional") do
-        expect(page).to have_field(cohort_label(cohort), checked: true, visible: :all)
+        expect(page).to have_field(course_cohort_label(course_cohort), checked: true, visible: :all)
       end
 
       # Uncheck the course provider (this should also uncheck all cohorts via JS)
@@ -88,21 +89,66 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
       expect(DeliveryPartnership.find_by(id: delivery_partnership.id)).to be_nil
     end
 
+    scenario "assigning two course cohorts in the same cohort" do
+      lead_provider = lead_providers.first
+      cohort = cohorts.first
+      first_course_cohort = course_cohorts.first
+      second_course_cohort = create(:course_cohort, cohort:, course: create(:course))
+
+      create(:delivery_partnership,
+             delivery_partner:,
+             lead_provider:,
+             cohort:,
+             course_cohort: first_course_cohort)
+
+      visit edit_admin_delivery_partner_delivery_partnerships_path(delivery_partner)
+
+      within("#delivery-partner-lead-provider-id-#{lead_provider.id}-conditional") do
+        check course_cohort_label(second_course_cohort), visible: :all
+      end
+
+      click_button "Save"
+
+      expect(page).to have_current_path(admin_delivery_partners_path)
+      expect(delivery_partner.course_cohorts.reload).to contain_exactly(first_course_cohort, second_course_cohort)
+      expect(delivery_partner.delivery_partnerships.find_by(course_cohort: second_course_cohort).cohort_id).to be_nil
+    end
+
+    scenario "assigning a course cohort when another delivery partner has a similar name" do
+      delivery_partner.update!(name: "Delivery partner 1")
+      create(:delivery_partner, name: "Delivery partner 2")
+      lead_provider = lead_providers.first
+      course_cohort = course_cohorts.first
+
+      visit edit_admin_delivery_partner_delivery_partnerships_path(delivery_partner)
+
+      check lead_provider.name, visible: :all
+      within("#delivery-partner-lead-provider-id-#{lead_provider.id}-conditional") do
+        check course_cohort_label(course_cohort), visible: :all
+      end
+
+      click_button "Save"
+
+      expect(page).to have_current_path(admin_delivery_partners_path)
+      expect(page).not_to have_content("We found similar delivery partners")
+      expect(DeliveryPartnership.where(delivery_partner:, lead_provider:, course_cohort:)).to exist
+    end
+
     scenario "removing a specific cohort from a course provider partnership" do
       # Create existing partnerships for two cohorts
       lead_provider = lead_providers.first
-      cohort1 = cohorts.first
-      cohort2 = cohorts.second
+      course_cohort1 = course_cohorts.first
+      course_cohort2 = course_cohorts.second
 
       partnership1 = create(:delivery_partnership,
                             delivery_partner: delivery_partner,
                             lead_provider: lead_provider,
-                            course_cohort: create(:course_cohort, cohort: cohort1))
+                            course_cohort: course_cohort1)
 
       partnership2 = create(:delivery_partnership,
                             delivery_partner: delivery_partner,
                             lead_provider: lead_provider,
-                            course_cohort: create(:course_cohort, cohort: cohort2))
+                            course_cohort: course_cohort2)
 
       visit edit_admin_delivery_partner_delivery_partnerships_path(delivery_partner)
 
@@ -111,11 +157,11 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
 
       # Both cohorts should be checked
       within("#delivery-partner-lead-provider-id-#{lead_provider.id}-conditional") do
-        expect(page).to have_field(cohort_label(cohort1), checked: true, visible: :all)
-        expect(page).to have_field(cohort_label(cohort2), checked: true, visible: :all)
+        expect(page).to have_field(course_cohort_label(course_cohort1), checked: true, visible: :all)
+        expect(page).to have_field(course_cohort_label(course_cohort2), checked: true, visible: :all)
 
         # Uncheck just the first cohort
-        uncheck cohort_label(cohort1), visible: :all
+        uncheck course_cohort_label(course_cohort1), visible: :all
       end
 
       click_button "Save"
@@ -136,7 +182,7 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
 
 private
 
-  def cohort_label(cohort)
-    "Cohort #{cohort.description}"
+  def course_cohort_label(course_cohort)
+    "#{course_cohort.course.name} – #{course_cohort.cohort.description}"
   end
 end

--- a/spec/requests/admin/cohort_courses_controller_spec.rb
+++ b/spec/requests/admin/cohort_courses_controller_spec.rb
@@ -14,13 +14,14 @@ RSpec.describe Admin::CohortCoursesController, :ecf_api_disabled, type: :request
   let(:valid_params) { { course_cohort: { course_id: course.id, schedule_id: schedule.id } } }
   let(:invalid_params) { { course_cohort: { course_id: "", schedule_id: "" } } }
 
-  before { create_list(:delivery_partnership, 2, cohort:, lead_provider:) }
-
   context "when logged in as super admin" do
     before { sign_in_as_admin(super_admin: true) }
 
     describe "#show" do
-      before { get admin_cohort_course_path(cohort, course_cohort.course) }
+      before do
+        create_list(:delivery_partnership, 2, course_cohort:, lead_provider:)
+        get admin_cohort_course_path(cohort, course_cohort.course)
+      end
 
       it { is_expected.to have_http_status :success }
 


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#647

Move delivery partner/partnerships to use course cohort

### Changes proposed in this pull request

Update admin console controllers/views to use course_cohort instead of cohort

Note that this is the third of four stacked PRs