### PR TITLE
2855 - Fixes typo in review-app-reconcile

### DIFF
--- a/.github/workflows/review-app-reconcile.yml
+++ b/.github/workflows/review-app-reconcile.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Set pull_request_number
         id: pull_request_number
         run: |
-          echo PULL_REQUEST_NUMBER=${{ matrix.pr_number }}" >> $GITHUB_ENV
+          echo "PULL_REQUEST_NUMBER=${{ matrix.pr_number }}" >> $GITHUB_ENV
 
       - name: Set environment variables
         shell: bash


### PR DESCRIPTION
## Context

The Reconcile review apps on AKS ran as scheduled yesterday morning, but failed at the delete stage due to a typo in the setting of environment variables.

## Changes proposed in this pull request

Added missing quotation mark to offending line.

## Link to Trello card

[Trello card](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)

## Checklist:

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Applied DevOps label
- [x] Tested by running locally