### PR TITLE
Fix bug in course/cohort calculator

### DIFF
--- a/app/services/statements/course_cohort_calculator.rb
+++ b/app/services/statements/course_cohort_calculator.rb
@@ -2,7 +2,6 @@ module Statements
   class CourseCohortCalculator
     def initialize(statement:, course_cohort:)
       @statement = statement
-      @lead_provider = statement.lead_provider
       @course_cohort = course_cohort
       @contract = statement.lead_provider.contract(course_cohort:)
       @milestones = course_cohort.milestones
@@ -12,11 +11,11 @@ module Statements
     attr_reader :contract, :course_name
 
     def funded
-      @funded ||= milestones.map { |milestone| calculate_row(milestone, funded_place: [true]) }
+      @funded ||= milestones.map { |milestone| calculate_row(milestone:, funded_place: [true]) }
     end
 
     def self_funded
-      @self_funded ||= milestones.map { |milestone| calculate_row(milestone, funded_place: [nil, false]) }
+      @self_funded ||= milestones.map { |milestone| calculate_row(milestone:, funded_place: [nil, false]) }
     end
 
     def get_funded(key, declaration_type:)
@@ -42,32 +41,16 @@ module Statements
 
   private
 
-    attr_reader :statement, :lead_provider, :course_cohort, :milestones
+    attr_reader :statement, :course_cohort, :milestones
 
-    def calculate_row(milestone, funded_place:)
-      received = received_for(milestone, funded_place:)
-      if funded_place.all?
-        expected = expected_for(milestone, funded_place:)
-        value = value_for(milestone)
-        {
-          declaration_type: milestone.declaration_type,
-          expected:,
-          received:,
-          outstanding: expected - received,
-          value:,
-          expected_value: (value ? expected * value : nil),
-          received_value: (value ? received * value : nil),
-        }
-      else
-        {
-          declaration_type: milestone.declaration_type,
-          expected: 0,
-          received:,
-          outstanding: 0,
-          expected_value: 0,
-          received_value: 0,
-        }
-      end
+    def calculate_row(milestone:, funded_place:)
+      MilestoneCourseCohortCalculator.new(
+        statement:,
+        course_cohort:,
+        milestone:,
+        funded_place:,
+        contract:,
+      ).row
     end
 
     def summarize(rows)
@@ -79,55 +62,6 @@ module Statements
         expected_value: rows.sum { |row| row[:expected_value] || 0 },
         received_value: rows.sum { |row| row[:received_value] || 0 },
       }
-    end
-
-    def received_for(milestone, funded_place:)
-      statement
-        .declarations
-        .billable
-        .joins(:application)
-        .where(milestone:, application: { funded_place: })
-        .count
-    end
-
-    def value_for(milestone)
-      return if milestone.payment_amount.blank?
-
-      contract.teacher_funding * (milestone.payment_amount / 100)
-    end
-
-    def expected_for(milestone, funded_place:)
-      return 0 if statement.deadline_date <= milestone.acceptance_window_start_date
-
-      scope = provider_applications(funded_place:)
-      if milestone.started_declaration_type?
-        scope.where(status: [Application::ACCEPTED, Application::STARTED, Application::COMPLETED])
-      else
-        scope.where(status: [Application::STARTED, Application::COMPLETED])
-      end
-
-      forecast = scope.count - previous_declarations(milestone:)
-      forecast.positive? ? forecast : 0
-    end
-
-    def provider_applications(funded_place:)
-      course_cohort.applications
-        .joins(:current_application_lead_provider)
-        .where(funded_place:)
-        .where(application_lead_providers: { lead_provider: })
-    end
-
-    def previous_declarations(milestone:)
-      previous_statments = Statement
-                             .includes(:declarations)
-                             .where(lead_provider:)
-                             .where.not(id: statement.id)
-                             .where(declarations: { milestone: })
-                             .all
-
-      previous_statments.sum do |statement|
-        statement.declarations.joins(:application).billable.where(milestone:, application: { funded_place: [true] }).count
-      end
     end
   end
 end

