### PR TITLE
2896 - Control Redis by environment and destroy staging

### DIFF
--- a/terraform/application/config/staging.tfvars.json
+++ b/terraform/application/config/staging.tfvars.json
@@ -6,5 +6,6 @@
     "container_delete_retention_days": 7,
     "enable_dfe_analytics_federated_auth": false,
     "server_version": "17",
-    "redis_mode": "managed"
+    "redis_mode": "managed",
+    "deploy_cache_redis": false
 }

--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -22,6 +22,7 @@ module "postgres" {
 module "redis-cache" {
   source = "./vendor/modules/aks//aks/redis"
 
+  count                     = var.deploy_cache_redis ? 1 : 0
   namespace                 = var.namespace
   environment               = local.environment
   azure_resource_prefix     = var.azure_resource_prefix
@@ -38,6 +39,7 @@ module "redis-cache" {
 module "redis-managed-cache" {
   source = "./vendor/modules/aks//aks/redis_managed"
 
+  count                 = var.deploy_managed_redis ? 1 : 0
   name                  = "cache"
   namespace             = var.namespace
   environment           = local.environment
@@ -52,4 +54,34 @@ module "redis-managed-cache" {
   azure_enable_monitoring = var.enable_monitoring
 
   azure_managed_redis_sku = var.redis_managed_cache_sku_name
+}
+
+moved {
+  from = module.redis-managed-cache.azurerm_private_endpoint.main[0]
+  to   = module.redis-managed-cache[0].azurerm_private_endpoint.main[0]
+}
+
+moved {
+  from = module.redis-managed-cache.azurerm_managed_redis.main[0]
+  to   = module.redis-managed-cache[0].azurerm_managed_redis.main[0]
+}
+
+moved  {
+  from = module.redis-cache.azurerm_redis_cache.main[0]
+  to   = module.redis-cache[0].azurerm_redis_cache.main[0]
+}
+
+moved {
+  from = module.redis-cache.azurerm_private_endpoint.main[0]
+  to   = module.redis-cache[0].azurerm_private_endpoint.main[0]
+}
+
+moved {
+  from = module.redis-managed-cache.azurerm_monitor_metric_alert.memory[0]
+  to   = module.redis-managed-cache[0].azurerm_monitor_metric_alert.memory[0]
+}
+
+moved {
+  from = module.redis-cache.azurerm_monitor_metric_alert.memory[0]
+  to   = module.redis-cache[0].azurerm_monitor_metric_alert.memory[0]
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -87,10 +87,10 @@ locals {
 
   redis = {
     legacy = {
-      cache_url = module.redis-cache.url
+      cache_url = try(module.redis-cache[0].url, null)
     }
     managed = {
-      cache_url = module.redis-managed-cache.url
+      cache_url = try(module.redis-managed-cache[0].url, null)
     }
   }
   selected_redis = local.redis[var.redis_mode]
@@ -190,3 +190,15 @@ variable "redis_mode" {
    type        = string
    default     = "17"
  }
+
+variable "deploy_cache_redis" {
+  description = "Whether to create a Cache for Redis instance"
+  type        = bool
+  default     = true
+}
+
+variable "deploy_managed_redis" {
+  description = "Whether to create a Managed Redis instance"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Context

https://trello.com/c/fehZCkrS/2896-service-tte-migrate-redis

We need to migrate from Cache for Redis to Managed Redis. There's insufficient capacity in UK South at the moment which causes problems with deploying instances of Managed Redis.

This change will remove the Cache for Redis in staging only. All environments are already using Managed Redis. Subsequent PRs will be required to destroy the other Cache for Redis instances and associated resources.

## Changes proposed in this pull request

This change gives us the ability to deploy and destroy Managed Redis instances and Cache for Redis instances by environment.
- New variables used as flags to create or destroy instances by environment.
- Redis modules logic changed to take into account the new flags.
- moved blocks needed as the Managed Redis resources and Cache for Redis resources are now indexed by terraform.

## Guidance to review

- `make review terraform-plan PR_NUMBER=1` shows that it would create Managed Redis resources as a  kubernetes_service
- `make staging terraform-plan` will show no changes other than new Kubernetes deployments, the destruction of the Cache for Redis instance and associated resources and the moves from unindexed resources to indexed resources.
- `make sandbox terraform-plan` will show no changes other than new Kubernetes deployments and the moves from unindexed resources to indexed resources.
- `make production terraform-plan CONFIRM_PRODUCTION=yes` will show no changes other than new Kubernetes deployments and the moves from unindexed resources to indexed resources.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `devops` label
- [x] I have attached the pull request to the Trello card