### PR TITLE
2937 - Postgres upgrade 17 Redis migration

### DIFF
--- a/.github/workflows/lead_provider_openapi_check.yml
+++ b/.github/workflows/lead_provider_openapi_check.yml
@@ -35,7 +35,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -67,7 +67,7 @@ jobs:
 
       - name: Set up test database
         run: bin/rails db:setup
- 
+
       - name: Generate API doc checksums (original)
         run: |
           find public/api/docs/ -type f -exec sed -i 's/[[:space:]]\+$//' {} \;

--- a/.github/workflows/refresh_knapsack_manifest.yml
+++ b/.github/workflows/refresh_knapsack_manifest.yml
@@ -25,7 +25,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -91,7 +91,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ x-app: &app
 
 services:
   db:
-    image: postgres:14-alpine
+    image: postgres:17-alpine
     restart: always
     volumes:
       - db-data:/var/lib/postgresql/data

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -19,5 +19,7 @@
     "statuscake_contact_groups": [282453, 356280],
     "blob_delete_retention_days": 7,
     "container_delete_retention_days": 7,
-    "enable_dfe_analytics_federated_auth": true
+    "enable_dfe_analytics_federated_auth": true,
+    "server_version": "17",
+    "redis_mode": "managed"
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -188,5 +188,5 @@ variable "redis_mode" {
  variable "server_version" {
    description = "Sets version of Postgres DB to use"
    type        = string
-   default     = "16"
+   default     = "17"
  }


### PR DESCRIPTION
### Context

We want to upgrade Postgres to version 17 and migrate to managed Redis at the same time.

### Changes proposed in this pull request

- Set the production environment to use Postgres v17
- Set the default Postgres version to 17 throughout the code.
- Point to the managed Redis instead of the Cache for Redis with a change to a Kubernetes secret.

### Guidance to review

- This PR must only be merged **AFTER** the manual upgrade has been completed.
- Make sure the PostgreSQL version is 17 in the overview of s189p01-cpdtte-pd-pg in the Azure portal.
- Check the Grafana Dashboards in the Azure portal to ensure we're using the [Managed Redis](https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-cpdtte-pd-rg/providers/Microsoft.Cache/redisEnterprise/s189p01-cpdtte-production-managed-redis-cache/AzureGrafanaReactView) not the [Cache for Redis](https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-cpdtte-pd-rg/providers/Microsoft.Cache/Redis/s189p01-cpdtte-production-redis/insights).

### Link to Trello card

https://trello.com/c/4wZkBbGt/2807-upgrade-tte-postgres-version
https://trello.com/c/fehZCkrS/2896-service-tte-migrate-redis

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