--- a/app/services/statements/milestone_course_cohort_calculator.rb
+++ b/app/services/statements/milestone_course_cohort_calculator.rb
@@ -1,0 +1,97 @@
+module Statements
+  class MilestoneCourseCohortCalculator
+    def initialize(statement:, course_cohort:, milestone:, funded_place:, contract:)
+      @statement = statement
+      @lead_provider = statement.lead_provider
+      @course_cohort = course_cohort
+      @milestone = milestone
+      @funded_place = funded_place
+      @contract = contract
+    end
+
+    def row
+      received = received_count
+
+      return self_funded_row(received:) unless funded?
+
+      expected = expected_count
+      value = value_for_milestone
+      {
+        declaration_type: milestone.declaration_type,
+        expected:,
+        received:,
+        outstanding: expected - received,
+        value:,
+        expected_value: (value ? expected * value : nil),
+        received_value: (value ? received * value : nil),
+      }
+    end
+
+  private
+
+    attr_reader :statement, :lead_provider, :course_cohort, :milestone, :funded_place, :contract
+
+    def funded?
+      funded_place.all?
+    end
+
+    def self_funded_row(received:)
+      {
+        declaration_type: milestone.declaration_type,
+        expected: 0,
+        received:,
+        outstanding: 0,
+        expected_value: 0,
+        received_value: 0,
+      }
+    end
+
+    def received_count
+      statement
+        .declarations
+        .billable
+        .joins(:application)
+        .where(milestone:, application: { funded_place: })
+        .count
+    end
+
+    def value_for_milestone
+      return if milestone.payment_amount.blank?
+
+      contract.teacher_funding * (milestone.payment_amount / 100)
+    end
+
+    def expected_count
+      return 0 if statement.deadline_date <= milestone.acceptance_window_start_date
+
+      forecast = provider_applications_count - previous_declarations_count
+      forecast.positive? ? forecast : 0
+    end
+
+    def provider_applications_count
+      scope = course_cohort.applications
+        .joins(:current_application_lead_provider)
+        .where(funded_place:)
+        .where(application_lead_providers: { lead_provider: })
+
+      if milestone.started_declaration_type?
+        scope.where(status: [Application::ACCEPTED, Application::STARTED, Application::COMPLETED]).count
+      else
+        scope.where(status: [Application::STARTED, Application::COMPLETED]).count
+      end
+    end
+
+    def previous_declarations_count
+      previous_statements = Statement
+        .includes(:declarations)
+        .where(lead_provider:)
+        .where.not(id: statement.id)
+        .where(declarations: { milestone: })
+        .all
+
+      previous_statements.sum do |statement|
+        statement.declarations.joins(:application).billable.where(milestone:, application: { funded_place: [true] }).count
+      end
+    end
+  end
+end

--- a/spec/services/statements/course_cohort_calculator_spec.rb
+++ b/spec/services/statements/course_cohort_calculator_spec.rb
@@ -45,11 +45,14 @@ RSpec.describe Statements::CourseCohortCalculator do
 
   describe "with only started declarations" do
     before do
-      # course_cohort has 5 applications (4 funded and 1 self-funded)
+      # course_cohort has 7 applications (4 funded, 2 rejected funded and 1 self-funded)
       # lead provider has 1 paid statement and 1 open statement for course_cohort
       # paid statement has 1 started declaration
       # open statement has 3 started declarations (2 funded, 1 self-funded)
       # completed milestone acceptance window is in the future so not expecting any completed declarations
+
+      # create some rejected applications to ensure they are not counted
+      create_list(:application, 2, :with_funded_place, course_cohort:, lead_provider:, status: Application::REJECTED)
 
       # out of scope for calculation
       started_received(application: funded_apps[0], statement: paid_statement, milestone: started_milestone)

