### PR TITLE
Disable npm/yarn install scripts

### DIFF
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -9,11 +9,11 @@ echo "Installing dependencies..."
 # See: https://github.com/ruby/bigdecimal/issues/297
 export CC=/usr/bin/clang && export CXX=/usr/bin/clang++
 bundle install
-yarn install
+yarn install --ignore-scripts
 yarn build
 yarn build:css
 
 echo "Creating database..."
-bin/rails db:prepare 
+bin/rails db:prepare
 
 echo "Done!"

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,13 @@ end
 
 Rails.application.load_tasks
 
+# these tasks are redefined in lib/tasks/yarn_overrides.rake to allow installing with --ignore-scripts
+Rake::Task["yarn:install"].clear
+Rake::Task["javascript:install"].clear
+Rake::Task["css:install"].clear
+
+load "lib/tasks/yarn_overrides.rake"
+
 task default: ["lint:ruby", "lint:scss", "spec"]
 
 Knapsack.load_tasks if defined?(Knapsack)

--- a/bin/setup
+++ b/bin/setup
@@ -18,7 +18,7 @@ FileUtils.chdir APP_ROOT do
   system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies
-  system!('bin/yarn')
+  system!("bin/yarn --ignore-scripts")
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")

--- a/lib/tasks/yarn_overrides.rake
+++ b/lib/tasks/yarn_overrides.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+namespace :yarn do
+  desc "overrides the default install task to allow installing with --ignore-scripts"
+  # rake task this is overriding can be found here: https://github.com/rails/rails/blob/v8.0.4.1/railties/lib/rails/tasks/yarn.rake
+  task :install do # rubocop:disable Rails/RakeEnvironment
+    system("yarn install --no-progress --frozen-lockfile --ignore-scripts")
+  end
+end
+
+namespace :javascript do
+  desc "overrides the default install task to allow installing with --ignore-scripts"
+  # rake task this is overriding can be found here: https://github.com/rails/jsbundling-rails/blob/v1.3.1/lib/tasks/jsbundling/build.rake#L28
+  task :install do # rubocop:disable Rails/RakeEnvironment
+    system("yarn install --ignore-scripts")
+  end
+end
+
+namespace :css do
+  desc "overrides the default install task to allow installing with --ignore-scripts"
+  # rake task this is overriding can be found here: https://github.com/rails/cssbundling-rails/blob/v1.4.3/lib/tasks/cssbundling/build.rake#L3
+  task :install do # rubocop:disable Rails/RakeEnvironment
+    system("yarn install --ignore-scripts")
+  end
+end


### PR DESCRIPTION
### Context

Fixes DFE-Digital/teacher-training-entitlement-board#662

To avoid running scripts at install for security reason
