### PR TITLE
Adds variable for server_version for postgres and sets review to v17

### DIFF
--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -4,6 +4,7 @@
     "environment": "review",
     "deploy_azure_backing_services": false,
     "enable_postgres_ssl" : false,
+    "server_version": "17",
     "command": ["/bin/sh", "-c", "RAILS_ENV=review bundle exec rails db:environment:set db:schema:load db:migrate && bundle exec rails server -b 0.0.0.0"],
     "enable_logit": true,
     "enable_dfe_analytics_federated_auth": false,

--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -11,7 +11,7 @@ module "postgres" {
   use_azure                   = var.deploy_azure_backing_services
   azure_enable_monitoring     = var.enable_monitoring
   azure_enable_backup_storage = var.enable_postgres_backup_storage
-  server_version              = "16"
+  server_version              = var.server_version
   azure_extensions            = ["btree_gin", "citext", "fuzzystrmatch", "pg_trgm"]
   azure_maintenance_window    = var.azure_maintenance_window
   azure_enable_high_availability = var.postgres_enable_high_availability

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -184,3 +184,9 @@ variable "redis_mode" {
    error_message = "redis_mode must be either 'legacy' (Cache for Redis) or 'managed' (Managed Redis)."
    }
  }
+
+ variable "server_version" {
+   description = "Sets version of Postgres DB to use"
+   type        = string
+   default     = "16"
+ }


### PR DESCRIPTION
### Context

Upgrades the version of postgres for the review app to v17

[Why are we making this change?]

Upgrade of postgres to version 17

[What has been changed?]

Variable added to postgres terraform to allow version of postgres to be controlled per environment, has a default value of 16 at the moment.
Sets server_version variable for review to v17

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Adds/removes serializer fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] API

### Data Integrity

Does this change affects existing data:
- [ ] Plan data migration

</details>