--- a/spec/services/statements/milestone_course_cohort_calculator_spec.rb
+++ b/spec/services/statements/milestone_course_cohort_calculator_spec.rb
@@ -1,0 +1,133 @@
+require "rails_helper"
+
+RSpec.describe Statements::MilestoneCourseCohortCalculator do
+  subject(:calculator) do
+    described_class.new(
+      statement:,
+      course_cohort:,
+      milestone:,
+      funded_place:,
+      contract:,
+    )
+  end
+
+  let(:lead_provider) { create(:lead_provider) }
+  let(:statement) { create(:statement, lead_provider:, deadline_date: Time.zone.today) }
+  let(:paid_statement) { create(:statement, :paid, lead_provider:) }
+  let(:course_cohort) do
+    create(:course_cohort).tap do |course_cohort|
+      create(:course_cohort_provider, course_cohort:, lead_provider:, teacher_funding: 100)
+    end
+  end
+  let(:contract) { lead_provider.contract(course_cohort:) }
+  let(:milestone) { create(:milestone, :started, course_cohort:, payment_amount: 60, acceptance_window_start_date: 1.day.ago) }
+  let(:funded_place) { [true] }
+
+  def create_declaration(application:, statement:, milestone:)
+    if milestone.started_declaration_type?
+      application.update!(status: Application::STARTED)
+    else
+      application.update!(status: Application::STARTED) if application.accepted_status?
+      application.update!(status: Application::COMPLETED)
+    end
+
+    create(
+      :declaration,
+      :eligible,
+      milestone.declaration_type.to_sym,
+      application:,
+      statement:,
+      milestone:,
+      lead_provider: statement.lead_provider,
+    )
+  end
+
+  describe "#row" do
+    context "with a funded started milestone" do
+      before do
+        create_list(:application, 2, :with_funded_place, course_cohort:, lead_provider:, status: Application::REJECTED)
+        create_declaration(application: funded_apps.first, statement: paid_statement, milestone:)
+
+        (funded_apps[1..2] + self_funded_apps).each do |application|
+          create_declaration(application:, statement:, milestone:)
+        end
+      end
+
+      let(:funded_apps) { create_list(:application, 4, :accepted, :with_funded_place, course_cohort:, lead_provider:) }
+      let(:self_funded_apps) { create_list(:application, 1, :accepted, :without_funded_place, course_cohort:, lead_provider:) }
+
+      it "counts funded applications in started states and deducts declarations on previous statements" do
+        expect(calculator.row).to eq(
+          declaration_type: Milestone::STARTED,
+          expected: 3,
+          received: 2,
+          outstanding: 1,
+          value: BigDecimal(60),
+          expected_value: BigDecimal(180),
+          received_value: BigDecimal(120),
+        )
+      end
+    end
+
+    context "with a self-funded started milestone" do
+      before do
+        create_declaration(application: funded_app, statement:, milestone:)
+        create_declaration(application: self_funded_app, statement:, milestone:)
+      end
+
+      let(:funded_place) { [nil, false] }
+      let(:funded_app) { create(:application, :accepted, :with_funded_place, course_cohort:, lead_provider:) }
+      let(:self_funded_app) { create(:application, :accepted, :without_funded_place, course_cohort:, lead_provider:) }
+
+      it "counts received declarations without forecasting expected payments" do
+        expect(calculator.row).to eq(
+          declaration_type: Milestone::STARTED,
+          expected: 0,
+          received: 1,
+          outstanding: 0,
+          expected_value: 0,
+          received_value: 0,
+        )
+      end
+    end
+
+    context "with a funded completed milestone" do
+      before do
+        accepted_application
+        started_application.update!(status: Application::STARTED)
+        rejected_application
+
+        create_declaration(application: completed_application, statement:, milestone:)
+      end
+
+      let(:milestone) { create(:milestone, :completed, course_cohort:, payment_amount: 40, acceptance_window_start_date: 1.day.ago) }
+      let(:accepted_application) { create(:application, :accepted, :with_funded_place, course_cohort:, lead_provider:) }
+      let(:started_application) { create(:application, :accepted, :with_funded_place, course_cohort:, lead_provider:) }
+      let(:completed_application) { create(:application, :accepted, :with_funded_place, course_cohort:, lead_provider:) }
+      let(:rejected_application) { create(:application, :with_funded_place, course_cohort:, lead_provider:, status: Application::REJECTED) }
+
+      it "counts only started and completed applications as expected" do
+        expect(calculator.row).to include(
+          declaration_type: Milestone::COMPLETED,
+          expected: 2,
+          received: 1,
+          outstanding: 1,
+          value: BigDecimal(40),
+        )
+      end
+    end
+
+    context "when the statement deadline is before the milestone acceptance window" do
+      let(:statement) { create(:statement, lead_provider:, start_date: 1.month.ago.beginning_of_month) }
+      let(:milestone) { create(:milestone, :started, course_cohort:, payment_amount: 60, acceptance_window_start_date: Time.zone.today) }
+
+      before do
+        create(:application, :accepted, :with_funded_place, course_cohort:, lead_provider:)
+      end
+
+      it "does not forecast expected declarations" do
+        expect(calculator.row).to include(expected: 0, received: 0, outstanding: 0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Fixes bug in Statements::CourseCohortCalculator#expected_for (L103-107) where the application status scope is not being applied - which means the application status is ignored in the counts.

### Changes proposed in this pull request

Fix the bug, plus also refactor out the milestone counts into a MilestoneCourseCohortCalculator